### PR TITLE
Fix compilation issues with -openmp

### DIFF
--- a/SIS_fast_thermo.F90
+++ b/SIS_fast_thermo.F90
@@ -133,7 +133,7 @@ subroutine sum_top_quantities (FIA, ABT, flux_u, flux_v, flux_t, flux_q, &
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,flux_u,flux_v,flux_t, &
 !$OMP                                  flux_q,flux_sw_nir_dir,flux_sw_nir_dif,        &
 !$OMP                                  flux_sw_vis_dir,flux_sw_vis_dif,flux_lw,       &
-!$OMP                                  lprec,fprec,flux_lh)
+!$OMP                                  lprec,fprec,flux_lh,FIA)
   do j=jsc,jec ; do k=0,ncat ; do i=isc,iec
     FIA%flux_u_top(i,j,k)  = FIA%flux_u_top(i,j,k)  + flux_u(i,j,k)
     FIA%flux_v_top(i,j,k)  = FIA%flux_v_top(i,j,k)  + flux_v(i,j,k)
@@ -192,7 +192,7 @@ subroutine avg_top_quantities(FIA, part_size, G, IG)
   sign = 1.0 ; if (FIA%atmos_winds) sign = -1.0
   divid = 1.0/real(FIA%avg_count)
 
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,sign,divid,G) private(u,v)
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,sign,divid,G,FIA) private(u,v)
   do j=jsc,jec
     do k=0,ncat ;  do i=isc,iec
       u = FIA%flux_u_top(i,j,k) * (sign*divid)
@@ -225,7 +225,7 @@ subroutine avg_top_quantities(FIA, part_size, G, IG)
   ! across all the ice thickness categories on an A-grid.  This is done
   ! over the entire data domain for safety.
   FIA%WindStr_x(:,:) = 0.0 ; FIA%WindStr_y(:,:) = 0.0 ; FIA%ice_cover(:,:) = 0.0
-!$OMP parallel do default(none) shared(isd,ied,jsd,jed,ncat,FIA) &
+!$OMP parallel do default(none) shared(isd,ied,jsd,jed,ncat,FIA,part_size) &
 !$OMP                           private(I_wts)
   do j=jsd,jed
     do k=1,ncat ; do i=isd,ied
@@ -334,7 +334,7 @@ subroutine do_update_ice_model_fast( Atmos_boundary, IST, OSS, FIA, CS, G, IG )
     call IST_chksum("Start do_update_ice_model_fast", IST, G, IG)
 
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,IST,Atmos_boundary,i_off, &
-!$OMP                                  j_off,Ice,flux_u,flux_v,flux_t,flux_q,flux_lw, &
+!$OMP                                  j_off,flux_u,flux_v,flux_t,flux_q,flux_lw, &
 !$OMP                                  flux_sw_nir_dir,flux_sw_nir_dif,               &
 !$OMP                                  flux_sw_vis_dir,flux_sw_vis_dif,               &
 !$OMP                                  lprec,fprec,dhdt,dedt,drdt        )            &
@@ -380,7 +380,7 @@ subroutine do_update_ice_model_fast( Atmos_boundary, IST, OSS, FIA, CS, G, IG )
 !$OMP                                  flux_sw_vis_dir,flux_sw_vis_dif,flux_sw_nir_dir, &
 !$OMP                                  flux_sw_nir_dif,flux_t,flux_q,flux_lw,enth_liq_0,&
 !$OMP                                  dt_fast,flux_lh,I_enth_unit,G,S_col,kg_H_Nk,     &
-!$OMP                                  enth_units,LatHtFus,LatHtVap,IG)                 &
+!$OMP                                  enth_units,LatHtFus,LatHtVap,IG,OSS,FIA,CS)      &
 !$OMP                          private(T_Freeze_surf,latent,enth_col,flux_sw,dhf_dt,    &
 !$OMP                                  hf_0,ts_new,dts,SW_abs_col,SW_absorbed,enth_here,&
 !$OMP                                  tot_heat_in,enth_imb,norm_enth_imb     )

