### PR TITLE
Passive tracers in slow thermodynamics routines

### DIFF
--- a/SIS2_ice_thm.F90
+++ b/SIS2_ice_thm.F90
@@ -1367,8 +1367,6 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
     Enthalpy(1) = (m_lay(1)*Enthalpy(1) + snow_to_ice*Enthalpy(0)) / &
                   (m_lay(1) + snow_to_ice)
     Salin(1) = Salin(1) * m_lay(1) / (m_lay(1) + snow_to_ice)
-    ! ### THIS NEEDS TO WORK WITH THE TRACER REGISTRY TO ADD SNOW TRACERS TO
-    ! ### THE CORRESPONDING ICE TRACER.
     do tr = 1,npassive
       TrLay(1,tr) = TrLay(1,tr) * m_lay(1) / (m_lay(1) + snow_to_ice)
     enddo
@@ -1529,9 +1527,6 @@ subroutine rebalance_ice_layers(m_lay, mtot_ice, Enthalpy, Salin, NkIce, npassiv
   real, dimension(NkIce,npassive) :: tr_ice_new
   integer :: k, k1, k2, kold, knew, tr
 
-  ! ### THIS NEEDS TO WORK WITH THE TRACER REGISTRY SO THAT IT WORKS ON ALL
-  ! ### TRACERS WITH MORE THAN 1 LAYER.
-
   mtot_ice = 0.0 ; do k=1,NkIce ; mtot_ice = mtot_ice + m_lay(k) ; enddo
   if (mtot_ice == 0.0) then ! There is no ice, so quit.
     return
@@ -1550,9 +1545,9 @@ subroutine rebalance_ice_layers(m_lay, mtot_ice, Enthalpy, Salin, NkIce, npassiv
         m_k1_to_k2 = m_lay(k1)
         enth_ice_new(k2) = enth_ice_new(k2) + m_k1_to_k2 * Enthalpy(k1)
         sal_ice_new(k2) = sal_ice_new(k2) + m_k1_to_k2 * Salin(k1)
-        do k=1,NkIce ; do tr = 1,npassive
-          tr_ice_new(k2,tr) = tr_ice_new(k2,tr) + m_k1_to_k2 * tr_ice_new(k1,tr)
-        enddo ; enddo
+        do tr = 1,npassive
+          tr_ice_new(k2,tr) = tr_ice_new(k2,tr) + m_k1_to_k2 * TrLay(k1,tr)
+        enddo
         mlay_new(k2) = mlay_new(k2) + m_k1_to_k2
         m_lay(k1) = 0.0 ! = m_lay(k1) - m_k1_to_k2
         k1 = k1+1
@@ -1561,9 +1556,9 @@ subroutine rebalance_ice_layers(m_lay, mtot_ice, Enthalpy, Salin, NkIce, npassiv
         m_k1_to_k2 = m_ice_avg - mlay_new(k2)
         enth_ice_new(k2) = enth_ice_new(k2) + m_k1_to_k2 * Enthalpy(k1)
         sal_ice_new(k2) = sal_ice_new(k2) + m_k1_to_k2 * Salin(k1)
-        do k=1,NkIce ; do tr = 1,npassive
-          tr_ice_new(k2,tr) = tr_ice_new(k2,tr) + m_k1_to_k2 * tr_ice_new(k1,tr)
-        enddo ; enddo
+        do tr = 1,npassive
+          tr_ice_new(k2,tr) = tr_ice_new(k2,tr) + m_k1_to_k2 * TrLay(k1,tr)
+        enddo
         mlay_new(k2) = m_ice_avg ! = mlay_new(k2) + m_k1_to_k2
         m_lay(k1) = m_lay(k1) - m_k1_to_k2
         k2 = k2+1

--- a/SIS_dyn_trans.F90
+++ b/SIS_dyn_trans.F90
@@ -74,6 +74,7 @@ use SIS_dyn_bgrid, only: SIS_B_dyn_CS, SIS_B_dynamics, SIS_B_dyn_init
 use SIS_dyn_bgrid, only: SIS_B_dyn_register_restarts, SIS_B_dyn_end
 use SIS_dyn_cgrid, only: SIS_C_dyn_CS, SIS_C_dynamics, SIS_C_dyn_init
 use SIS_dyn_cgrid, only: SIS_C_dyn_register_restarts, SIS_C_dyn_end
+use SIS_tracer_flow_control, only : SIS_tracer_flow_control_CS
 use SIS_transport, only : ice_transport, SIS_transport_init, SIS_transport_end
 use SIS_transport, only : SIS_transport_CS
 
@@ -236,7 +237,7 @@ end subroutine update_icebergs
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 ! SIS_dynamics_trans - do ice dynamics and mass and tracer transport           !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, IG)
+subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, IG, tracer_CSp)
 
   type(ice_state_type),       intent(inout) :: IST
   type(ocean_sfc_state_type), intent(in)    :: OSS
@@ -247,6 +248,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, I
   type(ice_grid_type),        intent(inout) :: IG
   type(dyn_trans_CS),         pointer       :: CS
   type(icebergs),             pointer       :: icebergs_CS
+  type(SIS_tracer_flow_control_CS), pointer :: tracer_CSp
 
   real, dimension(G%isc:G%iec,G%jsc:G%jec) :: h2o_chg_xprt, mass, mass_ice, mass_snow, tmp2d
   real, dimension(SZI_(G),SZJ_(G),IG%CatIce,IG%NkIce) :: &
@@ -688,7 +690,8 @@ real, dimension(SZIB_(G),SZJB_(G)) :: &
   endif
 
   if (CS%Time + set_time(int(floor(0.5*dt_slow+0.5))) > CS%write_ice_stats_time) then
-    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp)
+    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp, &
+        tracer_CSp = tracer_CSp)
     CS%write_ice_stats_time = CS%write_ice_stats_time + CS%ice_stats_interval
   elseif (CS%column_check) then
     call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp)

--- a/SIS_slow_thermo.F90
+++ b/SIS_slow_thermo.F90
@@ -561,6 +561,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
   Idt_slow = 0.0 ; if (dt_slow > 0.0) Idt_slow = 1.0/dt_slow
   npassive = IST%TrReg%npassive
   passive_idx = IST%TrReg%passive_idx
+  TrLay(:,:) = 0.0
 
   call get_SIS2_thermo_coefs(IST%ITV, ice_salinity=S_col, enthalpy_units=enth_units, &
                    rho_ice=rho_ice, specified_thermo_salinity=spec_thermo_sal, &
@@ -993,6 +994,11 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
         do m=1,NkIce+1 ; Salin(m) = CS%ice_bulk_salin ; enddo
       endif
 
+      ! Unpack a slice of the tracer array
+      do m=1,NkIce ; do tr = 1,npassive
+        TrLay(m,tr) = IST%TrReg%Tr_ice(tr+passive_idx-1)%t(i,j,k,m)
+      enddo ; enddo
+
       m_lay(0) = IST%mH_snow(i,j,k) * IG%H_to_kg_m2
       do m=1,NkIce ; m_lay(m) = IST%mH_ice(i,j,k) * kg_H_Nk ; enddo
 
@@ -1019,6 +1025,10 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
         endif
         salt_change(i,j) = salt_change(i,j) + IST%part_size(i,j,k) * salt_to_ice
       endif
+
+      do tr = 1,npassive ; do m=1,NkIce
+        IST%TrReg%Tr_ice(tr+passive_idx-1)%t(i,j,k,m) = TrLay(m,tr)
+      enddo ; enddo
 
 !      IOF%Enth_Mass_in_ocn(i,j) = IOF%Enth_Mass_in_ocn(i,j) + &
 !          IST%part_size(i,j,k) * enth_ocn_to_ice

--- a/SIS_sum_output.F90
+++ b/SIS_sum_output.F90
@@ -47,6 +47,7 @@ use SIS_hor_grid, only : SIS_hor_grid_type
 use ice_grid, only : ice_grid_type
 use SIS2_ice_thm, only : enth_from_TS, get_SIS2_thermo_coefs, ice_thermo_type
 use SIS_sum_output_type, only : SIS_sum_out_CS
+use SIS_tracer_flow_control, only : SIS_tracer_flow_control_CS, SIS_call_tracer_stocks
 
 use netcdf
 
@@ -200,7 +201,7 @@ subroutine SIS_sum_output_end(CS)
   endif
 end subroutine SIS_sum_output_end
 
-subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column) !, tracer_CSp)
+subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, tracer_CSp)
   type(ice_state_type),    intent(inout) :: IST
 
   type(time_type),         intent(inout) :: day
@@ -210,7 +211,7 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column) !
   type(SIS_sum_out_CS),    pointer       :: CS
   character(len=*), optional, intent(in) :: message
   logical,          optional, intent(in) :: check_column
-!  type(tracer_flow_control_CS), optional, pointer       :: tracer_CSp
+  type(SIS_tracer_flow_control_CS), optional, pointer       :: tracer_CSp
 
 !  This subroutine calculates and writes the total sea-ice mass by
 ! hemisphere, heat, salt, and other globally integrated quantities.
@@ -605,6 +606,9 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column) !
             trim(msg_start), Heat, Heat_chg, Heat_anom, Heat_anom/Heat
       endif
 
+      if (present(tracer_CSp)) &
+          call SIS_call_tracer_stocks(G,IG,tracer_CSp,IST%mH_ice)
+      
 !     do m=1,nTr_stocks
 
 !        write(*,'("      Total ",a,": ",ES24.16,X,a)') &

--- a/SIS_tracer_advect.F90
+++ b/SIS_tracer_advect.F90
@@ -86,7 +86,7 @@ integer :: id_clock_advect, id_clock_pass, id_clock_sync
 
 contains
 
-subroutine advect_SIS_tracers(h_prev, h_end, uhtr, vhtr, dt, G, IG, CS, Reg, snow_tr ) ! (, OBC)
+subroutine advect_SIS_tracers(h_prev, h_end, uhtr, vhtr, dt, G, IG, CS, TrReg, snow_tr ) ! (, OBC)
   type(SIS_hor_grid_type),                     intent(inout) :: G
   type(ice_grid_type),                         intent(inout) :: IG
   real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),  intent(in) :: h_prev, h_end
@@ -94,7 +94,7 @@ subroutine advect_SIS_tracers(h_prev, h_end, uhtr, vhtr, dt, G, IG, CS, Reg, sno
   real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), intent(in) :: vhtr
   real,                                        intent(in)    :: dt
   type(SIS_tracer_advect_CS),                  pointer       :: CS
-  type(SIS_tracer_registry_type),              pointer       :: Reg
+  type(SIS_tracer_registry_type),              pointer       :: TrReg
   logical,                                     intent(in) :: snow_tr
 
 ! Arguments: h_prev - Category thickness times fractional coverage before advection, in m or kg m-2.
