### PR TITLE
Update to avoid thermodynamics when using specified ice.

### DIFF
--- a/ice_model.F90
+++ b/ice_model.F90
@@ -1756,7 +1756,7 @@ subroutine update_ice_model_slow(Ice, IST, G, IG, runoff, calving, &
   !
   ! Thermodynamics
   !
-  if (.not.IST%interspersed_thermo) then
+  if (.not.IST%interspersed_thermo .and. .not. IST%specified_ice) then
     !TOM> Store old ice mass per unit area for calculating partial ice growth.  
     mi_old = IST%mH_ice
     


### PR DESCRIPTION
In AMIP mode, the model was crashing with a "snow being deposited on non-ice area" (or words to that effect).
This adds a check to avoid the thermodynamics and leave the specified ice concentration as is.