### PR TITLE
Iceberg run call only

### DIFF
--- a/SIS_slow.F90
+++ b/SIS_slow.F90
@@ -130,7 +130,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=CGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc-1:iec+1,jsc-1:jec+1))
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec))
   else
     call icebergs_run( icebergs_CS, IST%Time, &
             IOF%calving(isc:iec,jsc:jec), OSS%u_ocn_B(isc-1:iec+1,jsc-1:jec+1), &
@@ -140,7 +140,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=BGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc-1:iec+1,jsc-1:jec+1))
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec))
   endif
 
 end subroutine update_icebergs

--- a/SIS_slow.F90
+++ b/SIS_slow.F90
@@ -130,7 +130,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=CGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger)
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc-1:iec+1,jsc-1:jec+1))
   else
     call icebergs_run( icebergs_CS, IST%Time, &
             IOF%calving(isc:iec,jsc:jec), OSS%u_ocn_B(isc-1:iec+1,jsc-1:jec+1), &
@@ -140,7 +140,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=BGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger)
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc-1:iec+1,jsc-1:jec+1))
   endif
 
 end subroutine update_icebergs
@@ -161,6 +161,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, I
   type(icebergs),             pointer       :: icebergs_CS
 
   real, dimension(G%isc:G%iec,G%jsc:G%jec) :: h2o_chg_xprt, mass, tmp2d
+  real, dimension(:,:), allocatable :: ustar_berg, area_berg, mass_berg
   real, dimension(SZI_(G),SZJ_(G),IG%CatIce,IG%NkIce) :: &
     temp_ice    ! A diagnostic array with the ice temperature in degC.
   real, dimension(SZI_(G),SZJ_(G),IG%CatIce) :: &
@@ -596,6 +597,28 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
       call post_data(CS%id_mib, mass(isc:iec,jsc:jec), CS%diag)
     endif
   endif
+  if (CS%id_ustar_berg>0) then
+    allocate(ustar_berg(G%isc:G%iec,G%jsc:G%jec))
+    ustar_berg(:,:)=0.
+    if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean))&
+      ustar_berg(isc:iec,jsc:jec)=icebergs_CS%grd%ustar_iceberg(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+    call post_data(CS%id_ustar_berg, ustar_berg(isc:iec,jsc:jec), CS%diag)
+  endif
+  if (CS%id_area_berg>0) then
+    allocate(area_berg(G%isc:G%iec,G%jsc:G%jec))
+    area_berg(:,:)=0.
+    if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean))&
+      area_berg(isc:iec,jsc:jec)=icebergs_CS%grd%spread_area(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+    call post_data(CS%id_area_berg, area_berg(isc:iec,jsc:jec), CS%diag)
+  endif
+  if (CS%id_mass_berg>0) then
+    allocate(mass_berg(G%isc:G%iec,G%jsc:G%jec))
+    mass_berg(:,:)=0.
+    if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean)) &
+      mass_berg(isc:iec,jsc:jec)=icebergs_CS%grd%spread_mass(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+    call post_data(CS%id_mass_berg, mass_berg(isc:iec,jsc:jec), CS%diag)
+  endif
+
 
   call mpp_clock_end(iceClock8)
 
@@ -1134,6 +1157,13 @@ subroutine SIS_slow_init(Time, G, IG, param_file, diag, CS, output_dir, Time_ini
                'ice mass', 'kg/m^2', missing_value=missing)
   CS%id_mib  = register_diag_field('ice_model', 'MIB', diag%axesT1, Time, &
                'ice + bergs mass', 'kg/m^2', missing_value=missing)
+  CS%id_ustar_berg  = register_diag_field('ice_model', 'USTAR_BERG', diag%axesT1, Time, &
+               'iceberg ustar', 'm/s', missing_value=missing)
+  CS%id_area_berg  = register_diag_field('ice_model', 'AREA_BERG', diag%axesT1, Time, &
+               'icebergs area', 'm2/m2', missing_value=missing)
+  CS%id_mass_berg  = register_diag_field('ice_model', 'MASS_BERG', diag%axesT1, Time, &
+               'icebergs mass', 'kg/m2', missing_value=missing)
+
 
   iceClock4 = mpp_clock_id( '  Ice: slow: dynamics', flags=clock_flag_default, grain=CLOCK_LOOP )
   iceClocka = mpp_clock_id( '       slow: ice_dynamics', flags=clock_flag_default, grain=CLOCK_LOOP )

--- a/SIS_slow.F90
+++ b/SIS_slow.F90
@@ -130,7 +130,9 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=CGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec))
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec), &
+            mass_berg=IOF%mass_berg(isc:iec,jsc:jec),ustar_berg=IOF%ustar_berg(isc:iec,jsc:jec), &
+            area_berg=IOF%area_berg(isc:iec,jsc:jec) )
   else
     call icebergs_run( icebergs_CS, IST%Time, &
             IOF%calving(isc:iec,jsc:jec), OSS%u_ocn_B(isc-1:iec+1,jsc-1:jec+1), &
@@ -140,7 +142,9 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, G, IG)
             OSS%sea_lev(isc-1:iec+1,jsc-1:jec+1), IST%t_surf(isc:iec,jsc:jec,0),  &
             IOF%calving_hflx(isc:iec,jsc:jec), FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=BGRID_NE, &
