### PR TITLE
Make SIS2 compile with -openmp

### DIFF
--- a/SIS_tracer_advect.F90
+++ b/SIS_tracer_advect.F90
@@ -481,7 +481,7 @@ subroutine advect_scalar(scalar, h_prev, h_end, uhtr, vhtr, dt, G, CS) ! (, OBC)
     h_neglect = G%H_subroundoff
 !$OMP parallel default(none) shared(is,ie,js,je,ncat,domore_k,uhr,vhr,uhtr,vhtr,dt,G, &
 !$OMP                               hprev,h_prev,h_end,isd,ied,jsd,jed,uh_neglect,    &
-!$OMP                               h_neglect,vh_neglect)
+!$OMP                               h_neglect,vh_neglect,domore_u,domore_v)
 !$OMP do
     do k=1,ncat
       domore_k(k)=1

--- a/ice_model.F90
+++ b/ice_model.F90
@@ -2583,7 +2583,7 @@ subroutine SIS1_5L_thermodynamics(Ice, IST, G) !, runoff, calving, &
   endif
 
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,NkIce,G,IST,h_snow,h_ice, &
-!$OMP                                  dt_slow,snow_to_ice,Idt_slow,bsnk,S_col) &
+!$OMP                                  dt_slow,snow_to_ice,Idt_slow,bsnk,S_col,Ice) &
 !$OMP                          private(T_col,T_Freeze_surf,evap_from_ocn,h2o_to_ocn, &
 !$OMP                                  heat_to_ocn,bablt,sn2ic)
   do j=jsc,jec ; do k=1,ncat ; do i=isc,iec


### PR DESCRIPTION
issue #26
Missing OMP intent for a few variables cause sis2 not compiling with -openmp 