@@ -110,7 +110,7 @@ subroutine advect_SIS_tracers(h_prev, h_end, uhtr, vhtr, dt, G, IG, CS, Reg, sno
 !  (in)      IG - The sea-ice-specific grid structure.
 !  (in)      CS - The control structure returned by a previous call to
 !                 SIS_tracer_advect_init.
-!  (in)      Reg - A pointer to the tracer registry.
+!  (in)      TrReg - A pointer to the tracer registry.
 !  (in)      snow_tr - If true, advect the snow tracers, otherwise advect the
 !                      ice tracers.
 
@@ -118,23 +118,23 @@ subroutine advect_SIS_tracers(h_prev, h_end, uhtr, vhtr, dt, G, IG, CS, Reg, sno
 
   if (.not. associated(CS)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
        "SIS_tracer_advect_init must be called before advect_tracer.")
-  if (.not. associated(Reg)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
+  if (.not. associated(TrReg)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
        "register_tracer must be called before advect_tracer.")
-  ntr = Reg%ntr
+  ntr = TrReg%ntr
   if (ntr==0) return
 
   call cpu_clock_begin(id_clock_advect)
   if (snow_tr) then
     if (CS%use_upwind2d) then
-      call advect_upwind_2d(Reg%Tr_snow, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
+      call advect_upwind_2d(TrReg%Tr_snow, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
     else
-      call advect_tracer(Reg%Tr_snow, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG, CS)
+      call advect_tracer(TrReg%Tr_snow, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG, CS)
     endif
   else
     if (CS%use_upwind2d) then
-      call advect_upwind_2d(Reg%Tr_ice, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
+      call advect_upwind_2d(TrReg%Tr_ice, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
     else
-      call advect_tracer(Reg%Tr_ice, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG, CS)
+      call advect_tracer(TrReg%Tr_ice, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG, CS)
     endif
   endif
   call cpu_clock_end(id_clock_advect)
@@ -168,7 +168,7 @@ subroutine advect_tracer(Tr, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG, CS) ! (,
 !  (in)      IG - The sea-ice-specific grid structure.
 !  (in)      CS - The control structure returned by a previous call to
 !                 SIS_tracer_advect_init.
-!  (in)      Reg - A pointer to the tracer registry.
+!  (in)      TrReg - A pointer to the tracer registry.
 
   real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)) :: &
     hprev           ! The cell volume at the end of the previous tracer
@@ -1676,7 +1676,7 @@ subroutine advect_upwind_2d(Tr, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
 !  (in)      IG - The sea-ice-specific grid structure.
 !  (in)      CS - The control structure returned by a previous call to
 !                 tracer_advect_init.
-!  (in)      Reg - A pointer to the tracer registry.
+!  (in)      TrReg - A pointer to the tracer registry.
 
   real, dimension(SZIB_(G),SZJ_(G)) :: flux_x  ! x-direction tracer fluxes, in conc * kg
   real, dimension(SZI_(G),SZJB_(G)) :: flux_y  ! y-direction tracer fluxes, in conc * kg
@@ -1739,12 +1739,12 @@ subroutine advect_upwind_2d(Tr, h_prev, h_end, uhtr, vhtr, ntr, dt, G, IG)
 end subroutine advect_upwind_2d
 
 subroutine advect_tracers_thicker(vol_start, vol_trans, G, IG, CS, &
-                                  Reg, snow_tr, j, is, ie)
+                                  TrReg, snow_tr, j, is, ie)
   type(SIS_hor_grid_type),             intent(in) :: G
   type(ice_grid_type),                 intent(inout) :: IG
   real, dimension(SZI_(G),SZCAT_(IG)), intent(in) :: vol_start, vol_trans
   type(SIS_tracer_advect_CS),          pointer    :: CS
-  type(SIS_tracer_registry_type),      pointer    :: Reg
+  type(SIS_tracer_registry_type),      pointer    :: TrReg
   logical,                             intent(in) :: snow_tr
   integer,                             intent(in) :: j, is, ie
 
@@ -1755,23 +1755,23 @@ subroutine advect_tracers_thicker(vol_start, vol_trans, G, IG, CS, &
 
   if (.not. associated(CS)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
        "SIS_tracer_advect_init must be called before advect_tracers_thicker.")
-  if (.not. associated(Reg)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
+  if (.not. associated(TrReg)) call SIS_error(FATAL, "SIS_tracer_advect: "// &
        "register_tracer must be called before advect_tracers_thicker.")
-  if (Reg%ntr==0) return
+  if (TrReg%ntr==0) return
 
   ncat = IG%CatIce
 
   if (snow_tr) then
-    Tr => Reg%Tr_snow
+    Tr => TrReg%Tr_snow
   else
-    Tr => Reg%Tr_ice
+    Tr => TrReg%Tr_ice
   endif
 
   do k=1,ncat ; do i=is,ie ; vol(i,k) = vol_start(i,k) ; enddo ; enddo
   do K=1,ncat-1 ; do i=is,ie ; if (vol_trans(i,K) > 0.0) then
     Ivol_new = 1.0 / (vol(i,k+1) + vol_trans(i,K))
     ! This is upwind advection across categories.  Improve it later.
-    do n=1,Reg%ntr ; do m=1,Tr(n)%nL
+    do n=1,TrReg%ntr ; do m=1,Tr(n)%nL
       Tr(n)%t(i,j,k+1,m) = (vol_trans(i,K)*Tr(n)%t(i,j,k,m) + &
                        vol(i,k+1)*Tr(n)%t(i,j,k+1,m)) * Ivol_new
     enddo ; enddo
@@ -1782,7 +1782,7 @@ subroutine advect_tracers_thicker(vol_start, vol_trans, G, IG, CS, &
   do K=ncat-1,1,-1 ; do i=is,ie ; if (vol_trans(i,K) < 0.0) then
     Ivol_new = 1.0 / (vol(i,k) - vol_trans(i,K))
     ! This is upwind advection across categories.  Improve it later.
-    do n=1,Reg%ntr ; do m=1,Tr(n)%nL
+    do n=1,TrReg%ntr ; do m=1,Tr(n)%nL
       Tr(n)%t(i,j,k,m) = (vol(i,k)*Tr(n)%t(i,j,k,m) - &
                          vol_trans(i,K)*Tr(n)%t(i,j,k+1,m)) * Ivol_new
     enddo ; enddo

--- a/SIS_tracer_flow_control.F90
+++ b/SIS_tracer_flow_control.F90
@@ -1,249 +1,250 @@
 module SIS_tracer_flow_control
-    !***********************************************************************
-    !*                   GNU General Public License                        *
-    !* This file is a part of SIS2.                                        *
-    !*                                                                     *
-    !* SIS2 is free software; you can redistribute it and/or modify it and *
-    !* are expected to follow the terms of the GNU General Public License  *
-    !* as published by the Free Software Foundation; either version 2 of   *
-    !* the License, or (at your option) any later version.                 *
-    !*                                                                     *
-    !* SIS2 is distributed in the hope that it will be useful, but WITHOUT *
-    !* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
-    !* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
-    !* License for more details.                                           *
-    !*                                                                     *
-    !* For the full text of the GNU General Public License,                *
-    !* write to: Free Software Foundation, Inc.,                           *
-    !*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
-    !* or see:   http://www.gnu.org/licenses/gpl.html                      *
-    !***********************************************************************
+!***********************************************************************
+!*                   GNU General Public License                        *
+!* This file is a part of SIS2.                                        *
+!*                                                                     *
+!* SIS2 is free software; you can redistribute it and/or modify it and *
+!* are expected to follow the terms of the GNU General Public License  *
+!* as published by the Free Software Foundation; either version 2 of   *
+!* the License, or (at your option) any later version.                 *
+!*                                                                     *
+!* SIS2 is distributed in the hope that it will be useful, but WITHOUT *
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  *
+!* or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public    *
+!* License for more details.                                           *
+!*                                                                     *
+!* For the full text of the GNU General Public License,                *
+!* write to: Free Software Foundation, Inc.,                           *
+!*           675 Mass Ave, Cambridge, MA 02139, USA.                   *
+!* or see:   http://www.gnu.org/licenses/gpl.html                      *
+!***********************************************************************
 
-    !********+*********+*********+*********+*********+*********+*********+**
-    !*                                                                     *
-    !*  By Andrew Shao, April 2016                                         *
-    !*      Adapted from MOM6 code MOM_tracer_flow_control.F90             *
-    !*                                                                     *
-    !*    This module contains subroutines into which calls to the tracer  *
-    !*    specific functions should be called. To add a new tracer the     *
-    !*    calls should be added to each of the following subroutines.      *
-    !*    Use ice_age_tracer.F90 as a model on which to base new types of  *
-    !*    ice tracers. Generally, most tracer packages will want to        *
-    !*    define their own tracer control structures which will get        *
-    !*    pointed to by the main tracer registry in                        *
-    !*    SIS_tracer_registry.F90.                                         *
-    !*                                                                     *
-    !*    SIS_call_tracer_register:                                        *
-    !*      Allocates the tracer flow control structure and reads the      *
-    !*      parameter file SIS_input to identify which tracers will be     *
-    !*      included in the current run. Tracer packages should allocate   *
-    !*      their tracer arrays here, establish whether the tracer will    *
-    !*      be initialized from a restart file, and register the tracer    *
-    !*      for the advection module.                                      *
-    !*                                                                     *
-    !*    SIS_tracer_flow_control_init:                                    *
-    !*      Sets the initial conditions for the tracer. Also, register     *
-    !*      tracer fields for output with the diag_manager.                *
-    !*                                                                     *
-    !*    SIS_call_tracer_column_fns:                                      *
-    !*      Apply any special treatment of the tracer that may occur in    *
-    !*      a vertical column. For example, source and sink terms should   *
-    !*      be calculated and applied here                                 *
-    !*                                                                     *
-    !*    SIS_call_tracer_stocks:                                          *
-    !*      NOTE: CURRENTLY NOT CALLED. This subroutine is intended to     *
-    !*      at some point calculate the inventory of each tracer and       *
-    !*      ready it for either output to a file or STDOUT                 *
-    !*                                                                     *
-    !*    SIS_tracer_flow_control_end:                                     *
-    !*      Deallocate arrays and prepare for model finalization           *
-    !*                                                                     *
-    !*                                                                     *
-    !********+*********+*********+*********+*********+*********+*********+**
+!********+*********+*********+*********+*********+*********+*********+**
+!*                                                                     *
+!*  By Andrew Shao, April 2016                                         *
+!*      Adapted from MOM6 code MOM_tracer_flow_control.F90             *
+!*                                                                     *
+!*    This module contains subroutines into which calls to the tracer  *
+!*    specific functions should be called. To add a new tracer the     *
+!*    calls should be added to each of the following subroutines.      *
+!*    Use ice_age_tracer.F90 as a model on which to base new types of  *
+!*    ice tracers. Generally, most tracer packages will want to        *
+!*    define their own tracer control structures which will get        *
+!*    pointed to by the main tracer registry in                        *
+!*    SIS_tracer_registry.F90.                                         *
+!*                                                                     *
+!*    SIS_call_tracer_register:                                        *
+!*      Allocates the tracer flow control structure and reads the      *
+!*      parameter file SIS_input to identify which tracers will be     *
+!*      included in the current run. Tracer packages should allocate   *
+!*      their tracer arrays here, establish whether the tracer will    *
+!*      be initialized from a restart file, and register the tracer    *
+!*      for the advection module.                                      *
+!*                                                                     *
+!*    SIS_tracer_flow_control_init:                                    *
+!*      Sets the initial conditions for the tracer. Also, register     *
+!*      tracer fields for output with the diag_manager.                *
+!*                                                                     *
+!*    SIS_call_tracer_column_fns:                                      *
+!*      Apply any special treatment of the tracer that may occur in    *
+!*      a vertical column. For example, source and sink terms should   *
+!*      be calculated and applied here                                 *
+!*                                                                     *
+!*    SIS_call_tracer_stocks:                                          *
+!*      NOTE: CURRENTLY NOT CALLED. This subroutine is intended to     *
+!*      at some point calculate the inventory of each tracer and       *
+!*      ready it for either output to a file or STDOUT                 *
+!*                                                                     *
+!*    SIS_tracer_flow_control_end:                                     *
+!*      Deallocate arrays and prepare for model finalization           *
+!*                                                                     *
+!*                                                                     *
+!********+*********+*********+*********+*********+*********+*********+**
 
-    use SIS_diag_mediator, only : time_type, SIS_diag_ctrl
-    use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
-    use ice_grid, only : ice_grid_type
-    use SIS_tracer_registry, only : SIS_tracer_registry_type
-    use SIS_tracer_registry, only : register_SIS_tracer, register_SIS_tracer_pair
-    use SIS_hor_grid, only : SIS_hor_grid_type
+use SIS_diag_mediator, only : time_type, SIS_diag_ctrl
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
+use ice_grid, only : ice_grid_type
+use SIS_tracer_registry, only : SIS_tracer_registry_type
+use SIS_tracer_registry, only : register_SIS_tracer, register_SIS_tracer_pair
+use SIS_hor_grid, only : SIS_hor_grid_type
 
-    use fms_io_mod,      only : restart_file_type
-    use MOM_file_parser, only : get_param, log_version, param_file_type
+use fms_io_mod,      only : restart_file_type
+use MOM_file_parser, only : get_param, log_version, param_file_type
 
 #include <SIS2_memory.h>
 
-    ! Add references to other user-provided tracer modules here.
-    use ice_age_tracer, only : register_ice_age_tracer, initialize_ice_age_tracer
-    use ice_age_tracer, only : ice_age_tracer_column_physics
-    use ice_age_tracer, only : ice_age_stock, ice_age_end
-    use ice_age_tracer, only : ice_age_tracer_CS
+! Add references to other user-provided tracer modules here.
+use ice_age_tracer, only : register_ice_age_tracer, initialize_ice_age_tracer
+use ice_age_tracer, only : ice_age_tracer_column_physics
+use ice_age_tracer, only : ice_age_stock, ice_age_end
+use ice_age_tracer, only : ice_age_tracer_CS
 
-    implicit none ; private
+implicit none ; private
 
-    public SIS_call_tracer_register, SIS_tracer_flow_control_init
-    public SIS_call_tracer_column_fns, SIS_call_tracer_stocks, SIS_tracer_flow_control_end
+public SIS_call_tracer_register, SIS_tracer_flow_control_init
+public SIS_call_tracer_column_fns, SIS_call_tracer_stocks, SIS_tracer_flow_control_end
 
-    type, public :: SIS_tracer_flow_control_CS ; private
-        logical :: use_ice_age = .false.
-        type(ice_age_tracer_CS), pointer :: ice_age_tracer_CSp => NULL()
-    end type SIS_tracer_flow_control_CS
+type, public :: SIS_tracer_flow_control_CS ; private
+    logical :: use_ice_age = .false.
+    type(ice_age_tracer_CS), pointer :: ice_age_tracer_CSp => NULL()
+end type SIS_tracer_flow_control_CS
 
 contains
 
-    ! The following subroutines and associated definitions provide the
-    ! machinery to register and call the subroutines that initialize
-    ! tracers and apply vertical column processes to tracers.
+! The following subroutines and associated definitions provide the
+! machinery to register and call the subroutines that initialize
+! tracers and apply vertical column processes to tracers.
 
-    subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
-        Ice_restart, restart_file)
-        type(SIS_hor_grid_type),                intent(in) :: G
-        type(ice_grid_type),                    intent(in) :: IG
-        type(param_file_type),                  intent(in) :: param_file
-        type(SIS_tracer_flow_control_CS),       pointer    :: CS
-        type(SIS_diag_ctrl),                    target     :: diag
-        type(SIS_tracer_registry_type),         pointer    :: TrReg
-        type(restart_file_type),                intent(inout) :: Ice_restart
-        character(len=*),                       intent(in) :: restart_file
+subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
+    Ice_restart, restart_file)
+  type(SIS_hor_grid_type),                intent(in) :: G
+  type(ice_grid_type),                    intent(in) :: IG
+  type(param_file_type),                  intent(in) :: param_file
+  type(SIS_tracer_flow_control_CS),       pointer    :: CS
+  type(SIS_diag_ctrl),                    target     :: diag
+  type(SIS_tracer_registry_type),         pointer    :: TrReg
+  type(restart_file_type),                intent(inout) :: Ice_restart
+  character(len=*),                       intent(in) :: restart_file
 
-        ! Argument:  G - The ice model's horizontal grid structure.
-        !  (in)      IG - The ice model's grid structure.
-        !  (in)      param_file - A structure indicating the open file to parse for
-        !                         model parameter values.
-        !
-        !  (in/out)  CS - A pointer that is set to point to the control structure
-        !                 for the tracer flow control
-        !  (in)      diag - A structure that is used to regulate diagnostic output.
-        !  (in/out)  TrReg - A pointer that is set to point to the control structure
-        !                  for the tracer advection and diffusion module.
-        !  (in/out)  Ice model restart file to be written to
-        !  (in)      Path to the restart file
-        !
-        ! This include declares and sets the variable "version".
+  ! Argument:  G - The ice model's horizontal grid structure.
+  !  (in)      IG - The ice model's grid structure.
+  !  (in)      param_file - A structure indicating the open file to parse for
+  !                         model parameter values.
+  !
+  !  (in/out)  CS - A pointer that is set to point to the control structure
+  !                 for the tracer flow control
+  !  (in)      diag - A structure that is used to regulate diagnostic output.
+  !  (in/out)  TrReg - A pointer that is set to point to the control structure
+  !                  for the tracer advection and diffusion module.
+  !  (in/out)  Ice model restart file to be written to
+  !  (in)      Path to the restart file
+  !
+  ! This include declares and sets the variable "version".
 #include "version_variable.h"
-        character(len=40)  :: mod = "SIS_tracer_flow_control" ! This module's name.
+  character(len=40)  :: mod = "SIS_tracer_flow_control" ! This module's name.
 
-        if (associated(CS)) then
-            call SIS_error(WARNING, "SIS_call_tracer_register called with an associated "// &
-                "control structure.")
-            return
-        else ; allocate(CS) ; endif
+  if (associated(CS)) then
+      call SIS_error(WARNING, "SIS_call_tracer_register called with an associated "// &
+          "control structure.")
+      return
+  else ; allocate(CS) ; endif
 
-            ! Read all relevant parameters and write them to the model log.
-            call log_version(param_file, mod, version, "")
-            call get_param(param_file, mod, "USE_ICE_AGE_TRACER", CS%use_ice_age, &
-                "If true, use the concentration based age tracer package.", &
-                default=.false.)
+      ! Read all relevant parameters and write them to the model log.
+      call log_version(param_file, mod, version, "")
+      call get_param(param_file, mod, "USE_ICE_AGE_TRACER", CS%use_ice_age, &
+          "If true, use the concentration based age tracer package.", &
+          default=.false.)
 
-            !    Add other user-provided calls to register tracers for restarting here. Each
-            !  tracer package registration call returns a logical false if it cannot be run
-            !  for some reason.  This then overrides the run-time selection from above.
+      !    Add other user-provided calls to register tracers for restarting here. Each
+      !  tracer package registration call returns a logical false if it cannot be run
+      !  for some reason.  This then overrides the run-time selection from above.
 
-            if (CS%use_ice_age) CS%use_ice_age = &
-                register_ice_age_tracer(G, IG, param_file, CS%ice_age_tracer_CSp, &
-                diag, TrReg, Ice_restart, restart_file)
+      if (CS%use_ice_age) CS%use_ice_age = &
+          register_ice_age_tracer(G, IG, param_file, CS%ice_age_tracer_CSp, &
+          diag, TrReg, Ice_restart, restart_file)
 
 
-        end subroutine SIS_call_tracer_register
+end subroutine SIS_call_tracer_register
 
-        subroutine SIS_tracer_flow_control_init(day, G, IG, param_file, CS, is_restart)
-            type(time_type), target,                    intent(in) :: day
-            type(SIS_hor_grid_type),                    intent(inout) :: G
-            type(ice_grid_type),                        intent(in) :: IG
-            type(param_file_type),                      intent(in) :: param_file
-            type(SIS_tracer_flow_control_CS),           pointer    :: CS
-            logical,                                    intent(in) :: is_restart
-            !   This subroutine calls all registered tracer initialization
-            ! subroutines.
+subroutine SIS_tracer_flow_control_init(day, G, IG, param_file, CS, is_restart)
+  type(time_type), target,                    intent(in) :: day
+  type(SIS_hor_grid_type),                    intent(inout) :: G
+  type(ice_grid_type),                        intent(in) :: IG
+  type(param_file_type),                      intent(in) :: param_file
+  type(SIS_tracer_flow_control_CS),           pointer    :: CS
+  logical,                                    intent(in) :: is_restart
+  !   This subroutine calls all registered tracer initialization
+  ! subroutines.
 
-            ! Arguments:
-            !  (in)      day - Time of the start of the run.
-            !  (in)      G - The ice model's horizontal grid structure.
-            !  (in)      IG - The ice model's vertical grid structure.
-            !  (in)      CS - The control structure returned by a previous call to
-            !                 call_tracer_register.
-            !  (in)      is_restart - flag for whether tracer should be initialized from restart
-            if (.not. associated(CS)) call SIS_error(FATAL, "tracer_flow_control_init: "// &
-                "Module must be initialized via call_tracer_register before it is used.")
+  ! Arguments:
+  !  (in)      day - Time of the start of the run.
+  !  (in)      G - The ice model's horizontal grid structure.
+  !  (in)      IG - The ice model's vertical grid structure.
+  !  (in)      CS - The control structure returned by a previous call to
+  !                 call_tracer_register.
+  !  (in)      is_restart - flag for whether tracer should be initialized from restart
+  if (.not. associated(CS)) call SIS_error(FATAL, "tracer_flow_control_init: "// &
+      "Module must be initialized via call_tracer_register before it is used.")
 
-            !  Add other user-provided calls here.
-            if (CS%use_ice_age) &
-                call initialize_ice_age_tracer(day, G, IG, CS%ice_age_tracer_CSp, is_restart)
+  !  Add other user-provided calls here.
+  if (CS%use_ice_age) &
+      call initialize_ice_age_tracer(day, G, IG, CS%ice_age_tracer_CSp, is_restart)
 
-        end subroutine SIS_tracer_flow_control_init
+end subroutine SIS_tracer_flow_control_init
 
-        subroutine SIS_call_tracer_column_fns(dt, G, IG, CS, mi, mi_old)
-            real,                                           intent(in) :: dt
-            type(SIS_hor_grid_type),                        intent(in) :: G
-            type(ice_grid_type),                            intent(in) :: IG
-            type(SIS_tracer_flow_control_CS),               pointer    :: CS
-            real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi
-            real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi_old
-            !   This subroutine calls all registered tracer column physics
-            ! subroutines.
+subroutine SIS_call_tracer_column_fns(dt, G, IG, CS, mi, mi_old)
+  
+  real,                                           intent(in) :: dt
+  type(SIS_hor_grid_type),                        intent(in) :: G
+  type(ice_grid_type),                            intent(in) :: IG
+  type(SIS_tracer_flow_control_CS),               pointer    :: CS
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi_old
+  !   This subroutine calls all registered tracer column physics
+  ! subroutines.
 
-            ! Arguments:
-            !  (in)      dt - The amount of time covered by this call, in s.
-            !  (in)      G - The ice model's grid structure.
-            !  (in)      IG - The ice model's vertical grid structure.
+  ! Arguments:
+  !  (in)      dt - The amount of time covered by this call, in s.
+  !  (in)      G - The ice model's grid structure.
+  !  (in)      IG - The ice model's vertical grid structure.
 
-            if (.not. associated(CS)) call SIS_error(FATAL, "SIS_call_tracer_column_fns: "// &
-                "Module must be initialized via call_tracer_register before it is used.")
-            ! Add calls to tracer column functions here.
-            if (CS%use_ice_age) &
-                call ice_age_tracer_column_physics(dt, G, IG,  CS%ice_age_tracer_CSp, mi, mi_old)
+  if (.not. associated(CS)) call SIS_error(FATAL, "SIS_call_tracer_column_fns: "// &
+      "Module must be initialized via call_tracer_register before it is used.")
+  ! Add calls to tracer column functions here.
+  if (CS%use_ice_age) &
+      call ice_age_tracer_column_physics(dt, G, IG,  CS%ice_age_tracer_CSp, mi, mi_old)
 
-        end subroutine SIS_call_tracer_column_fns
+end subroutine SIS_call_tracer_column_fns
 
-        subroutine SIS_call_tracer_stocks(G, IG, CS, mi)
+subroutine SIS_call_tracer_stocks(G, IG, CS, mi)
 
-            type(SIS_hor_grid_type),                        intent(in) :: G
-            type(ice_grid_type),                            intent(in) :: IG
-            type(SIS_tracer_flow_control_CS),               pointer    :: CS
-            real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi
+  type(SIS_hor_grid_type),                        intent(in) :: G
+  type(ice_grid_type),                            intent(in) :: IG
+  type(SIS_tracer_flow_control_CS),               pointer    :: CS
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),    intent(in) :: mi
 
-            !   This subroutine calls all registered tracer packages to enable them to
-            ! add to the surface state returned to the coupler. These routines are optional.
+  !   This subroutine calls all registered tracer packages to enable them to
+  ! add to the surface state returned to the coupler. These routines are optional.
 
-            ! Arguments:
-            !  (out)     stock_values - The integrated amounts of a tracer on the current
-            !                           PE, usually in kg x concentration.
-            !  (in)      G - The ocean's grid structure.
-            !  (in)      IG - The ocean's vertical grid structure.
-            !  (in)      CS - The control structure returned by a previous call to
-            !                 call_tracer_register.
+  ! Arguments:
+  !  (out)     stock_values - The integrated amounts of a tracer on the current
+  !                           PE, usually in kg x concentration.
+  !  (in)      G - The ocean's grid structure.
+  !  (in)      IG - The ocean's vertical grid structure.
+  !  (in)      CS - The control structure returned by a previous call to
+  !                 call_tracer_register.
 
-            character(len=200), dimension(MAX_FIELDS_) :: names, units
-            character(len=200) :: set_pkg_name
-            real, dimension(MAX_FIELDS_) :: stocks
-            integer :: nstocks, m
+  character(len=200), dimension(MAX_FIELDS_) :: names, units
+  character(len=200) :: set_pkg_name
+  real, dimension(MAX_FIELDS_) :: stocks
+  integer :: nstocks, m
 
-            if (.not. associated(CS)) call SIS_error(FATAL, "SIS_call_tracer_stocks: "// &
-                "Module must be initialized via call_tracer_register before it is used.")
+  if (.not. associated(CS)) call SIS_error(FATAL, "SIS_call_tracer_stocks: "// &
+      "Module must be initialized via call_tracer_register before it is used.")
 
-            nstocks = 0
-            stocks = 0.0
-            !  Add other user-provided calls here.
-            if (CS%use_ice_age) then
-                call ice_age_stock(nstocks, stocks, names, units, G, IG, &
-                    CS%ice_age_tracer_CSp, mi)
-            endif
+  nstocks = 0
+  stocks = 0.0
+  !  Add other user-provided calls here.
+  if (CS%use_ice_age) then
+      call ice_age_stock(nstocks, stocks, names, units, G, IG, &
+          CS%ice_age_tracer_CSp, mi)
+  endif
 
-            if(nstocks>0) then
-                do m=1,nstocks
-                    write(*,'(A,"Total ",A,A,ES24.16)') &
-                        achar(9),trim(names(m)),achar(9),stocks(m)
-                enddo
-            endif
+  if(nstocks>0) then
+      do m=1,nstocks
+          write(*,'(A,"Total ",A,A,ES24.16)') &
+              achar(9),trim(names(m)),achar(9),stocks(m)
+      enddo
+  endif
 
-        end subroutine SIS_call_tracer_stocks
+end subroutine SIS_call_tracer_stocks
 
-        subroutine SIS_tracer_flow_control_end(CS)
-            type(SIS_tracer_flow_control_CS), pointer :: CS
+subroutine SIS_tracer_flow_control_end(CS)
+  type(SIS_tracer_flow_control_CS), pointer :: CS
 
-            if (CS%use_ice_age) call ice_age_end(CS%ice_age_tracer_CSp)
+  if (CS%use_ice_age) call ice_age_end(CS%ice_age_tracer_CSp)
 
-            if (associated(CS)) deallocate(CS)
-        end subroutine SIS_tracer_flow_control_end
+  if (associated(CS)) deallocate(CS)
+end subroutine SIS_tracer_flow_control_end
 
-    end module SIS_tracer_flow_control
+end module SIS_tracer_flow_control

--- a/ice_age_tracer.F90
+++ b/ice_age_tracer.F90
@@ -386,18 +386,24 @@ subroutine ice_age_tracer_column_physics(dt, G, IG, CS,  mi, mi_old)
     ! Increment the age of the ice if it exists
     if (CS%tracer_ages(tr) .and. &
         (year>=CS%tracer_start_year(tr))) then
-      do m=1,CS%nlevels(tr)
-        do k=1,IG%CatIce; do j=jsc,jec ; do i=isc,iec
+        do j=jsc,jec ; do i=isc,iec 
+          if(G%mask2dT(i,j)>0.0 then
+            do k=1,IG%CatIce; do m=1,CS%nlevels(tr)
+              if(CS%tr(i,j,k,m,tr)<min_age) CS%tr(i,j,k,m,tr) = 0.0
 
-          if(CS%tr(i,j,k,m,tr)<min_age) CS%tr(i,j,k,m,tr) = 0.0
-
-          if(mi(i,j,k)>CS%min_mass) then
-            CS%tr(i,j,k,m,tr) = CS%tr(i,j,k,m,tr) + dt_year
+              if(mi(i,j,k)>CS%min_mass) then
+                CS%tr(i,j,k,m,tr) = CS%tr(i,j,k,m,tr) + dt_year
+              else
+                CS%tr(i,j,k,m,tr) = 0.0
+              endif
+            enddo ; enddo
           else
-            CS%tr(i,j,k,m,tr) = 0.0
+            do m=1,CS%nlevels(tr) ; do k=1,IG%CatIce
+              CS%tr(i,j,k,m,tr) = 0.0
+            enddo ; enddo
           endif
 
-        enddo ; enddo ; enddo
+        enddo ; enddo
       enddo
     endif
 

--- a/ice_age_tracer.F90
+++ b/ice_age_tracer.F90
@@ -48,453 +48,471 @@
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 module ice_age_tracer
-    ! ashao: Get all the dependencies from other modules (check against
-    !   ideal_age_example.F90)
+! ashao: Get all the dependencies from other modules (check against
+!   ideal_age_example.F90)
 
-    use SIS_diag_mediator, only     : register_SIS_diag_field, &
-                                       safe_alloc_ptr
-    use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
-    use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type
-    use SIS_hor_grid, only          : sis_hor_grid_type
-    use SIS_utils, only         : post_avg
+use SIS_diag_mediator, only     : register_SIS_diag_field, &
+                                   safe_alloc_ptr
+use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
+use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type
+use SIS_hor_grid, only          : sis_hor_grid_type
+use SIS_utils, only         : post_avg
 
-    use MOM_file_parser, only       : get_param, log_param, log_version, param_file_type
-    use MOM_restart, only           : query_initialized, MOM_restart_CS
-    use MOM_io, only                : vardesc, var_desc, query_vardesc, file_exists
-    use MOM_time_manager, only      : time_type, get_time
-    use MOM_sponge, only            : set_up_sponge_field, sponge_CS
-    use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING
-    use MOM_error_handler, only     : SIS_mesg=>MOM_mesg
-    use MOM_string_functions, only  : slasher
+use MOM_file_parser, only       : get_param, log_param, log_version, param_file_type
+use MOM_restart, only           : query_initialized, MOM_restart_CS
+use MOM_io, only                : vardesc, var_desc, query_vardesc, file_exists
+use MOM_time_manager, only      : time_type, get_time
+use MOM_sponge, only            : set_up_sponge_field, sponge_CS
+use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING
+use MOM_error_handler, only     : SIS_mesg=>MOM_mesg
+use MOM_string_functions, only  : slasher
 
-    use fms_mod, only               : read_data
-    use fms_io_mod, only            : register_restart_field, restore_state
-    use fms_io_mod, only            : restart_file_type
+use fms_mod, only               : read_data
+use fms_io_mod, only            : register_restart_field, restore_state
+use fms_io_mod, only            : restart_file_type
 
-    use ice_grid, only              : ice_grid_type
+use ice_grid, only              : ice_grid_type
 
-    implicit none ; private
+implicit none ; private
 #include "SIS2_memory.h"
 
-    public register_ice_age_tracer, initialize_ice_age_tracer
-    public ice_age_tracer_column_physics
-    public ice_age_stock, ice_age_end
+public register_ice_age_tracer, initialize_ice_age_tracer
+public ice_age_tracer_column_physics
+public ice_age_stock, ice_age_end
 
-    integer, parameter :: NTR_MAX = 2
+integer, parameter :: NTR_MAX = 2
 
-    type p3d
-        real, dimension(:,:,:), pointer :: p => NULL()
-    end type p3d
+type p3d
+  real, dimension(:,:,:), pointer :: p => NULL()
+end type p3d
 
-    type, public :: ice_age_tracer_CS
-        integer :: ntr                              ! The number of tracers that are actually used.
-        character(len = 200) :: IC_file             ! The file in which the age-tracer initial values
-                                                    ! can be found, or an empty string for internal initialization.
-        type(time_type), pointer :: Time            ! A pointer to the ocean model's clock.
-        type(SIS_tracer_registry_type), pointer :: TrReg => NULL()
-        real, pointer :: tr(:,:,:,:,:) => NULL()     ! The array of tracers used in this
-                                                     ! subroutine, in g m-3?
-        real, pointer :: tr_aux(:,:,:,:,:) => NULL() ! The masked tracer concentration
-                                                    ! for output, in g m-3.
-        type(p3d), dimension(NTR_MAX) :: &
-            tr_adx, &                               ! Tracer zonal advective fluxes in g m-3 m3 s-1.
-            tr_ady                                  ! Tracer meridional advective fluxes in g m-3 m3 s-1.
+type, public :: ice_age_tracer_CS
+  integer :: ntr                              ! The number of tracers that are actually used.
+  character(len = 200) :: IC_file             ! The file in which the age-tracer initial values
+                                              ! can be found, or an empty string for internal initialization.
+  type(time_type), pointer :: Time            ! A pointer to the ocean model's clock.
+  type(SIS_tracer_registry_type), pointer :: TrReg => NULL()
+  real, pointer :: tr(:,:,:,:,:) => NULL()     ! The array of tracers used in this
+                                               ! subroutine, in g m-3?
+  real, pointer :: tr_aux(:,:,:,:,:) => NULL() ! The masked tracer concentration
+                                              ! for output, in g m-3.
+  type(p3d), dimension(NTR_MAX) :: &
+      tr_adx, &                               ! Tracer zonal advective fluxes in g m-3 m3 s-1.
+      tr_ady                                  ! Tracer meridional advective fluxes in g m-3 m3 s-1.
 
-        real, dimension(NTR_MAX) :: &
-            IC_val = 0.0, &                         ! The (uniform) initial condition value.
-            young_val = 0.0, &                      ! The value assigned to tr at the surface.
-            land_val = -1.0, &                      ! The value of tr used where land is masked out.
-            tracer_start_year = 0.0                 ! The year in which tracers start aging, or at which the
-                                                    ! surface value equals young_val, in years.
-        logical :: mask_tracers                     ! If true, tracers are masked out in massless layers.
-        logical :: tracers_may_reinit               ! If true, tracers may go through the
-                                                    ! initialization code if they are not found in the
-                                                    ! restart files.
-        logical :: tracer_ages(NTR_MAX)             ! Flag if the tracer ages as a function of time
-        logical :: new_ice_is_sink(NTR_MAX)         ! Flag for whether the formation of new ice acts
-                                                    ! as a sink for age
-        logical :: advect_vertical(NTR_MAX)         ! Whether the tracer should be advected "vertically"
-                                                    ! to thicker ice
-        logical :: uniform_vertical(NTR_MAX)        ! Whether the tracer should uniform across ice thickness
-                                                    ! categories if so, "mix" the tracer by setting it to
-                                                    ! the maximum age at the grid pont
-        logical :: do_ice_age_areal
-        logical :: do_ice_age_mass
-        real :: min_thick_age, min_conc_age
+  real, dimension(NTR_MAX) :: &
+      IC_val = 0.0, &                         ! The (uniform) initial condition value.
+      young_val = 0.0, &                      ! The value assigned to tr at the surface.
+      land_val = -1.0, &                      ! The value of tr used where land is masked out.
+      tracer_start_year = 0.0                 ! The year in which tracers start aging, or at which the
+                                              ! surface value equals young_val, in years.
+  logical :: mask_tracers                     ! If true, tracers are masked out in massless layers.
+  logical :: tracers_may_reinit               ! If true, tracers may go through the
+                                              ! initialization code if they are not found in the
+                                              ! restart files.
+  logical :: tracer_ages(NTR_MAX)             ! Flag if the tracer ages as a function of time
+  logical :: new_ice_is_sink(NTR_MAX)         ! Flag for whether the formation of new ice acts
+                                              ! as a sink for age
+  logical :: advect_vertical(NTR_MAX)         ! Whether the tracer should be advected "vertically"
+                                              ! to thicker ice
+  logical :: uniform_vertical(NTR_MAX)        ! Whether the tracer should uniform across ice thickness
+                                              ! categories if so, "mix" the tracer by setting it to
+                                              ! the maximum age at the grid pont
+  logical :: do_ice_age_areal
+  logical :: do_ice_age_mass
+  real :: min_thick_age, min_conc_age
 
-        integer, dimension(NTR_MAX) :: &
-            id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1, id_avg =-1 ! Indices used for the diagnostic
-                                                                       ! mediator
-        integer, dimension(NTR_MAX) :: nlevels
+  integer, dimension(NTR_MAX) :: &
+      id_tracer = -1, id_tr_adx = -1, id_tr_ady = -1, id_avg =-1 ! Indices used for the diagnostic
+                                                                 ! mediator
+  integer, dimension(NTR_MAX) :: nlevels
 
-        type(SIS_diag_ctrl), pointer :: diag ! A structure that is used to regulate the
-                                   ! timing of diagnostic output.
+  type(SIS_diag_ctrl), pointer :: diag ! A structure that is used to regulate the
+                             ! timing of diagnostic output.
 
-        real :: min_mass                            ! Minimum mass of ice in thickness category for it
-                                                    ! to 'exist'
+  real :: min_mass                            ! Minimum mass of ice in thickness category for it
+                                              ! to 'exist'
 
-        type(vardesc) :: tr_desc(NTR_MAX)
-    end type ice_age_tracer_CS
+  type(vardesc) :: tr_desc(NTR_MAX)
+end type ice_age_tracer_CS
 
 contains
 
-    logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
-        Ice_restart, restart_file)
-        type(sis_hor_grid_type),                intent(in) :: G
-        type(ice_grid_type),                    intent(in) :: IG
-        type(param_file_type),                  intent(in) :: param_file
-        type(ice_age_tracer_CS),                pointer    :: CS
-        type(SIS_diag_ctrl),                    target     :: diag
-        type(SIS_tracer_registry_type),         pointer    :: TrReg
-        type(restart_file_type),                intent(inout) :: Ice_restart
-        character(len=*)                                   :: restart_file
-        ! This subroutine is used to age register tracer fields and subroutines
-        ! to be used with SIS.
-        ! Arguments:
-        !  (in)      Ice - The ice data type
-        !  (in)      G - The ocean's grid structure.
-        !  (in)      IG - Ice model's grid structure
-        !  (in)      param_file - A structure indicating the open file to parse for
-        !                         model parameter values.
-        !  (in/out)  CS - A pointer that is set to point to the control structure
-        !                 for the ice age tracer
-        !  (in)      diag - A structure that is used to regulate diagnostic output.
-        !  (in/out)  TrReg - A pointer that is set to point to the control structure
-        !                  for the tracer advection and diffusion module.
-        !  (in)      restart_file - Name of the restart file for the ice model.
+logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
+    Ice_restart, restart_file)
+  type(sis_hor_grid_type),                intent(in) :: G
+  type(ice_grid_type),                    intent(in) :: IG
+  type(param_file_type),                  intent(in) :: param_file
+  type(ice_age_tracer_CS),                pointer    :: CS
+  type(SIS_diag_ctrl),                    target     :: diag
+  type(SIS_tracer_registry_type),         pointer    :: TrReg
+  type(restart_file_type),                intent(inout) :: Ice_restart
+  character(len=*)                                   :: restart_file
+  ! This subroutine is used to age register tracer fields and subroutines
+  ! to be used with SIS.
+  ! Arguments:
+  !  (in)      Ice - The ice data type
+  !  (in)      G - The ocean's grid structure.
+  !  (in)      IG - Ice model's grid structure
+  !  (in)      param_file - A structure indicating the open file to parse for
+  !                         model parameter values.
+  !  (in/out)  CS - A pointer that is set to point to the control structure
+  !                 for the ice age tracer
+  !  (in)      diag - A structure that is used to regulate diagnostic output.
+  !  (in/out)  TrReg - A pointer that is set to point to the control structure
+  !                  for the tracer advection and diffusion module.
+  !  (in)      restart_file - Name of the restart file for the ice model.
 
-        ! This include declares and sets the variable "version".
+  ! This include declares and sets the variable "version".
 #include "version_variable.h"
-        character(len=40)  :: mod = "ice_age_tracer" ! This module's name.
-        character(len=200) :: inputdir ! The directory where the input files are.
-        character(len=48)  :: var_name ! The variable's name.
-        integer :: isc, iec, jsc, jec, m
-        isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
+  character(len=40)  :: mod = "ice_age_tracer" ! This module's name.
+  character(len=200) :: inputdir ! The directory where the input files are.
+  character(len=48)  :: var_name ! The variable's name.
+  integer :: isc, iec, jsc, jec, m
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
 
-        if (associated(CS)) then
-            call SIS_error(WARNING, "register_ice_age_tracer called with an "// &
-                "associated control structure.")
-            register_ice_age_tracer = .false.
-            return
+  if (associated(CS)) then
+      call SIS_error(WARNING, "register_ice_age_tracer called with an "// &
+          "associated control structure.")
+      register_ice_age_tracer = .false.
+      return
+  endif
+  allocate(CS)
+
+  ! Read all relevant parameters and write them to the model log.
+  call log_version(param_file, mod, version, "")
+  call get_param(param_file, mod, "DO_ICE_AGE_AREAL", CS%do_ice_age_areal, &
+      "If true, use an ice age tracer that ages at \n"//&
+      "a unit rate if the ice exists.", &
+      default=.false.)
+  call get_param(param_file, mod, "DO_ICE_AGE_MASS", CS%do_ice_age_mass, &
+      "If true, use an ice age tracer that is set to 0 age \n"//&
+      "when ice is first formed, ages at unit rate in the ice pack \n"// &
+      "and any new ice added to the ice pack represents a decrease in age", &
+      default=.false.)
+  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+      "If true, tracers may go through the initialization code \n"//&
+      "if they are not found in the restart files.  Otherwise \n"//&
+      "it is a fatal error if the tracers are not found in the \n"//&
+      "restart files of a restarted run.", default=.false.)
+
+  CS%ntr = 0
+  if (CS%do_ice_age_areal) then
+      CS%ntr = CS%ntr + 1 ; m = CS%ntr
+      CS%tr_desc(m) = var_desc("ice_age_areal", "years", "Area based ice age tracer", caller=mod)
+      CS%tracer_ages(m) = .true.
+      CS%new_ice_is_sink(m) = .false.
+      CS%uniform_vertical(m) = .false.
+      CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = -1.0
+      CS%land_val(m) = 0.0
+      CS%nlevels(m) = IG%CatIce
+  endif
+  if (CS%do_ice_age_mass) then
+      CS%ntr = CS%ntr + 1 ; m = CS%ntr
+      CS%tr_desc(m) = var_desc("ice_age_mass", "years", "Mass-based ice age tracer", caller=mod)
+      CS%tracer_ages(m) = .true.
+      CS%new_ice_is_sink(m) = .true.
+      CS%uniform_vertical(m) = .false.
+      CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = -1.0
+      CS%land_val(m) = 0.0
+      CS%nlevels(m) = IG%CatIce
+  endif
+  CS%min_mass = 1.0e-7*IG%kg_m2_to_H
+
+  ! Allocate the main tracer arrays, note that this creates a singleton dimension
+  ! along the ice layer (not thickness), but is necessary because the tracer
+  ! advection routine expects a 4d array per tracer
+  allocate(CS%tr(SZI_(G), SZJ_(G),IG%CatIce,1,CS%ntr)) ; CS%tr(:,:,:,:,:) = 0.0
+
+  ! Make sure that diag manager is assigned
+  CS%diag => diag
+
+  do m=1,CS%ntr
+
+    call query_vardesc(CS%tr_desc(m), name=var_name, &
+        caller="register_ice_age_tracer")
+
+    ! Register the tracer for the restart file.
+    CS%id_tracer(m) = register_restart_field(Ice_restart, restart_file, var_name, &
+        CS%tr(:,:,:,1,m), domain=G%domain%mpp_domain, &
+        mandatory=.false.)
+
+    ! Register the tracer for horizontal advection & diffusion. Note that the argument
+    ! of nLTr is IG%NkIce
+    call register_SIS_tracer(CS%tr(:,:,:,IG%NkIce,m), G, IG, IG%NkIce, var_name, param_file, &
+        TrReg, snow_tracer=.false.,ad_3d_x=CS%tr_adx(m)%p, ad_3d_y=CS%tr_ady(m)%p)
+
+
+  enddo ! do m=1, CS%ntr
+
+  CS%TrReg => TrReg
+  register_ice_age_tracer = .true.
+
+end function register_ice_age_tracer
+
+
+subroutine initialize_ice_age_tracer( day, G, IG, CS, is_restart )
+  type(time_type), target,                intent(in) :: day
+  type(sis_hor_grid_type),                intent(in) :: G
+  type(ice_grid_type),                    intent(in) :: IG
+  type(ice_age_tracer_CS),                pointer    :: CS
+  logical,                                intent(in) :: is_restart
+
+  !   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
+  ! and it sets up the tracer output.
+
+  ! Arguments: restart - .true. if the fields have already been read from
+  !                     a restart file.
+  !  (in)      day - Time of the start of the run.
+  !  (in)      G - The ocean's grid structure.
+  !  (in)      IG - The ice model's grid structure.
+  !  (in/out)  CS - The control structure returned by a previous call to
+  !                 register_ideal_age_tracer.
+  real, parameter   :: missing = -1.0e34
+  character(len=24) :: name     ! A variable's name in a NetCDF file.
+  character(len=72) :: longname ! The long name of that variable.
+  character(len=48) :: units    ! The dimensions of the variable.
+  character(len=48) :: flux_units ! The units for age tracer fluxes, either
+                                ! years m3 s-1 or years kg s-1.
+  integer :: i, j, k, isc, iec, jsc, jec, nz, m, tr
+  integer :: IscB, IecB, JscB, JecB
+
+
+  if (.not.associated(CS)) return
+  if (CS%ntr < 1) return
+
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
+  IscB = G%IscB ; IecB = G%IecB ; JscB = G%JscB ; JecB = G%JecB
+
+  CS%Time => day
+
+  do tr=1,CS%ntr
+    do k=1,CS%nlevels(tr) ; do j=jsc,jec ; do i=isc,iec
+        if (G%mask2dT(i,j) < 0.5) then
+            CS%tr(i,j,k,m,tr) = CS%land_val(tr)
+        elseif(.not. is_restart) then
+            CS%tr(i,j,k,m,tr) = CS%IC_val(tr)
         endif
-        allocate(CS)
+    enddo ; enddo ; enddo
+  enddo ! Tracer loop
 
-        ! Read all relevant parameters and write them to the model log.
-        call log_version(param_file, mod, version, "")
-        call get_param(param_file, mod, "DO_ICE_AGE_AREAL", CS%do_ice_age_areal, &
-            "If true, use an ice age tracer that ages at \n"//&
-            "a unit rate if the ice exists.", &
-            default=.false.)
-        call get_param(param_file, mod, "DO_ICE_AGE_MASS", CS%do_ice_age_mass, &
-            "If true, use an ice age tracer that is set to 0 age \n"//&
-            "when ice is first formed, ages at unit rate in the ice pack \n"// &
-            "and any new ice added to the ice pack represents a decrease in age", &
-            default=.false.)
-        call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-            "If true, tracers may go through the initialization code \n"//&
-            "if they are not found in the restart files.  Otherwise \n"//&
-            "it is a fatal error if the tracers are not found in the \n"//&
-            "restart files of a restarted run.", default=.false.)
+  ! This needs to be changed if the units of tracer are changed above.
+  flux_units = "years kg s-1"
 
-        CS%ntr = 0
-        if (CS%do_ice_age_areal) then
-            CS%ntr = CS%ntr + 1 ; m = CS%ntr
-            CS%tr_desc(m) = var_desc("ice_age_areal", "years", "Area based ice age tracer", caller=mod)
-            CS%tracer_ages(m) = .true.
-            CS%new_ice_is_sink(m) = .false.
-            CS%uniform_vertical(m) = .false.
-            CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = -1.0
-            CS%land_val(m) = 0.0
-            CS%nlevels(m) = IG%CatIce
-        endif
-        if (CS%do_ice_age_mass) then
-            CS%ntr = CS%ntr + 1 ; m = CS%ntr
-            CS%tr_desc(m) = var_desc("ice_age_mass", "years", "Mass-based ice age tracer", caller=mod)
-            CS%tracer_ages(m) = .true.
-            CS%new_ice_is_sink(m) = .true.
-            CS%uniform_vertical(m) = .false.
-            CS%IC_val(m) = 0.0 ; CS%young_val(m) = 0.0 ; CS%tracer_start_year(m) = -1.0
-            CS%land_val(m) = 0.0
-            CS%nlevels(m) = IG%CatIce
-        endif
-        CS%min_mass = 1.0e-7*IG%kg_m2_to_H
+  do tr=1,CS%ntr
 
-        ! Allocate the main tracer arrays, note that this creates a singleton dimension
-        ! along the ice layer (not thickness), but is necessary because the tracer
-        ! advection routine expects a 4d array per tracer
-        allocate(CS%tr(SZI_(G), SZJ_(G),IG%CatIce,1,CS%ntr)) ; CS%tr(:,:,:,:,:) = 0.0
-
-        ! Make sure that diag manager is assigned
-        CS%diag => diag
-
-        do m=1,CS%ntr
-
-            call query_vardesc(CS%tr_desc(m), name=var_name, &
-                caller="register_ice_age_tracer")
-
-            ! Register the tracer for the restart file.
-            CS%id_tracer(m) = register_restart_field(Ice_restart, restart_file, var_name, &
-                CS%tr(:,:,:,1,m), domain=G%domain%mpp_domain, &
-                mandatory=.false.)
-
-            ! Register the tracer for horizontal advection & diffusion. Note that the argument
-            ! of nLTr is 1 because age is uniform within an ice thickness category
-            call register_SIS_tracer(CS%tr(:,:,:,1,m), G, IG, 1, var_name, param_file, &
-                TrReg, snow_tracer=.false.,ad_3d_x=CS%tr_adx(m)%p, ad_3d_y=CS%tr_ady(m)%p)
-                             
-
-        enddo ! do m=1, CS%ntr
-
-        CS%TrReg => TrReg
-        register_ice_age_tracer = .true.
-
-    end function register_ice_age_tracer
+    call query_vardesc(CS%tr_desc(tr), name, units=units, longname=longname, &
+        caller="initialize_ice_age_tracer")
+    CS%id_tracer(tr) = register_SIS_diag_field("ice_model", trim(name), CS%diag%axesTc, &
+        CS%Time, trim(longname) , trim(units),missing_value = missing)
+    CS%id_tr_adx(tr) = register_SIS_diag_field("ice_model", trim(name)//"_adx", &
+        CS%diag%axesCuc, CS%Time, trim(longname)//" advective zonal flux" , &
+        trim(flux_units))
+    CS%id_tr_ady(tr) = register_SIS_diag_field("ice_model", trim(name)//"_ady", &
+        CS%diag%axesCvc, CS%Time, trim(longname)//" advective meridional flux" , &
+        trim(flux_units))
+    CS%id_avg(tr) = register_SIS_diag_field("ice_model", trim(name)//"_avg", &
+        CS%diag%axesT1, CS%Time, trim(longname)//" mass-averaged over all thickness categories" , &
+        trim(units))
 
 
-    subroutine initialize_ice_age_tracer( day, G, IG, CS, is_restart )
-        type(time_type), target,                intent(in) :: day
-        type(sis_hor_grid_type),                intent(in) :: G
-        type(ice_grid_type),                    intent(in) :: IG
-        type(ice_age_tracer_CS),                pointer    :: CS
-        logical,                                intent(in) :: is_restart
+    if (CS%id_tr_adx(tr) > 0) call safe_alloc_ptr(CS%tr_adx(tr)%p,IscB,IecB,jsc,jec,CS%nlevels(tr))
+    if (CS%id_tr_ady(tr) > 0) call safe_alloc_ptr(CS%tr_ady(tr)%p,isc,iec,JscB,JecB,CS%nlevels(tr))
 
-        !   This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
-        ! and it sets up the tracer output.
+  enddo
 
-        ! Arguments: restart - .true. if the fields have already been read from
-        !                     a restart file.
-        !  (in)      day - Time of the start of the run.
-        !  (in)      G - The ocean's grid structure.
-        !  (in)      IG - The ice model's grid structure.
-        !  (in/out)  CS - The control structure returned by a previous call to
-        !                 register_ideal_age_tracer.
-        real, parameter   :: missing = -1.0e34
-        character(len=24) :: name     ! A variable's name in a NetCDF file.
-        character(len=72) :: longname ! The long name of that variable.
-        character(len=48) :: units    ! The dimensions of the variable.
-        character(len=48) :: flux_units ! The units for age tracer fluxes, either
-                                      ! years m3 s-1 or years kg s-1.
-        integer :: i, j, k, isc, iec, jsc, jec, nz, m
-        integer :: IscB, IecB, JscB, JecB
+end subroutine initialize_ice_age_tracer
 
+subroutine ice_age_tracer_column_physics(dt, G, IG, CS,  mi, mi_old)
+  real,                                       intent(in) :: dt
+  type(sis_hor_grid_type),                    intent(in) :: G
+  type(ice_grid_type),                        intent(in) :: IG
+  type(ice_age_tracer_CS)                                :: CS
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),intent(in) :: mi
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),intent(in) :: mi_old
 
-        if (.not.associated(CS)) return
-        if (CS%ntr < 1) return
+  ! Arguments:
+  !  (in)      dt - The amount of time covered by this call, in s.
+  !  (in)      mi_old - Mass of ice at the beginning of the ice model timestep
+  !  (in)      G - The ocean model's grid structure.
+  !  (in)      IG - The ice model's grid structure.
+  !  (in)      CS - The control structure returned by a previous call to
+  !                 register_ideal_age_tracer.
 
-        isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
-        IscB = G%IscB ; IecB = G%IecB ; JscB = G%JscB ; JecB = G%JecB
+  real :: Isecs_per_year  ! The number of seconds in a year.
+  real :: year            ! The time in years.
+  real :: dt_year         ! Timestep in units of years
+  real :: min_age         ! Minimum age of ice to avoid being set to 0
+  real :: mi_min          ! Minimum mass in ice category
+  real :: max_age         ! Maximum age at a grid point
+  real, dimension(SZI_(G),SZJ_(G)) :: vertsum_mi, vertsum_mi_old
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)) :: tr_avg
+  integer :: secs, days   ! Integer components of the time type.
+  integer :: i, j, k, m, tr
+  integer :: isc, iec, jsc, jec
 
