### PR TITLE
Make icebergs use the mask_table

### DIFF
--- a/ice_bergs.F90
+++ b/ice_bergs.F90
@@ -2578,9 +2578,9 @@ end subroutine send_bergs_to_other_pes
 ! ##############################################################################
 
 subroutine icebergs_init(bergs, &
-             gni, gnj, layout, io_layout, axes, maskmap, dom_x_flags, dom_y_flags, &
+             gni, gnj, layout, io_layout, axes, dom_x_flags, dom_y_flags, &
              dt, Time, ice_lon, ice_lat, ice_wet, ice_dx, ice_dy, ice_area, &
-             cos_rot, sin_rot)
+             cos_rot, sin_rot, maskmap)
 ! Arguments
 type(icebergs), pointer :: bergs
 integer, intent(in) :: gni, gnj, layout(2), io_layout(2), axes(2)

--- a/ice_model.F90
+++ b/ice_model.F90
@@ -3358,11 +3358,21 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow )
   iceClock3 = mpp_clock_id( 'Ice: update fast', flags=clock_flag_default, grain=CLOCK_ROUTINE )
 
   ! Initialize icebergs
-  if (IST%do_icebergs) call icebergs_init(Ice%icebergs, &
+  if (IST%do_icebergs) then
+     if( ASSOCIATED(G%Domain%maskmap)) then
+       call icebergs_init(Ice%icebergs, &
        G%Domain%niglobal, G%Domain%njglobal, G%Domain%layout, G%Domain%io_layout, &
-       Ice%axes(1:2), G%Domain%maskmap, G%Domain%X_flags, G%Domain%Y_flags, &
+       Ice%axes(1:2), G%Domain%X_flags, G%Domain%Y_flags, &
+       time_type_to_real(Time_step_slow), Time, G%geoLonBu(isc:iec,jsc:jec), G%geoLatBu(isc:iec,jsc:jec), &
+       G%mask2dT, G%dxCv, G%dyCu, Ice%area, G%cos_rot, G%sin_rot, maskmap=G%Domain%maskmap )
+     else
+       call icebergs_init(Ice%icebergs, &
+       G%Domain%niglobal, G%Domain%njglobal, G%Domain%layout, G%Domain%io_layout, &
+       Ice%axes(1:2), G%Domain%X_flags, G%Domain%Y_flags, &
        time_type_to_real(Time_step_slow), Time, G%geoLonBu(isc:iec,jsc:jec), G%geoLatBu(isc:iec,jsc:jec), &
        G%mask2dT, G%dxCv, G%dyCu, Ice%area, G%cos_rot, G%sin_rot )
+     endif
+  endif
 
   if (IST%add_diurnal_sw .or. IST%do_sun_angle_for_alb) call astronomy_init
 


### PR DESCRIPTION
icebergs need to use the mask_table whenever SIS2 does. and SIS2 needs to use it for OM4_SIS2 experiments.

```
- The maskmap argument was commented out (inherited from sis1 when it was not using the mask_table I suspect).
- There will be "bad lon" , "bad lat" warnings in the stderr because
  lon and lat for bergs are not being initialized over the masking area.
```
