### PR TITLE
frazil_cat size is wrong

### DIFF
--- a/ice_model.F90
+++ b/ice_model.F90
@@ -2883,7 +2883,7 @@ subroutine SIS2_thermodynamics(Ice, IST, G, IG) !, runoff, calving, &
   real, dimension(0:IG%NkIce+1) :: &
     enthalpy              ! The initial enthalpy of a column of ice and snow
                           ! and the surface ocean, in enth_units (often J/kg).
-  real, dimension(IG%NkIce) :: frazil_cat  ! The frazil heating applied to each thickness
+  real, dimension(IG%CatIce) :: frazil_cat  ! The frazil heating applied to each thickness
                        ! category, averaged over the area of that category in J m-2.
   real :: enthalpy_ocean  ! The enthalpy of the ocean surface waters, in Enth_units.
   real :: heat_fill_val   ! An enthalpy to use for massless categories, in enth_units.


### PR DESCRIPTION
Running single column test in debug mode found this issue (which causes a crash in prod mode):
```
forrtl: severe (408): fort: (2): Subscript #1 of the array FRAZIL_CAT has value 5 which is greater than the upper bound of 4
Image              PC                Routine            Line        Source
fms_SIS2_OCEANMIX  000000000077C3B6  ice_model_mod_mp_        3265  ice_model.F90
fms_SIS2_OCEANMIX  0000000000646612  ice_model_mod_mp_        1777  ice_model.F90
fms_SIS2_OCEANMIX  00000000005310AE  ice_model_mod_mp_         138  ice_model.F90
fms_SIS2_OCEANMIX  000000000040E356  MAIN__                    875  coupler_main.F90
```

frazil_cat size is wrong.