-        CS%Time => day
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec ; 
 
-        do m=1,CS%ntr
-            do k=1,CS%nlevels(m) ; do j=jsc,jec ; do i=isc,iec
-                if (G%mask2dT(i,j) < 0.5) then
-                    CS%tr(i,j,k,1,m) = CS%land_val(m)
-                elseif(.not. is_restart) then
-                    CS%tr(i,j,k,1,m) = CS%IC_val(m)
-                endif
-            enddo ; enddo ; enddo
-        enddo ! Tracer loop
+  if (CS%ntr < 1) return
 
-        ! This needs to be changed if the units of tracer are changed above.
-        flux_units = "years kg s-1"
+  Isecs_per_year = 1.0 / (365.0*86400.0)
+  dt_year = dt * Isecs_per_year
 
-        do m=1,CS%ntr
+  min_age = dt_year * 1.0e-10
 
-            call query_vardesc(CS%tr_desc(m), name, units=units, longname=longname, &
-                caller="initialize_ice_age_tracer")
-            CS%id_tracer(m) = register_SIS_diag_field("ice_model", trim(name), CS%diag%axesTc, &
-                CS%Time, trim(longname) , trim(units),missing_value = missing)
-            CS%id_tr_adx(m) = register_SIS_diag_field("ice_model", trim(name)//"_adx", &
-                CS%diag%axesCuc, CS%Time, trim(longname)//" advective zonal flux" , &
-                trim(flux_units))
-            CS%id_tr_ady(m) = register_SIS_diag_field("ice_model", trim(name)//"_ady", &
-                CS%diag%axesCvc, CS%Time, trim(longname)//" advective meridional flux" , &
-                trim(flux_units))
-            CS%id_avg(m) = register_SIS_diag_field("ice_model", trim(name)//"_avg", &
-                CS%diag%axesT1, CS%Time, trim(longname)//" mass-averaged over all thickness categories" , &
-                trim(units))
+  call get_time(CS%Time, secs, days)
+  year = (86400.0*days + real(secs)) * Isecs_per_year
 
 
-            if (CS%id_tr_adx(m) > 0) call safe_alloc_ptr(CS%tr_adx(m)%p,IscB,IecB,jsc,jec,CS%nlevels(m))
-            if (CS%id_tr_ady(m) > 0) call safe_alloc_ptr(CS%tr_ady(m)%p,isc,iec,JscB,JecB,CS%nlevels(m))
+  vertsum_mi(:,:) = 0.0
+  vertsum_mi_old(:,:) = 0.0
 
