### PR TITLE
Fixes out-of-bounds index in SIS_fast_thermo.F90

### DIFF
--- a/SIS_fast_thermo.F90
+++ b/SIS_fast_thermo.F90
@@ -212,7 +212,7 @@ subroutine avg_top_quantities(FIA, Rad, part_size, G, IG)
       FIA%flux_lh_top(i,j,k) = FIA%flux_lh_top(i,j,k) * divid
       
       ! Copy radiation fields from the fast to the slow states.
-      FIA%sw_abs_ocn(i,j,k) = Rad%sw_abs_ocn(i,j,k)
+      if (k>0) FIA%sw_abs_ocn(i,j,k) = Rad%sw_abs_ocn(i,j,k)
       ! Convert frost forming atop sea ice into frozen precip.
       if ((k>0) .and. (FIA%flux_q_top(i,j,k) < 0.0)) then
         FIA%fprec_top(i,j,k) = FIA%fprec_top(i,j,k) - FIA%flux_q_top(i,j,k)


### PR DESCRIPTION
- FIA%sw_abs_ocn(i,j,k) is is being set in a loop k=0:ncat but is
  declared with 1:ncat. The declaration has not changed but the
  offending line was added recently. Other arrays set in the loop
  are declared 0:ncat so the loop length is not incorrect.
  Inspection of older code suggests a related line was copied from
  a loop with k=1:ncat so the proposed fix emulates that.
- Run with debug executables using gnu, intel and pgi.
- Reproduces committed answers.