### PR TITLE
Avoids round off errors when compressing

### DIFF
--- a/SIS_transport.F90
+++ b/SIS_transport.F90
@@ -816,9 +816,11 @@ subroutine compress_ice(part_sz, mca_ice, mca_snow, mca_pond, &
       k=nCat
       do i=isc,iec
         if (excess_cover(i,j) > 0.0) then
-          if (part_sz(i,j,k) <= 1.0) &
-            call SIS_error(FATAL, &
+          if (part_sz(i,j,k) <= 1.0 .and. &
+             (excess_cover(i,j) > 2.0*nCat*epsilon(Icompress_here))) then
+             call SIS_error(FATAL, &
                 "Category CatIce part_sz inconsistent with excess cover.")
+          endif
           Icompress_here = part_sz(i,j,k) / (part_sz(i,j,k) - excess_cover(i,j))
           mH_ice(i,j,k) = mH_ice(i,j,k) * Icompress_here
           mH_snow(i,j,k) = mH_snow(i,j,k) * Icompress_here


### PR DESCRIPTION
An if statement that checks if part_sz(i,j,k) <= 1.0 has been improved so that round off errors do not lead to category CatIce part_sz being inconsistent with excess cover.