-        enddo
-
-    end subroutine initialize_ice_age_tracer
-
-    subroutine ice_age_tracer_column_physics(dt, G, IG, CS,  mi, mi_old)
-        real,                               	    intent(in) :: dt
-        type(sis_hor_grid_type),                    intent(in) :: G
-        type(ice_grid_type),                	    intent(in) :: IG
-        type(ice_age_tracer_CS)                    	           :: CS
-        real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),intent(in) :: mi
-        real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)),intent(in) :: mi_old
-        
-        ! Arguments:
-        !  (in)      dt - The amount of time covered by this call, in s.
-        !  (in)      mi_old - Mass of ice at the beginning of the ice model timestep
-        !  (in)      G - The ocean model's grid structure.
-        !  (in)      IG - The ice model's grid structure.
-        !  (in)      CS - The control structure returned by a previous call to
-        !                 register_ideal_age_tracer.
-
-        real :: Isecs_per_year  ! The number of seconds in a year.
-        real :: year            ! The time in years.
-        real :: dt_year         ! Timestep in units of years
-        real :: min_age         ! Minimum age of ice to avoid being set to 0
-        real :: mi_min          ! Minimum mass in ice category
-        real :: max_age         ! Maximum age at a grid point
-        real,dimension(SZI_(G),SZJ_(G)) :: vertsum_mi, vertsum_mi_old
-        integer :: secs, days   ! Integer components of the time type.
-        integer :: i, j, k, m
-        integer :: isc, iec, jsc, jec
-
-        isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec ;
-
-        if (CS%ntr < 1) return
-
-        Isecs_per_year = 1.0 / (365.0*86400.0)
-        dt_year = dt * Isecs_per_year
-
-        min_age = dt_year * 0.01
-
-        call get_time(CS%Time, secs, days)
-        year = (86400.0*days + real(secs)) * Isecs_per_year
-
-
-        vertsum_mi(:,:) = 0.0
-        vertsum_mi_old(:,:) = 0.0
-
-        do j=jsc,jec; do i=isc,iec
-            do k=1,IG%CatIce
-                vertsum_mi(i,j) = vertsum_mi(i,j) + mi(i,j,k)
+  do j=jsc,jec; do i=isc,iec
+      do k=1,IG%CatIce
+          vertsum_mi(i,j) = vertsum_mi(i,j) + mi(i,j,k)
 !                vertsum_mi_old(i,j) = vertsum_mi_old(i,j) + mi_old(i,j,k)