-            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec))
+            stress_stagger=IOF%flux_uv_stagger,sss=OSS%s_surf(isc:iec,jsc:jec), &
+            mass_berg=IOF%mass_berg(isc:iec,jsc:jec),ustar_berg=IOF%ustar_berg(isc:iec,jsc:jec), &
+            area_berg=IOF%area_berg(isc:iec,jsc:jec) )
   endif
 
 end subroutine update_icebergs
@@ -593,7 +597,8 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
     if (CS%id_mi>0) call post_data(CS%id_mi, mass(isc:iec,jsc:jec), CS%diag)
 
     if (CS%id_mib>0) then
-      if (IST%do_icebergs) call icebergs_incr_mass(icebergs_CS, mass(isc:iec,jsc:jec)) ! Add icebergs mass in kg/m^2
+      if (IST%do_icebergs)  mass(isc:iec,jsc:jec) = (mass(isc:iec,jsc:jec) + IOF%mass_berg(G%isc:G%iec,G%jsc:G%jec)) ! Add icebergs mass in kg/m^2
+      !if (IST%do_icebergs)  call icebergs_incr_mass(icebergs_CS, mass(isc:iec,jsc:jec) ) ! Add icebergs mass in kg/m^2
       call post_data(CS%id_mib, mass(isc:iec,jsc:jec), CS%diag)
     endif
   endif
@@ -601,21 +606,21 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
     allocate(ustar_berg(G%isc:G%iec,G%jsc:G%jec))
     ustar_berg(:,:)=0.
     if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean))&
-      ustar_berg(isc:iec,jsc:jec)=icebergs_CS%grd%ustar_iceberg(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+      ustar_berg(:,:)=IOF%ustar_berg(G%isc:G%iec,G%jsc:G%jec)
     call post_data(CS%id_ustar_berg, ustar_berg(isc:iec,jsc:jec), CS%diag)
   endif
   if (CS%id_area_berg>0) then
     allocate(area_berg(G%isc:G%iec,G%jsc:G%jec))
     area_berg(:,:)=0.
     if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean))&
-      area_berg(isc:iec,jsc:jec)=icebergs_CS%grd%spread_area(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+      area_berg(:,:)=IOF%area_berg(G%isc:G%iec,G%jsc:G%jec)
     call post_data(CS%id_area_berg, area_berg(isc:iec,jsc:jec), CS%diag)
   endif
   if (CS%id_mass_berg>0) then
     allocate(mass_berg(G%isc:G%iec,G%jsc:G%jec))
     mass_berg(:,:)=0.
     if ((IST%do_icebergs) .and. (IST%pass_iceberg_area_to_ocean)) &
-      mass_berg(isc:iec,jsc:jec)=icebergs_CS%grd%spread_mass(icebergs_CS%grd%isc:icebergs_CS%grd%iec,icebergs_CS%grd%jsc:icebergs_CS%grd%jec)
+      mass_berg(:,:)=IOF%mass_berg(G%isc:G%iec,G%jsc:G%jec)
     call post_data(CS%id_mass_berg, mass_berg(isc:iec,jsc:jec), CS%diag)
   endif
 

--- a/ice_model.F90
+++ b/ice_model.F90
@@ -259,11 +259,12 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, G, IG)
   enddo ; enddo ; enddo
 
   if (IST%do_icebergs) then
-    call icebergs_incr_mass(Ice%icebergs, Ice%mi(:,:)) ! Add icebergs mass in kg/m^2
+    Ice%mi(:,:)=Ice%mi(:,:)+ IOF%mass_berg(G%isc:G%iec,G%jsc:G%jec)
+    !call icebergs_incr_mass(Ice%icebergs,  Ice%mi(:,:)) ! Add icebergs mass in kg/m^2
     if  (IST%pass_iceberg_area_to_ocean) then