--- a/SIS_slow.F90
+++ b/SIS_slow.F90
@@ -246,7 +246,7 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
   endif
 !$OMP parallel do default(none) shared(isd,ied,jsd,jed,WindStr_x_A,WindStr_y_A,  &
 !$OMP                                  ice_cover,ice_free,WindStr_x_ocn_A,       &
-!$OMP                                  WindStr_y_ocn_A)
+!$OMP                                  WindStr_y_ocn_A,FIA)
   do j=jsd,jed
     do i=isd,ied
       WindStr_x_ocn_A(i,j) = FIA%flux_u_top(i,j,0)
@@ -573,7 +573,7 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
   call enable_SIS_averaging(dt_slow, CS%Time, CS%diag)
 
   ! Set appropriate surface quantities in categories with no ice.  Change <1e-10 to == 0?
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,IST)
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,IST,OSS)
   do j=jsc,jec ; do k=1,ncat ; do i=isc,iec ; if (IST%part_size(i,j,k)<1e-10) &
     IST%t_surf(i,j,k) = T_0degC + T_Freeze(OSS%s_surf(i,j),IST%ITV)
   enddo ; enddo ; enddo
@@ -802,7 +802,7 @@ subroutine set_ocean_top_stress_Bgrid(IOF, windstr_x_water, windstr_y_water, &
 
   !   Copy and interpolate the ice-ocean stress_Bgrid.  This code is slightly
   ! complicated because there are 3 different staggering options supported.
-!$OMP parallel default(none) shared(isc,iec,jsc,jec,ncat,G,                    &
+!$OMP parallel default(none) shared(isc,iec,jsc,jec,ncat,G,IOF,                &
 !$OMP                               part_size,windstr_x_water,windstr_y_water, &
 !$OMP                               str_ice_oce_x,str_ice_oce_y)               &
 !$OMP                       private(ps_vel)
@@ -905,7 +905,7 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
 
   !   Copy and interpolate the ice-ocean stress_Cgrid.  This code is slightly
   ! complicated because there are 3 different staggering options supported.
-!$OMP parallel default(none) shared(isc,iec,jsc,jec,ncat,G,    &
+!$OMP parallel default(none) shared(isc,iec,jsc,jec,ncat,G,IOF,    &
 !$OMP                               part_size,windstr_x_water,windstr_y_water, &
 !$OMP                               str_ice_oce_x,str_ice_oce_y)               &
 !$OMP                       private(ps_vel)

--- a/SIS_sum_output.F90
+++ b/SIS_sum_output.F90
@@ -779,7 +779,7 @@ subroutine accumulate_input_1(IST, FIA, dt, G, IG, CS)
 
   FW_in(:,:) = 0.0 ; salt_in(:,:) = 0.0 ; heat_in(:,:) = 0.0
 
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,IST,CS,enth_units,dt) &
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,IST,CS,enth_units,dt,FIA) &
 !$OMP                          private(area_pt,Flux_SW)
   do j=jsc,jec ; do k=1,ncat ; do i=isc,iec
     area_pt = IST%part_size(i,j,k)
@@ -829,7 +829,7 @@ subroutine accumulate_input_2(IST, FIA, IOF, part_size, dt, G, IG, CS)
   ! as these are not yet known.
 
   call get_SIS2_thermo_coefs(IST%ITV, enthalpy_units=enth_units, Latent_fusion=LI)
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,i_off,j_off,CS,dt,Ice,IST,&
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,CS,dt,IST,FIA,IOF,&
 !$OMP                                  enth_units, LI) &
 !$OMP                          private(area_pt)
   do j=jsc,jec ; do i=isc,iec
@@ -849,7 +849,7 @@ subroutine accumulate_input_2(IST, FIA, IOF, part_size, dt, G, IG, CS)
 
   ! The terms that are added here include surface fluxes that will be passed
   ! directly on into the ocean.
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,part_size,IST,CS,dt,enth_units)&
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,part_size,IST,CS,dt,enth_units,FIA)&
 !$OMP                          private(area_pt,pen_frac,Flux_SW)
     do j=jsc,jec ; do k=0,ncat ; do i=isc,iec
       area_pt = part_size(i,j,k)


### PR DESCRIPTION
SIS2 dev/master does not compile with -openmp , which affects CM4 models.
This fixes the compilation issues. 
Note that a restart issue #42 exists regardless of the openmp and this fix.