-            enddo
-        enddo; enddo
+      enddo
+  enddo; enddo
 
-        ! Increment the age of the ice if it exists
-        do m=1,CS%ntr ; if (CS%tracer_ages(m) .and. &
-            (year>=CS%tracer_start_year(m))) then
-            do k=1,CS%nlevels(m) ; do j=jsc,jec ; do i=isc,iec
+  do tr=1,CS%ntr
+    ! Increment the age of the ice if it exists
+    if (CS%tracer_ages(tr) .and. &
+        (year>=CS%tracer_start_year(tr))) then
+      do m=1,IG%NkIce  
+        do k=1,CS%nlevels(tr) ; do j=jsc,jec ; do i=isc,iec
 
-                if(CS%tr(i,j,k,1,m)<min_age) CS%tr(i,j,k,1,m) = 0.0
+          if(CS%tr(i,j,k,m,tr)<min_age) CS%tr(i,j,k,m,tr) = 0.0
 
-                if(mi(i,j,k)>CS%min_mass) then
-                    CS%tr(i,j,k,1,m) = CS%tr(i,j,k,1,m) + dt_year
-                else
-                    CS%tr(i,j,k,1,m) = 0.0
-                endif
+          if(mi(i,j,k)>CS%min_mass) then
+            CS%tr(i,j,k,m,tr) = CS%tr(i,j,k,m,tr) + dt_year
+          else
+            CS%tr(i,j,k,m,tr) = 0.0
+          endif
 
