### PR TITLE
Update to https://github.com/NOAA-GFDL/SIS2/pull/64

### DIFF
--- a/SIS_slow_thermo.F90
+++ b/SIS_slow_thermo.F90
@@ -1209,6 +1209,8 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
     IOF%lprec_ocn_top(i,j) = IOF%lprec_ocn_top(i,j) + net_melt(i,j)
   enddo ; enddo
 
+  ! Double check to make sure TrLay is no longer allocated
+  if(allocated(TrLay)) deallocate(TrLay)
 end subroutine SIS2_thermodynamics
 
 

--- a/SIS_tracer_flow_control.F90
+++ b/SIS_tracer_flow_control.F90
@@ -136,19 +136,12 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
       "If true, use the concentration based age tracer package.", &
       default=.false.)
 
-
-  ! Set number of passive tracers to 0 initially
-  TrReg%npassive = 0
-  ! Set first passive tracer index
-  TrReg%passive_idx = TrReg%ntr + 1
-
   !    Add other user-provided calls to register tracers for restarting here. Each
   !  tracer package registration call returns a logical false if it cannot be run
   !  for some reason.  This then overrides the run-time selection from above.
   if (CS%use_ice_age) then
     CS%use_ice_age = register_ice_age_tracer(G, IG, param_file, CS%ice_age_tracer_CSp, &
         diag, TrReg, Ice_restart, restart_file)
-    TrReg%npassive = TrReg%npassive + 1
   endif
 
 

--- a/SIS_tracer_registry.F90
+++ b/SIS_tracer_registry.F90
@@ -56,6 +56,7 @@ implicit none ; private
 #endif
 
 public register_SIS_tracer, register_SIS_tracer_pair, get_SIS_tracer_pointer
+public SIS_unpack_passive_ice_tr, SIS_repack_passive_ice_tr
 public SIS_tracer_chksum, add_SIS_tracer_diagnostics, add_SIS_tracer_OBC_values
 public update_SIS_tracer_halos, set_massless_SIS_tracers, check_SIS_tracer_bounds
 public SIS_tracer_registry_init, SIS_tracer_registry_end
@@ -84,13 +85,14 @@ type, public :: SIS_tracer_type
              ! Value of the tracer at the snow-ice boundary
 
   ! @ashao: OBC NOT IMPLEMENTED YET
-  real :: OBC_inflow_conc = 0.0  ! A tracer concentration for generic inflows.
+  real :: OBC_inflow_conc = 0.0  !< A tracer concentration for generic inflows.
   real, dimension(:,:,:), pointer :: OBC_in_u => NULL(), OBC_in_v => NULL()
-             ! These arrays contain structured values for flow into the domain
-             ! that are specified in open boundary conditions through u- and
-             ! v- faces of the tracer cell.
-  character(len=32) :: name  ! A tracer name for error messages.
+             !< These arrays contain structured values for flow into the domain
+             !! that are specified in open boundary conditions through u- and
+             !! v- faces of the tracer cell.
+  character(len=32) :: name         !< A tracer name for error messages.
   logical :: nonnegative = .false.
+  logical :: is_passive  = .false. !< True if this ice tracer is passive
 end type SIS_tracer_type
 
 type, public :: p3d
@@ -103,8 +105,6 @@ type, public :: SIS_tracer_registry_type
   type(SIS_tracer_type) :: Tr_ice(MAX_FIELDS_)  ! The array of registered ice tracers.
   type(SIS_diag_ctrl), pointer :: diag ! A structure that is used to regulate the
                              ! timing of diagnostic output.
-  integer :: passive_idx    ! The index of the first passive tracer
-  integer :: npassive       ! Number of passive tracers
 end type SIS_tracer_registry_type
 
 contains
@@ -112,7 +112,7 @@ contains
 subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_tracer, &
                              massless_val, ad_2d_x, ad_2d_y, ad_3d_x, ad_3d_y, &
                              ad_4d_x, ad_4d_y, OBC_inflow, OBC_in_u, OBC_in_v, &
-                             nonnegative, ocean_BC, snow_BC)
+                             nonnegative, ocean_BC, snow_BC, is_passive)
   integer,                         intent(in) :: nLtr
   type(SIS_hor_grid_type),         intent(in) :: G
   type(ice_grid_type),             intent(in) :: IG