-      Ice%ustar_berg(:,:)=Ice%icebergs%grd%ustar_iceberg(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
-      Ice%area_berg(:,:)=Ice%icebergs%grd%spread_area(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
-      Ice%mass_berg(:,:)=Ice%icebergs%grd%spread_mass(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
+      Ice%ustar_berg(:,:)=IOF%ustar_berg(G%isc:G%iec,G%jsc:G%jec)
+      Ice%area_berg(:,:)=IOF%area_berg(G%isc:G%iec,G%jsc:G%jec)
+      Ice%mass_berg(:,:)=IOF%mass_berg(G%isc:G%iec,G%jsc:G%jec)
     endif
   endif
 

--- a/ice_model.F90
+++ b/ice_model.F90
@@ -257,7 +257,15 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, G, IG)
     Ice%mi(i2,j2) = Ice%mi(i2,j2) + IST%part_size(i,j,k) * &
         (IG%H_to_kg_m2 * (IST%mH_snow(i,j,k) + IST%mH_ice(i,j,k)))
   enddo ; enddo ; enddo
-  if (IST%do_icebergs) call icebergs_incr_mass(Ice%icebergs, Ice%mi(:,:)) ! Add icebergs mass in kg/m^2
+
+  if (IST%do_icebergs) then
+    call icebergs_incr_mass(Ice%icebergs, Ice%mi(:,:)) ! Add icebergs mass in kg/m^2
+    if  (IST%pass_iceberg_area_to_ocean) then
+      Ice%ustar_berg(:,:)=Ice%icebergs%grd%ustar_iceberg(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
+      Ice%area_berg(:,:)=Ice%icebergs%grd%spread_area(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
+      Ice%mass_berg(:,:)=Ice%icebergs%grd%spread_mass(Ice%icebergs%grd%isc:Ice%icebergs%grd%iec,Ice%icebergs%grd%jsc:Ice%icebergs%grd%jec)
+    endif
+  endif
 
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,ncat,Ice,IST,i_off,j_off) &
 !$OMP                           private(i2,j2)
@@ -1218,6 +1226,8 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow )
                  "calculations.", units="m", default=0.0)
   call get_param(param_file, mod, "DO_ICEBERGS", IST%do_icebergs, &
                  "If true, call the iceberg module.", default=.false.)
+  call get_param(param_file, mod, "PASS_ICEBERG_AREA_TO_OCEAN", IST%pass_iceberg_area_to_ocean, &
+                 "If true, iceberg area is passed through coupler", default=.false.)
   call get_param(param_file, mod, "ADD_DIURNAL_SW", IST%add_diurnal_sw, &
                  "If true, add a synthetic diurnal cycle to the shortwave \n"//&
                  "radiation.", default=.false.)

--- a/ice_type.F90
+++ b/ice_type.F90
@@ -446,6 +446,12 @@ type ice_ocean_flux_type
                         ! facilitate the retention of sea ice, in kg m-2 s-1.
     flux_salt           ! The flux of salt out of the ocean in kg m-2.
 
+  !Iceberg fields
+  real, allocatable, dimension(:,:)   :: &
+    ustar_berg , &  !ustar contribution below icebergs in m/s
+    area_berg ,  &  !fraction of grid cell covered by icebergs in m2/m2
+    mass_berg       !mass of icebergs in km/m^2
+
 
   ! These arrays are used for enthalpy change diagnostics in the slow thermodynamics.
   real, allocatable, dimension(:,:)   :: &
@@ -920,6 +926,10 @@ subroutine alloc_ice_ocean_flux(IOF, HI)
   allocate(IOF%Enth_Mass_in_ocn(SZI_(HI), SZJ_(HI)))  ; IOF%Enth_Mass_in_ocn(:,:) = 0.0 !NR
   allocate(IOF%Enth_Mass_out_ocn(SZI_(HI), SZJ_(HI))) ; IOF%Enth_Mass_out_ocn(:,:) = 0.0 !NR
 
+  !Allocating iceberg fields (only used if pass_iceberg_area_to_ocean=.True.) 
+  allocate(IOF%mass_berg(SZI_(HI), SZJ_(HI))) ; IOF%mass_berg(:,:) = 0.0 !NI
+  allocate(IOF%ustar_berg(SZI_(HI), SZJ_(HI))) ; IOF%ustar_berg(:,:) = 0.0 !NI
+  allocate(IOF%area_berg(SZI_(HI), SZJ_(HI))) ; IOF%area_berg(:,:) = 0.0 !NI
 
 end subroutine alloc_ice_ocean_flux
 
@@ -1050,6 +1060,10 @@ subroutine dealloc_ice_ocean_flux(IOF)
 
   deallocate(IOF%Enth_Mass_in_atm, IOF%Enth_Mass_out_atm)
   deallocate(IOF%Enth_Mass_in_ocn, IOF%Enth_Mass_out_ocn)
+
+  !Deallocating iceberg fields
+  deallocate(IOF%mass_berg, IOF%ustar_berg)
+  deallocate(IOF%area_berg)
 
   deallocate(IOF)
 end subroutine dealloc_ice_ocean_flux


### PR DESCRIPTION
The area_berg, mass_berg and ustar_berg are now updated in the icebergs_run call, which means that the icebergs_incr_mass subroutine does not need to be called from the SIS2 module.

With these changes, these fields can now be passed through the coupler.

In order to make this work, I had to define each field in both the ice_data_type and the ice_ocean_flux_type. This is a round about way of doing this, but I could not think of a better way, since the ice_data_type can not be seen by the update_icebergs routine.

Also, note that grid for the ice_ocean_boundary_type fields and ice_data_type fields must be the same for this to work. I hope this will not be a problem


Finally, note that I did notice that the value of the fields changes when the fields are passed through in the global model, SIS2_bergs_cgrid. In an idealize cartesian grid, the values to not change. This needs to be addressed later.