-            enddo ; enddo ; enddo
-        endif ; enddo
+        enddo ; enddo ; enddo
+      enddo
+    endif  
 
-        ! If newly formed ice reduces the age, then apply the net sink term
-        do m=1,CS%ntr ; if (CS%new_ice_is_sink(m)) then
-            do k=1,CS%nlevels(m) ; do j=jsc,jec ; do i=isc,iec
-                ! @ashao: Need to think about how and where the sink associated
-                ! with newly formed sea ice gets applied. For now, apply to
-                ! the entire ice pack assuming that new ice is formed equally
-                ! on every ice thickness category. New ice has an age equal 
-		        ! to the length of the timestep
+    ! If newly formed ice reduces the age, then apply the net sink term
+    if (CS%new_ice_is_sink(tr)) then
+      do m=1,IG%NkIce ; do k=1,CS%nlevels(tr) ; do j=jsc,jec ; do i=isc,iec
+      ! @ashao: Need to think about how and where the sink associated
+      ! with newly formed sea ice gets applied. For now, apply to
+      ! the entire ice pack assuming that new ice is formed equally
+      ! on every ice thickness category. New ice has an age equal 
+      ! to the length of the timestep
 
-                if(mi(i,j,k)>mi_old(i,j,k)) then
-			        CS%tr(i,j,k,1,m) = ((mi(i,j,k) - mi_old(i,j,k))*dt_year &
-				    + mi_old(i,j,k)*CS%tr(i,j,k,1,m))/mi(i,j,k)
-                endif
-
-            enddo ; enddo ; enddo
-        endif ; enddo
-
-        ! If the tracer should be uniform, set age at every grid point to the maximum
-        ! Note as of May 2016, this option is not used since it tends to make all ice
-        ! the same age
-
-        do m=1,CS%ntr ; if (CS%uniform_vertical(m)) then
-            do j=jsc,jec ; do i=isc,iec
-                if(vertsum_mi(i,j) > 0.0) then
-                    max_age = maxval(CS%tr(i,j,:,1,m))
-                    do k=1,CS%nlevels(m)
-                        CS%tr(i,j,k,1,m) = max_age
-                    enddo
-
-                endif
-            enddo ; enddo
-        endif ; enddo
-
-        do m=1,CS%ntr
-            if (CS%id_tracer(m)>0) &
-                call post_data(CS%id_tracer(m),CS%tr(:,:,:,1,m),CS%diag)
-            if (CS%id_tr_adx(m)>0) &
-                call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
-            if (CS%id_tr_ady(m)>0) &
-                call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
-            if (CS%id_avg(m)>0) &
-                call post_avg(CS%id_avg(m), CS%tr(:,:,:,1,m), mi, &
-                     CS%diag, G=G, wtd=.true.)
-        enddo
-
-    end subroutine ice_age_tracer_column_physics
-
-    subroutine ice_age_stock(nstocks, stocks, names, units, G, IG, CS, mi)
-        integer                                                 :: nstocks
-        real, dimension(:)                                      :: stocks
-        character(len=*), dimension(:)                          :: names
-        character(len=*), dimension(:)                          :: units
-        type(sis_hor_grid_type),                     intent(in) :: G
-        type(ice_grid_type),                         intent(in) :: IG
-        type(ice_age_tracer_CS)                                 :: CS
-        real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)), intent(in) :: mi
-
-        ! This function calculates the mass-weighted integral of all tracer stocks,
-        ! returning the number of stocks it has calculated.  If the stock_index
-        ! is present, only the stock corresponding to that coded index is returned.
-
-        ! Arguments: stocks - the mass-weighted integrated amount of each tracer,
-        !                     in kg times concentration units.
-        !  (in)      G - The ocean's grid structure.
-        !  (in)      G - The ice model's grid structure.
-        !  (in)      CS - The control structure returned by a previous call to
-        !                 register_ideal_age_tracer.
-        !  (out)     names - the names of the stocks calculated.
-        !  (out)     units - the units of the stocks calculated.
-        ! Return value: the number of stocks calculated here.
-
-        integer :: i, j, k, m
-        integer :: isc, iec, jsc, jec
-        isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
-
-        if (CS%ntr < 1) return
-
-        do m=1,CS%ntr
-            nstocks = nstocks + 1
-            call query_vardesc(CS%tr_desc(m), name=names(nstocks), units=units(nstocks), caller="ice_age_stock")
-            units(nstocks) = trim(units(m))//" kg"
-            stocks(nstocks) = 0.0
-            do k=1,IG%CatIce ; do j=jsc,jec ; do i=isc,iec
-                stocks(nstocks) = stocks(nstocks) + CS%tr(i,j,k,1,m) * &
-                    (G%mask2dT(i,j) * G%areaT(i,j) * mi(i,j,k))
-            enddo ; enddo ; enddo
-!            stocks(nstocks) = IG%H_to_kg_m2 * stocks(nstocks)
-        enddo
-
-
-    end subroutine ice_age_stock
-
-    subroutine ice_age_end(CS)
-        type(ice_age_tracer_CS), pointer :: CS
-        integer :: m
-
-        if (associated(CS)) then
-            if (associated(CS%tr)) deallocate(CS%tr)
-            if (associated(CS%tr_aux)) deallocate(CS%tr_aux)
-            do m=1,CS%ntr
-                if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
-                if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
-            enddo
-
-            deallocate(CS)
+        if(mi(i,j,k)>mi_old(i,j,k)) then
+          CS%tr(i,j,k,m,tr) = ((mi(i,j,k) - mi_old(i,j,k))*dt_year &
+              + mi_old(i,j,k)*CS%tr(i,j,k,m,tr))/mi(i,j,k)
         endif