@@ -130,6 +130,7 @@ subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_t
   logical,               intent(in), optional :: nonnegative
   real, dimension(:,:,:),   pointer, optional :: ocean_BC
   real, dimension(:,:,:),   pointer, optional :: snow_BC
+  logical,                           optional :: is_passive
 ! This subroutine registers a tracer to be advected.
 
 ! Arguments: tr1 - The pointer to the tracer, in arbitrary concentration units
@@ -225,11 +226,16 @@ subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_t
   Tr_here%nonnegative = .false.
   if (present(nonnegative)) Tr_here%nonnegative = nonnegative
 
+  ! This is set as the default to guard against operations being performed on
+  ! active tracers twice
+  TrReg%Tr_ice(TrReg%ntr)%is_passive = .false.
+  if(present(is_passive)) TrReg%Tr_ice(TrReg%ntr)%is_passive = is_passive
+
 end subroutine register_SIS_tracer
 
 subroutine register_SIS_tracer_pair(ice_tr, nL_ice, name_ice, snow_tr, nL_snow, &
                                     name_snow, G, IG, param_file, TrReg, &
-                                    massless_iceval, massless_snowval, nonnegative)
+                                    massless_iceval, massless_snowval, nonnegative, is_passive)
   integer,                                          intent(in) :: nL_ice, nL_snow
   type(SIS_hor_grid_type),                          intent(in) :: G
   type(ice_grid_type),                              intent(in) :: IG
