### PR TITLE
Fixes two openmp issues #49

### DIFF
--- a/SIS_slow_thermo.F90
+++ b/SIS_slow_thermo.F90
@@ -588,6 +588,9 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
   enddo ; enddo ; enddo
 
   if (FIA%num_tr_fluxes>0) then
+!It is necessary and sufficient that only one OMP thread goes through the following block
+!since IOF is shared between the threads (hence the block is not thread-safe).
+!$OMP SINGLE
     if (IOF%num_tr_fluxes < 0) then
       ! This is the first call, and the IOF arrays need to be allocated.
       IOF%num_tr_fluxes = FIA%num_tr_fluxes
@@ -597,7 +600,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
       allocate(IOF%tr_flux_index(size(FIA%tr_flux_index,1), size(FIA%tr_flux_index,2)))
       IOF%tr_flux_index(:,:) = FIA%tr_flux_index(:,:)
     endif
-
+!$OMP END SINGLE
 !$OMP do
     do n=1,FIA%num_tr_fluxes
       do j=jsc,jec ; do i=isc,iec

--- a/ice_transport.F90
+++ b/ice_transport.F90
@@ -766,10 +766,14 @@ subroutine compress_ice(part_sz, mca_ice, mca_snow, mH_ice, mH_snow, &
       enddo ; enddo
 
       if (do_any) then
+!The following subroutine calls are not thread-safe. There is a pointer in the subroutine
+!(Tr) that could be redirected from underneath a thread when another goes in.
+!$OMP CRITICAL
         call advect_tracers_thicker(mca0_ice, trans_ice, G, IG, CS%SIS_tr_adv_CSp, &
                                     TrReg, .false., j, isc, iec)
         call advect_tracers_thicker(mca0_snow, trans_snow, G, IG, CS%SIS_tr_adv_CSp, &
                                     TrReg, .true., j, isc, iec)
+!$OMP END CRITICAL
       endif
 
       k=nCat

--- a/ice_transport.F90
+++ b/ice_transport.F90
@@ -768,12 +768,12 @@ subroutine compress_ice(part_sz, mca_ice, mca_snow, mH_ice, mH_snow, &
       if (do_any) then
 !The following subroutine calls are not thread-safe. There is a pointer in the subroutine
 !(Tr) that could be redirected from underneath a thread when another goes in.
-!$OMP CRITICAL
+!$OMP CRITICAL (safepointer)
         call advect_tracers_thicker(mca0_ice, trans_ice, G, IG, CS%SIS_tr_adv_CSp, &
                                     TrReg, .false., j, isc, iec)
         call advect_tracers_thicker(mca0_snow, trans_snow, G, IG, CS%SIS_tr_adv_CSp, &
                                     TrReg, .true., j, isc, iec)
-!$OMP END CRITICAL
+!$OMP END CRITICAL (safepointer)
       endif
 
       k=nCat


### PR DESCRIPTION
- Closes issue #49
- 1st issue
  The crash in prod+openmp mode comes from a non-thread-safe subroutine call from within an OMP PARALLEL DO region.
  The offending subroutine calls are advect_tracers_thicker() in ice_transport.F90.
  This subroutine has a pointer inside (Tr) that could change unexpectedly from underneath a thread depending on an input argument.
  The easy way to bypass the issue is to put the subroutine calls inside a OMP CRITICAL section (see below) which forces the threads
  to pass through one at a time. Of course this is not the efficient way to fix the issue.
  For an efficient fix we need to change the way the subroutine uses the pointer (Tr).
- 2nd issue
  The crash with debug + openmp comes from another non-thread-safe block of code that allocates
  some arrays inside a OMP parallel region in SIS_slow_thermo.F90.
  The fix is to protect the block with the $OMP SINGLE clause to let only one thread to pass through