### PR TITLE
Avoids round off errors when compressing ice

### DIFF
--- a/SIS2_ice_thm.F90
+++ b/SIS2_ice_thm.F90
@@ -618,8 +618,10 @@ subroutine ice_temp_SIS2(m_pond, m_snow, m_ice, enthalpy, sice, sh_T0, B, sol, t
     endif
   endif
 
-  call ice_check(mL_snow, NkIce*mL_ice, enthalpy, sice, NkIce, &
-           "at end of ice_temp_SIS2", ITV, bmelt=bmelt, tmelt=tmelt, t_sfc=tsurf)
+! GM, I am commenting the following line to avoid excessive warning messages,
+! which slow's down the model.
+!  call ice_check(mL_snow, NkIce*mL_ice, enthalpy, sice, NkIce, &
+!           "at end of ice_temp_SIS2", ITV, bmelt=bmelt, tmelt=tmelt, t_sfc=tsurf)
 
 end subroutine ice_temp_SIS2
 

--- a/SIS_transport.F90
+++ b/SIS_transport.F90
@@ -816,9 +816,11 @@ subroutine compress_ice(part_sz, mca_ice, mca_snow, mca_pond, &
       k=nCat
       do i=isc,iec
         if (excess_cover(i,j) > 0.0) then
-          if (part_sz(i,j,k) <= 1.0) &
-            call SIS_error(FATAL, &
+          if (part_sz(i,j,k) <= 1.0 .and. &
+             (excess_cover(i,j) > 2.0*nCat*epsilon(Icompress_here))) then
+             call SIS_error(FATAL, &
                 "Category CatIce part_sz inconsistent with excess cover.")
+          endif
           Icompress_here = part_sz(i,j,k) / (part_sz(i,j,k) - excess_cover(i,j))
           mH_ice(i,j,k) = mH_ice(i,j,k) * Icompress_here
           mH_snow(i,j,k) = mH_snow(i,j,k) * Icompress_here

--- a/ice_type.F90
+++ b/ice_type.F90
@@ -424,7 +424,7 @@ subroutine Ice_public_type_bounds_check(Ice, G, msg)
 
   if (n_bad > 0) then
     i2 = i_bad+i_off ; j2 = j_bad+j_off ; k2 = k_bad+1
-    write(mesg1,'(" at ", 2(F6.1)," or i,j,k = ",3i4,"; nbad = ",i6," on pe ",i4)') &
+    write(mesg1,'(" at ", 2(F16.1)," or i,j,k = ",3i4,"; nbad = ",i6," on pe ",i4)') &
            G%geolonT(i_bad,j_bad), G%geolatT(i_bad,j_bad), i_bad, j_bad, k_bad, n_bad, pe_here()
     if (fluxes_avail) then
       write(mesg2,'("T_sfc = ",1pe12.4,", ps = ",1pe12.4,", flux_t,lw,q = ",3(1pe12.4))') &


### PR DESCRIPTION
An if statement that checks if part_sz(i,j,k) <= 1.0 has been improved so that round off errors do not lead to category CatIce part_sz being inconsistent with excess cover.