@@ -240,6 +246,7 @@ subroutine register_SIS_tracer_pair(ice_tr, nL_ice, name_ice, snow_tr, nL_snow, 
   type(SIS_tracer_registry_type),                   pointer    :: TrReg
   real,                                   optional, intent(in) :: massless_iceval, massless_snowval
   logical,                                optional, intent(in) :: nonnegative
+  logical,                                optional, intent(in) :: is_passive
 ! This subroutine registers a pair of ice and snow tracers to be advected.
 
 ! Arguments: ice_tr - The pointer to the ice tracer, in arbitrary concentration
@@ -286,7 +293,99 @@ subroutine register_SIS_tracer_pair(ice_tr, nL_ice, name_ice, snow_tr, nL_snow, 
   TrReg%Tr_ice(TrReg%ntr)%nonnegative = .false.
   if (present(nonnegative)) TrReg%Tr_ice(TrReg%ntr)%nonnegative = nonnegative
 
+  TrReg%Tr_ice(TrReg%ntr)%is_passive = .false.
+  if (present(is_passive)) TrReg%Tr_ice(TrReg%ntr)%is_passive = is_passive
+
 end subroutine register_SIS_tracer_pair
+
+!> Unpacks only the passive tracer arrays into TrLay which is a slice of the
+!! vertical layers within an ice thickness category
+subroutine SIS_unpack_passive_ice_tr(i, j, cat, nkice, TrReg, TrLay, npassive)
+  integer,                          intent(in)    :: i     !< Horizontal index i-direction
+  integer,                          intent(in)    :: j     !< Horizontal index j-direction
+  integer,                          intent(in)    :: cat   !< Index of ice thickness category
+  integer,                          intent(in)    :: nkice !< Number of levels in the ice
+  type(SIS_tracer_registry_type),   intent(in)    :: TrReg !< Main tracer register
+  real, dimension(:,:), allocatable,intent(inout) :: TrLay !< Array to hold vertical slice
+                                                                 !! of passive tracers
+  integer,                          intent(  out) :: npassive   !< Number of passive tracers
+
+  integer :: m, tr
+  logical :: copy(MAX_FIELDS_)      !< True if the tracer should be copied over to the slice
+
+  copy(:) = .false.
+  npassive = 0
+  do tr=1,TrReg%ntr
+    ! Tracer array has to be allocated and also designated passive to be copied
+    if( associated(TrReg%Tr_ice(tr)%t) .and. TrReg%Tr_ice(tr)%is_passive ) then
+      copy(tr) = .true.
+      npassive = npassive+1
+    endif
+  enddo
+
+  ! Allocate the tracer slice array if it has not been done yet
+  if(.not. allocated(TrLay)) allocate(TrLay(nkice,npassive))
+
+  do tr=1,TrReg%ntr
+    if(copy(tr)) then
+      ! Copy from main tracer array
+      do m=1,nkice ; TrLay(m,tr) = TrReg%Tr_ice(tr)%t(i,j,cat,m) ; enddo
+
+      ! Set snow and ice boundary conditions (if they exist)
+      if(associated(TrReg%Tr_ice(tr)%ocean_BC)) then
+        TrLay(NkIce+1,tr) = TrReg%Tr_ice(tr)%ocean_BC(i,j,cat)
+      else
+        TrLay(NkIce+1,tr) = 0.0
+      endif
+
+      if(associated(TrReg%Tr_ice(tr)%snow_BC)) then
+        TrLay(0,tr) = TrReg%Tr_ice(tr)%snow_BC(i,j,cat)
+      else
+        TrLay(0,tr) = 0.0
+      endif
+    endif
+  enddo
+
+end subroutine SIS_unpack_passive_ice_tr
+
+!> Copy the vertical slice of passive tracers back into their 4D arrays
+subroutine SIS_repack_passive_ice_tr(i, j, cat, nkice, TrReg, TrLay, deallocate_now)
+  integer,                          intent(in   ) :: i     !< Horizontal index i-direction
+  integer,                          intent(in   ) :: j     !< Horizontal index j-direction
+  integer,                          intent(in   ) :: cat   !< Index of ice thickness category
+  integer,                          intent(in   ) :: nkice !< Number of levels in the ice
+  type(SIS_tracer_registry_type),   intent(inout) :: TrReg !< Main tracer register
+  real, dimension(:,:), allocatable,intent(inout) :: TrLay !< Array to hold vertical slice
+                                                           !! of passive tracers
+  logical, optional,                intent(in   ) :: deallocate_now
+
+  integer :: m, tr
+  logical :: copy(MAX_FIELDS_)      ! True if the tracer should be copied over to the slice
+  logical :: now_deallocate
+
+  ! Do nothing if there are no passive tracers
+  if(.not. allocated(TrLay)) return
+
+  copy(:) = .false.
+  do tr=1,TrReg%ntr
+    ! Tracer array has to be exist and also designated passive to be copied
+    if( associated(TrReg%Tr_ice(tr)%t) .and. TrReg%Tr_ice(tr)%is_passive ) &
+        copy(tr) = .true.
+  enddo
+
+  do tr=1,TrReg%ntr
+    if(copy(tr)) then
+      ! Copy values back to tracer array
+      do m=1,nkice ; TrReg%Tr_ice(tr)%t(i,j,cat,m) = TrLay(m,tr) ; enddo
+    endif
+  enddo
+
+  ! Check to see if we can deallocate TrLay
+  now_deallocate = .true.
+  if(present(deallocate_now)) now_deallocate = deallocate_now
+  if(now_deallocate)  deallocate(TrLay)
+
+end subroutine SIS_repack_passive_ice_tr
 
 subroutine get_SIS_tracer_pointer(name, TrReg, Tr_ptr, nLayer)
   character(len=*),                      intent(in) :: name

--- a/ice_age_tracer.F90
+++ b/ice_age_tracer.F90
@@ -248,7 +248,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
     ! of nLTr is IG%NkIce
     call register_SIS_tracer(CS%tr(:,:,:,:,m), G, IG, IG%NkIce, var_name, param_file, &
         TrReg, snow_tracer=.false.,ad_3d_x=CS%tr_adx(m)%p, &
-        ad_3d_y=CS%tr_ady(m)%p, ocean_BC=ocean_BC_ptr, snow_BC=snow_BC_ptr)
+        ad_3d_y=CS%tr_ady(m)%p, ocean_BC=ocean_BC_ptr, snow_BC=snow_BC_ptr, is_passive=.true.)
 
     ! Set boundary conditions
     if(CS%new_ice_is_sink(m)) then


### PR DESCRIPTION
After conversations with @Hallberg-NOAA , we agreed that the portions of SIS2_thermodynamics that exposed elements of the TrReg to the routine could be pulled out. Here, three new routines were added to SIS_tracer_registry.F90 that handle the packing/unpacking of slices from 4d tracer arrays.