-    end subroutine ice_age_end
+
+        enddo ; enddo ; enddo ; enddo
+    endif ; 
+
+    ! If the tracer should be uniform, set age at every grid point to the maximum
+    ! Note as of May 2016, this option is not used since it tends to make all ice
+    ! the same age
+    if (CS%uniform_vertical(tr)) then
+      do m=1,IG%NkIce ; do j=jsc,jec ; do i=isc,iec
+        if(vertsum_mi(i,j) > 0.0) then
+          max_age = maxval(CS%tr(i,j,:,m,tr))
+          do k=1,CS%nlevels(tr)
+            CS%tr(i,j,k,m,tr) = max_age
+          enddo
+
+        endif
+      enddo ; enddo ; enddo
+    endif  
+
+    ! If levels with different thicknesses are implemented, this averaging
+    ! will need to be updated
+    tr_avg(:,:,:) = 0.0
+    do k=1,IG%CatIce ; do j=jsc,jec ; do i=isc,iec
+      do m=1,IG%NkIce
+        tr_avg(i,j,m) = tr_avg(i,j,m) + CS%tr(i,j,k,m,tr)/IG%NkIce
+      enddo
+    enddo ; enddo ; enddo
+
+    if (CS%id_tracer(tr)>0) &
+        call post_data(CS%id_tracer(m),tr_avg,CS%diag)
+    if (CS%id_tr_adx(tr)>0) &
+        call post_data(CS%id_tr_adx(m),CS%tr_adx(m)%p(:,:,:),CS%diag)
+    if (CS%id_tr_ady(tr)>0) &
+        call post_data(CS%id_tr_ady(m),CS%tr_ady(m)%p(:,:,:),CS%diag)
+    if (CS%id_avg(tr)>0) then
+      call post_avg(CS%id_avg(tr), tr_avg, mi, &
+          CS%diag, G=G, wtd=.true.)
+    endif
+  enddo
+
+end subroutine ice_age_tracer_column_physics
+
+subroutine ice_age_stock(nstocks, stocks, names, units, G, IG, CS, mi)
+  integer                                                 :: nstocks
+  real, dimension(:)                                      :: stocks
+  character(len=*), dimension(:)                          :: names
+  character(len=*), dimension(:)                          :: units
+  type(sis_hor_grid_type),                     intent(in) :: G
+  type(ice_grid_type),                         intent(in) :: IG
+  type(ice_age_tracer_CS)                                 :: CS
+  real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)), intent(in) :: mi
+
+  ! This function calculates the mass-weighted integral of all tracer stocks,
+  ! returning the number of stocks it has calculated.  If the stock_index
+  ! is present, only the stock corresponding to that coded index is returned.
+
+  ! Arguments: stocks - the mass-weighted integrated amount of each tracer,
+  !                     in kg times concentration units.
+  !  (in)      G - The ocean's grid structure.
+  !  (in)      G - The ice model's grid structure.
+  !  (in)      CS - The control structure returned by a previous call to
+  !                 register_ideal_age_tracer.
+  !  (out)     names - the names of the stocks calculated.
+  !  (out)     units - the units of the stocks calculated.
+  ! Return value: the number of stocks calculated here.
+
+  integer :: i, j, k, m, tr
+  integer :: isc, iec, jsc, jec
+  real :: avg_tr
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
+
+  if (CS%ntr < 1) return
+
+  do tr=1,CS%ntr
+    nstocks = nstocks + 1
+    call query_vardesc(CS%tr_desc(m), name=names(nstocks), units=units(nstocks), caller="ice_age_stock")
+    units(nstocks) = trim(units(m))//" kg"
+    stocks(nstocks) = 0.0    
+    do k=1,IG%CatIce ; do j=jsc,jec ; do i=isc,iec
+      avg_tr = 0.0
+      ! For now an equally weighted average over the layers is used to calculate the stocks
+      ! In the future, if ice levels have different thicknesses, this will need to be updated
+      do m=1,IG%NkIce ; avg_tr = avg_tr + CS%tr(i,j,k,m,tr) ; enddo
+      avg_tr = avg_tr/IG%NkIce
+      
+      stocks(nstocks) = stocks(nstocks) + avg_tr * &
+          (G%mask2dT(i,j) * G%areaT(i,j) * mi(i,j,k))
+    enddo ; enddo ; enddo
+  enddo
+
+
+end subroutine ice_age_stock
+
+subroutine ice_age_end(CS)
+  type(ice_age_tracer_CS), pointer :: CS
+  integer :: m
+
+  if (associated(CS)) then
+    if (associated(CS%tr)) deallocate(CS%tr)
+    if (associated(CS%tr_aux)) deallocate(CS%tr_aux)
+    do m=1,CS%ntr
+      if (associated(CS%tr_adx(m)%p)) deallocate(CS%tr_adx(m)%p)
+      if (associated(CS%tr_ady(m)%p)) deallocate(CS%tr_ady(m)%p)
+    enddo
+
+    deallocate(CS)
+  endif
+end subroutine ice_age_end
 
 end module ice_age_tracer

--- a/ice_grid.F90
+++ b/ice_grid.F90
@@ -16,7 +16,7 @@ public :: set_ice_grid, ice_grid_end
 
 type, public :: ice_grid_type
   ! This type contains sea-ice specific grid elements, including information
-  ! about the category descreptions and the vertical layers in the snow and ice.
+  ! about the category descriptions and the vertical layers in the snow and ice.
   integer :: CatIce     ! The number of sea ice categories.
   integer :: NkIce      ! The number of vertical partitions within the
                         ! sea ice.
@@ -27,7 +27,7 @@ type, public :: ice_grid_type
   real :: kg_m2_to_H    ! A constant that translates thicknesses from kg m-2 to
                         ! the internal units of thickness.
   real :: H_subroundoff !   A thickness that is so small that it can be added to
-                        ! any physically meaningflu positive thickness without
+                        ! any physically meaningful positive thickness without
                         ! changing it at the bit level, in thickness units.
 
   real, allocatable, dimension(:) :: &

--- a/ice_model.F90
+++ b/ice_model.F90
@@ -267,7 +267,8 @@ subroutine update_ice_model_slow(Ice)
   endif
 
   call SIS_dynamics_trans(Ice%sCS%IST, Ice%sCS%OSS, Ice%sCS%FIA, Ice%sCS%IOF, &
-                          dt_slow, Ice%sCS%dyn_trans_CSp, Ice%icebergs, Ice%sCS%G, Ice%sCS%IG)
+                          dt_slow, Ice%sCS%dyn_trans_CSp, Ice%icebergs, Ice%sCS%G, &
+                          Ice%sCS%IG, Ice%sCS%SIS_tracer_flow_CSp)
 
   if (Ice%sCS%debug) then
     call Ice_public_type_chksum("Before set_ocean_top_fluxes", Ice, check_slow=.true.)


### PR DESCRIPTION
- The treatment of passive ice tracers in SIS2 has been updated to better follow the movement of ice across and within thickness categories.
- Passive ice tracers should be four dimensional (i,j,ncat,nlevels)
- Ice-snow and Ice-ocean boundary conditions for passive tracers can be set
- Passive tracer stock calculation mirrors MOM6 more closely

These changes do not affect answers in Baltic and Baltic_ALE_z

To be done:
Design a pseudo-salt tracer that mimics the salinity tracer in SIS2
