### PR TITLE
Renamed variables "mod" to "mdl"

### DIFF
--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -192,42 +192,42 @@ subroutine SIS2_ice_thm_init(param_file, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS2_ice_thm (updates)" ! This module's name.
+  character(len=40)  :: mdl = "SIS2_ice_thm (updates)" ! This module's name.
 
   if (.not.associated(CS)) allocate(CS)
 
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This sub-module does updates of the sea-ice due to thermodynamic changes.")
 
-  call get_param(param_file, mod, "SNOW_CONDUCTIVITY", CS%Ks, &
+  call get_param(param_file, mdl, "SNOW_CONDUCTIVITY", CS%Ks, &
                  "The conductivity of heat in snow.", units="W m-1 K-1", &
                  default=0.31)
-  call get_param(param_file, mod, "ICE_CONDUCTIVITY", CS%Ki, &
+  call get_param(param_file, mdl, "ICE_CONDUCTIVITY", CS%Ki, &
                  "The conductivity of heat in ice.", units="W m-1 K-1", &
                  default=2.03)
-  call get_param(param_file, mod, "MIN_H_FOR_TEMP_CALC", CS%h_lo_lim, &
+  call get_param(param_file, mdl, "MIN_H_FOR_TEMP_CALC", CS%h_lo_lim, &
                  "The minimum ice thickness at which to do temperature \n"//&
                  "calculations.", units="m", default=0.0)
 
-  call get_param(param_file, mod, "DO_POND", CS%do_pond, &
+  call get_param(param_file, mdl, "DO_POND", CS%do_pond, &
                  "If true, calculate melt ponds and use them for\n"//&
                  "shortwave radiation calculation.", default=.false.)
-  call get_param(param_file, mod, "TDRAIN", CS%tdrain, &
+  call get_param(param_file, mdl, "TDRAIN", CS%tdrain, &
                  "Melt ponds drain to sea level when ice average temp.\n"//&
                  "exceeds TDRAIN (stand-in for mushy layer thermo)", default=-0.8)
-  call get_param(param_file, mod, "R_MIN_POND", CS%r_min_pond, &
+  call get_param(param_file, mdl, "R_MIN_POND", CS%r_min_pond, &
                  "Minimum retention rate of surface water sources in melt pond\n"//&
                  "(retention scales linearly with ice cover)", default=0.15)
-  call get_param(param_file, mod, "R_MAX_POND", CS%r_max_pond, &
+  call get_param(param_file, mdl, "R_MAX_POND", CS%r_max_pond, &
                  "Maximum retention rate of surface water sources in melt pond\n"//&
                  "(retention scales linearly with ice cover)", default=0.9)
-  call get_param(param_file, mod, "MIN_POND_FRAC", CS%min_pond_frac, &
+  call get_param(param_file, mdl, "MIN_POND_FRAC", CS%min_pond_frac, &
                  "Minimum melt pond cover (by ponds at sea level)\n"//&
                  "pond drains to this when ice is porous.", default=0.2)
-  call get_param(param_file, mod, "MAX_POND_FRAC", CS%max_pond_frac, &
+  call get_param(param_file, mdl, "MAX_POND_FRAC", CS%max_pond_frac, &
                  "Maximum melt pond cover - associated with pond volume\n"//&
                  "that suppresses ice top to waterline", default=0.5)
-  call get_param(param_file, mod, "ICE_TEMP_RANGE_ESTIMATE", CS%temp_range_est,&
+  call get_param(param_file, mdl, "ICE_TEMP_RANGE_ESTIMATE", CS%temp_range_est,&
                  "An estimate of the range of snow and ice temperatures \n"//&
                  "that is used to evaluate whether an explicit diffusive \n"//&
                  "form of the heat fluxes or an inversion based on the \n"//&
@@ -1786,51 +1786,51 @@ subroutine ice_thermo_init(param_file, ITV, init_EOS )
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS2_ice_thm (thermo)" ! This module's name.
+  character(len=40)  :: mdl = "SIS2_ice_thm (thermo)" ! This module's name.
   logical :: specified_ice
 
   if (.not.associated(ITV)) allocate(ITV)
 
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This sub-module calculates ice thermodynamic quantities.")
-  call get_param(param_file, mod, "LATENT_HEAT_FUSION", ITV%LI, &
+  call get_param(param_file, mdl, "LATENT_HEAT_FUSION", ITV%LI, &
                  "The latent heat of fusion as used by SIS.", &
                  units="J kg-1", default=3.34e5)
-  call get_param(param_file, mod, "LATENT_HEAT_VAPOR", ITV%Lat_Vapor, &
+  call get_param(param_file, mdl, "LATENT_HEAT_VAPOR", ITV%Lat_Vapor, &
                  "The latent heat of vaporization of water at 0C as used by SIS.", &
                  units="J kg-1", default=2.500e6)
-  call get_param(param_file, mod, "RHO_OCEAN", ITV%Rho_water, &
+  call get_param(param_file, mdl, "RHO_OCEAN", ITV%Rho_water, &
                  "The nominal density of sea water as used by SIS.", &
                  units="kg m-3", default=1030.0)
-  call get_param(param_file, mod, "RHO_ICE", ITV%Rho_ice, &
+  call get_param(param_file, mdl, "RHO_ICE", ITV%Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0)
-  call get_param(param_file, mod, "RHO_SNOW", ITV%Rho_snow, &
+  call get_param(param_file, mdl, "RHO_SNOW", ITV%Rho_snow, &
                  "The nominal density of snow as used by SIS.", &
                  units="kg m-3", default=330.0)
-  call get_param(param_file, mod, "CP_ICE", ITV%Cp_ice, &
+  call get_param(param_file, mdl, "CP_ICE", ITV%Cp_ice, &
                  "The heat capacity of fresh ice, approximated as a \n"//&
                  "constant.", units="J kg-1 K-1", default=2100.0)
-  call get_param(param_file, mod, "CP_SEAWATER", ITV%Cp_Water, &
+  call get_param(param_file, mdl, "CP_SEAWATER", ITV%Cp_Water, &
                  "The heat capacity of sea water, approximated as a \n"//&
                  "constant.", units="J kg-1 K-1", default=4200.0)
-  call get_param(param_file, mod, "CP_BRINE", ITV%Cp_brine, &
+  call get_param(param_file, mdl, "CP_BRINE", ITV%Cp_brine, &
                  "The heat capacity of water in brine pockets within the \n"//&
                  "sea-ice, approximated as a constant.  CP_BRINE and \n"//&
                  "CP_SEAWATER should be equal, but for computational \n"//&
                  "convenience CP_BRINE can be set equal to CP_ICE.", &
                  units="J kg-1 K-1", default=ITV%Cp_Water)
-  call get_param(param_file, mod, "DTFREEZE_DS", ITV%dTf_dS, &
+  call get_param(param_file, mdl, "DTFREEZE_DS", ITV%dTf_dS, &
                  "The derivative of the freezing temperature with salinity.", &
                  units="deg C PSU-1", default=-0.054)
 
-  call get_param(param_file, mod, "ENTHALPY_LIQUID_0", ITV%enth_liq_0, &
+  call get_param(param_file, mdl, "ENTHALPY_LIQUID_0", ITV%enth_liq_0, &
                  "The enthalpy of liquid fresh water at 0 C.  The solutions \n"//&
                  "should be physically consistent when this is adjusted, \n"//&
                  "because only the relative value is of physical meaning, \n"//&
                  "but roundoff errors can change the solution.", units="J kg-1", &
                  default=0.0)
-  call get_param(param_file, mod, "ENTHALPY_UNITS", ITV%enth_unit, &
+  call get_param(param_file, mdl, "ENTHALPY_UNITS", ITV%enth_unit, &
                  "A constant that rescales enthalpy from J/kg to a \n"//&
                  "different scale in its internal representation.  Changing \n"//&
                  "this by a power of 2 is useful for debugging, as answers \n"//&
@@ -1838,22 +1838,22 @@ subroutine ice_thermo_init(param_file, ITV, init_EOS )
                  units="J kg-1", default=1.0)
   if (ITV%enth_unit < 0.) ITV%enth_unit = -1.0 / ITV%enth_unit
   ITV%I_enth_unit = 1.0 / ITV%enth_unit
-  call get_param(param_file, mod, "SUBLIMATION_BUG", ITV%sublimation_bug, &
+  call get_param(param_file, mdl, "SUBLIMATION_BUG", ITV%sublimation_bug, &
                  "If true use an older calculation that omits the latent \n"//&
                  "heat of fusion from the latent heat of sublimation. \n"//&
                  "This variable should be obsoleted as soon as possible.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "SPECIFIED_ICE", specified_ice, &
+  call get_param(param_file, mdl, "SPECIFIED_ICE", specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   if (specified_ice) then
     ITV%slab_ice = .true.
-    call log_param(param_file, mod, "USE_SLAB_ICE", ITV%slab_ice, &
+    call log_param(param_file, mdl, "USE_SLAB_ICE", ITV%slab_ice, &
                  "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
                  "USE_SLAB_ICE is always true.")
   else
-    call get_param(param_file, mod, "USE_SLAB_ICE", ITV%slab_ice, &
+    call get_param(param_file, mdl, "USE_SLAB_ICE", ITV%slab_ice, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
 

--- a/src/SIS_continuity.F90
+++ b/src/SIS_continuity.F90
@@ -814,7 +814,7 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS)
 !                 for this module
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_continuity" ! This module's name.
+  character(len=40) :: mdl = "SIS_continuity" ! This module's name.
   character(len=40) :: mesg    ! Message for error messages.
 
   if (associated(CS)) then
@@ -824,8 +824,8 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS)
   allocate(CS)
 
 ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "SIS_CONTINUITY_SCHEME", mesg, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "SIS_CONTINUITY_SCHEME", mesg, &
           desc="The horizontal transport scheme used in continuity:\n"//&
           "  UPWIND_2D - Non-directionally split upwind\n"//&
           "  PCM       - Directionally split piecewise constant\n"//&
@@ -857,7 +857,7 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS)
   call obsolete_logical(param_file, "UPWIND_1ST_CONTINUITY", &
        hint="Use SIS_CONTINUITY_SCHEME instead.")
 
-  call get_param(param_file, mod, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
+  call get_param(param_file, mdl, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
                  "If true, use the ratio of the open face lengths to the \n"//&
                  "tracer cell areas when estimating CFL numbers.", &
                  default=.false.)

--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -93,15 +93,15 @@ subroutine SIS_debugging_init(param_file)
   type(param_file_type),   intent(in)    :: param_file
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_debugging" ! This module's name.
+  character(len=40)  :: mdl = "SIS_debugging" ! This module's name.
 
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_CHKSUMS", debug_chksums, &
+  call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
                  "If true, checksums are performed on arrays in the \n"//&
                  "various vec_chksum routines.", default=debug)
-  call get_param(param_file, mod, "DEBUG_REDUNDANT", debug_redundant, &
+  call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
                  "If true, debug redundant data points during calls to \n"//&
                  "the various vec_chksum routines.", default=debug)
 

--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -153,14 +153,14 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
   character(len=80) :: grid_config, units_temp, set_name
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod  = "SIS_diag_mediator" ! This module's name.
+  character(len=40)  :: mdl = "SIS_diag_mediator" ! This module's name.
 
   set_vert = .true. ; if (present(set_vertical)) set_vert = set_vertical
   set_name = "ice" ; if (present(axes_set_name)) set_name = trim(axes_set_name)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "GRID_CONFIG", grid_config, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "GRID_CONFIG", grid_config, &
                  "The method for defining the horizontal grid.  Valid \n"//&
                  "entries include:\n"//&
                  "\t file - read the grid from GRID_FILE \n"//&
@@ -174,7 +174,7 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
   if (index(lowercase(trim(grid_config)),"cartesian") > 0) then
     ! This is a cartesian grid, and may have different axis units.
     Cartesian_grid = .true.
-    call get_param(param_file, mod, "AXIS_UNITS", units_temp, &
+    call get_param(param_file, mdl, "AXIS_UNITS", units_temp, &
                  "The units for the x- and y- axis labels.  AXIS_UNITS \n"//&
                  "should be defined as 'k' for km, 'm' for m, or 'd' \n"//&
                  "for degrees of latitude and longitude (the default). \n"//&
@@ -185,7 +185,7 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
     elseif (units_temp(1:1) == 'm') then
       G%x_axis_units = "meters" ; G%y_axis_units = "meters"
     endif
-    call log_param(param_file, mod, "explicit AXIS_UNITS", G%x_axis_units)
+    call log_param(param_file, mdl, "explicit AXIS_UNITS", G%x_axis_units)
   else
     Cartesian_grid = .false.
   endif
@@ -785,7 +785,7 @@ subroutine SIS_diag_mediator_init(G, IG, param_file, diag_cs, component, err_msg
   character(len=8)   :: this_pe
   character(len=240) :: doc_file, doc_file_dflt, doc_path
   character(len=40)  :: doc_file_param
-  character(len=40)  :: mod  = "SIS_diag_mediator" ! This module's name.
+  character(len=40)  :: mdl = "SIS_diag_mediator" ! This module's name.
 
   call diag_manager_init(err_msg=err_msg)
 
@@ -807,7 +807,7 @@ subroutine SIS_diag_mediator_init(G, IG, param_file, diag_cs, component, err_msg
       doc_file_dflt = "available_diags."//this_pe
       doc_file_param = "AVAILABLE_DIAGS_FILE"
     endif
-    call get_param(param_file, mod, trim(doc_file_param), doc_file, &
+    call get_param(param_file, mdl, trim(doc_file_param), doc_file, &
                  "A file into which to write a list of all available \n"//&
                  "sea ice diagnostics that can be included in a diag_table.", &
                  default=doc_file_dflt)

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -102,7 +102,7 @@ subroutine SIS_B_dyn_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_dyn_bgrid" ! This module's name.
+  character(len=40) :: mdl = "SIS_dyn_bgrid" ! This module's name.
   logical           :: debug
   real, parameter   :: missing = -1e34
 
@@ -116,64 +116,64 @@ subroutine SIS_B_dyn_init(Time, G, param_file, diag, CS)
   CS%Time => Time
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "SPECIFIED_ICE", CS%specified_ice, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "SPECIFIED_ICE", CS%specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   if ( CS%specified_ice ) then
     CS%evp_sub_steps = 0 ; CS%dt_Rheo = -1.0
-    call log_param(param_file, mod, "NSTEPS_DYN", CS%evp_sub_steps, &
+    call log_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
                  "The number of iterations in the EVP dynamics for each \n"//&
                  "slow time step.  With SPECIFIED_ICE this is always 0.")
   else
-    call get_param(param_file, mod, "DT_RHEOLOGY", CS%dt_Rheo, &
+    call get_param(param_file, mdl, "DT_RHEOLOGY", CS%dt_Rheo, &
                  "The sub-cycling time step for iterating the rheology \n"//&
                  "and ice momentum equations. If DT_RHEOLOGY is negative, \n"//&
                  "the time step is set via NSTEPS_DYN.", units="seconds", &
                  default=-1.0)
     CS%evp_sub_steps = -1
     if (CS%dt_Rheo <= 0.0) &
-      call get_param(param_file, mod, "NSTEPS_DYN", CS%evp_sub_steps, &
+      call get_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
                  "The number of iterations of the rheology and ice \n"//&
                  "momentum equations for each slow ice time step.", default=432)
   endif
 
-  call get_param(param_file, mod, "ICE_STRENGTH_PSTAR", CS%p0, &
+  call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
                  "A constant in the expression for the ice strength, \n"//&
                  "P* in Hunke & Dukowicz 1997.", units="Pa", default=2.75e4)
-  call get_param(param_file, mod, "ICE_STRENGTH_CSTAR", CS%c0, &
+  call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
                  "A constant in the exponent of the expression for the \n"//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
                  units="nondim", default=20.)
-  call get_param(param_file, mod, "ICE_CDRAG_WATER", CS%cdw, &
+  call get_param(param_file, mdl, "ICE_CDRAG_WATER", CS%cdw, &
                  "The drag coefficient between the sea ice and water.", &
                  units="nondim", default=3.24e-3)
 
-  call get_param(param_file, mod, "RHO_OCEAN", CS%Rho_ocean, &
+  call get_param(param_file, mdl, "RHO_OCEAN", CS%Rho_ocean, &
                  "The nominal density of sea water as used by SIS.", &
                  units="kg m-3", default=1030.0)
-  call get_param(param_file, mod, "RHO_ICE", CS%Rho_ice, &
+  call get_param(param_file, mdl, "RHO_ICE", CS%Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0)
   CS%p0_rho = CS%p0 / CS%Rho_ice
 
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "DEBUG_REDUNDANT", CS%debug_redundant, &
+  call get_param(param_file, mdl, "DEBUG_REDUNDANT", CS%debug_redundant, &
                  "If true, debug redundant data points.", default=CS%debug)
   if ( CS%specified_ice ) then
     CS%slab_ice = .true.
-    call log_param(param_file, mod, "USE_SLAB_ICE", CS%slab_ice, &
+    call log_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
                  "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
                  "USE_SLAB_ICE is always true.")
   else
-    call get_param(param_file, mod, "USE_SLAB_ICE", CS%slab_ice, &
+    call get_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
-  call get_param(param_file, mod, "AIR_WATER_STRESS_TURN_ANGLE", CS%blturn, &
+  call get_param(param_file, mdl, "AIR_WATER_STRESS_TURN_ANGLE", CS%blturn, &
                  "An angle by which to rotate the velocities at the air- \n"//&
                  "water boundary in calculating stresses.", units="degrees", &
                  default=0.0)

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -167,7 +167,7 @@ subroutine SIS_C_dyn_init(Time, G, param_file, diag, CS, ntrunc)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_C_dyn" ! This module's name.
+  character(len=40) :: mdl = "SIS_C_dyn" ! This module's name.
   logical           :: debug
   real, parameter   :: missing = -1e34
 
@@ -183,118 +183,118 @@ subroutine SIS_C_dyn_init(Time, G, param_file, diag, CS, ntrunc)
   CS%ntrunc = 0
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "SPECIFIED_ICE", CS%specified_ice, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "SPECIFIED_ICE", CS%specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   if ( CS%specified_ice ) then
     CS%evp_sub_steps = 0 ; CS%dt_Rheo = -1.0
-    call log_param(param_file, mod, "NSTEPS_DYN", CS%evp_sub_steps, &
+    call log_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
                  "The number of iterations in the EVP dynamics for each \n"//&
                  "slow time step.  With SPECIFIED_ICE this is always 0.")
   else
-    call get_param(param_file, mod, "DT_RHEOLOGY", CS%dt_Rheo, &
+    call get_param(param_file, mdl, "DT_RHEOLOGY", CS%dt_Rheo, &
                  "The sub-cycling time step for iterating the rheology \n"//&
                  "and ice momentum equations. If DT_RHEOLOGY is negative, \n"//&
                  "the time step is set via NSTEPS_DYN.", units="seconds", &
                  default=-1.0)
     CS%evp_sub_steps = -1
     if (CS%dt_Rheo <= 0.0) &
-      call get_param(param_file, mod, "NSTEPS_DYN", CS%evp_sub_steps, &
+      call get_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
                  "The number of iterations of the rheology and ice \n"//&
                  "momentum equations for each slow ice time step.", default=432)
   endif
-  call get_param(param_file, mod, "ICE_TDAMP_ELASTIC", CS%Tdamp, &
+  call get_param(param_file, mdl, "ICE_TDAMP_ELASTIC", CS%Tdamp, &
                  "The damping timescale associated with the elastic terms \n"//&
                  "in the sea-ice dynamics equations (if positive) or the \n"//&
                  "fraction of DT_ICE_DYNAMICS (if negative).", &
                  units = "s or nondim", default=-0.2)
-  call get_param(param_file, mod, "WEAK_LOW_SHEAR_ICE", CS%weak_low_shear, &
+  call get_param(param_file, mdl, "WEAK_LOW_SHEAR_ICE", CS%weak_low_shear, &
                  "If true, the divergent stresses go toward 0 in the C-grid \n"//&
                  "dynamics when the shear magnitudes are very weak. \n"//&
                  "Otherwise they go to -P_ice.  This setting is temporary.", &
                  default=.false.)
 
-  call get_param(param_file, mod, "PROJECT_ICE_DRAG_VEL", CS%project_drag_vel, &
+  call get_param(param_file, mdl, "PROJECT_ICE_DRAG_VEL", CS%project_drag_vel, &
                  "If true, project forward the ice velocity used in the \n"//&
                  "drag calculation to avoid an instability that can occur \n"//&
                  "when an finite stress is applied to thin ice moving with \n"//&
                  "the velocity of the ocean.", default=.true.)
-  call get_param(param_file, mod, "ICE_YIELD_ELLIPTICITY", CS%EC, &
+  call get_param(param_file, mdl, "ICE_YIELD_ELLIPTICITY", CS%EC, &
                  "The ellipticity coefficient for the plastic yield curve \n"//&
                  "in the sea-ice rheology.  For an infinite ellipticity \n"//&
                  "(i.e., a cavitating fluid rheology), use 0.", &
                  units = "Nondim", default=2.0)
 
-  call get_param(param_file, mod, "ICE_STRENGTH_PSTAR", CS%p0, &
+  call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
                  "A constant in the expression for the ice strength, \n"//&
                  "P* in Hunke & Dukowicz 1997.", units="Pa", default=2.75e4)
-  call get_param(param_file, mod, "ICE_STRENGTH_CSTAR", CS%c0, &
+  call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
                  "A constant in the exponent of the expression for the \n"//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
                  units="nondim", default=20.)
-  call get_param(param_file, mod, "ICE_CDRAG_WATER", CS%cdw, &
+  call get_param(param_file, mdl, "ICE_CDRAG_WATER", CS%cdw, &
                  "The drag coefficient between the sea ice and water.", &
                  units="nondim", default=3.24e-3)
-  call get_param(param_file, mod, "MIN_OCN_INTERTIAL_H", CS%min_ocn_inertial_h, &
+  call get_param(param_file, mdl, "MIN_OCN_INTERTIAL_H", CS%min_ocn_inertial_h, &
                  "A minimum ocean thickness used to limit the viscous coupling rate\n"//&
                  "implied for the ocean by the ice-ocean stress. Only used if positive.", &
                  units="m", default=0.0)
-  call get_param(param_file, mod, "ICE_DEL_SH_MIN_SCALE", CS%del_sh_min_scale, &
+  call get_param(param_file, mdl, "ICE_DEL_SH_MIN_SCALE", CS%del_sh_min_scale, &
                  "A scaling factor for the lower bound on the shear rates \n"//&
                  "used in the denominator of the stress calculation. This \n"//&
                  "probably needs to be greater than 1.", units="nondim", default=2.0)
-  call get_param(param_file, mod, "PROJECT_ICE_CONCENTRATION", CS%project_ci, &
+  call get_param(param_file, mdl, "PROJECT_ICE_CONCENTRATION", CS%project_ci, &
                  "If true, project the evolution of the ice concentration \n"//&
                  "due to the convergence or divergence of the ice flow.", default=.true.)
 
-  call get_param(param_file, mod, "RHO_OCEAN", CS%Rho_ocean, &
+  call get_param(param_file, mdl, "RHO_OCEAN", CS%Rho_ocean, &
                  "The nominal density of sea water as used by SIS.", &
                  units="kg m-3", default=1030.0)
-  call get_param(param_file, mod, "RHO_ICE", CS%Rho_ice, &
+  call get_param(param_file, mdl, "RHO_ICE", CS%Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0)
   CS%p0_rho = CS%p0 / CS%Rho_ice
 
-  call get_param(param_file, mod, "CFL_TRUNCATE", CS%CFL_trunc, &
+  call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
                  "The value of the CFL number that will cause ice velocity \n"//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5)
-  call get_param(param_file, mod, "CFL_TRUNC_DYN_ITS", CS%CFL_check_its, &
+  call get_param(param_file, mdl, "CFL_TRUNC_DYN_ITS", CS%CFL_check_its, &
                  "If true, check the CFL number for every iteration of the \n"//&
                  "rheology solver; otherwise only the final velocities that \n"//&
                  "are used for transport are checked.", &
                  default=.false.)
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "DEBUG_EVP_SUBSTEPS", CS%debug_EVP, &
+  call get_param(param_file, mdl, "DEBUG_EVP_SUBSTEPS", CS%debug_EVP, &
                  "If true, write out verbose debugging data for each of the \n"//&
                  "steps within the EVP solver.", default=debug)
-  call get_param(param_file, mod, "DEBUG_REDUNDANT", CS%debug_redundant, &
+  call get_param(param_file, mdl, "DEBUG_REDUNDANT", CS%debug_redundant, &
                  "If true, debug redundant data points.", default=CS%debug)
   if ( CS%specified_ice ) then
     CS%slab_ice = .true.
-    call log_param(param_file, mod, "USE_SLAB_ICE", CS%slab_ice, &
+    call log_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
                  "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
                  "USE_SLAB_ICE is always true.")
   else
-    call get_param(param_file, mod, "USE_SLAB_ICE", CS%slab_ice, &
+    call get_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
-  call get_param(param_file, mod, "U_TRUNC_FILE", CS%u_trunc_file, &
+  call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to zonal velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
                  "not needed.", default="")
-  call get_param(param_file, mod, "V_TRUNC_FILE", CS%v_trunc_file, &
+  call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
                  "not needed.", default="")
-  call get_param(param_file, mod, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
+  call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
                  "The maximum number of colums of truncations that any PE \n"//&
                  "will write out during a run.", default=50)
 
@@ -303,8 +303,8 @@ subroutine SIS_C_dyn_init(Time, G, param_file, diag, CS, ntrunc)
 !      CS%u_trunc_file = trim(dirs%output_directory)//trim(CS%u_trunc_file)
 !    if (len_trim(CS%v_trunc_file) > 0) &
 !      CS%v_trunc_file = trim(dirs%output_directory)//trim(CS%v_trunc_file)
-!    call log_param(param_file, mod, "output_dir/U_TRUNC_FILE", CS%u_trunc_file)
-!    call log_param(param_file, mod, "output_dir/V_TRUNC_FILE", CS%v_trunc_file)
+!    call log_param(param_file, mdl, "output_dir/U_TRUNC_FILE", CS%u_trunc_file)
+!    call log_param(param_file, mdl, "output_dir/V_TRUNC_FILE", CS%v_trunc_file)
 !  endif
   CS%u_file = -1 ; CS%v_file = -1 ; CS%cols_written = 0
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1251,7 +1251,7 @@ subroutine SIS_dyn_trans_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_dyn_trans" ! This module's name.
+  character(len=40) :: mdl = "SIS_dyn_trans" ! This module's name.
   real :: Time_unit      ! The time unit in seconds for ICE_STATS_INTERVAL.
   character(len=8) :: nstr
   integer :: n, nLay
@@ -1274,60 +1274,60 @@ subroutine SIS_dyn_trans_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
   CS%diag => diag ; CS%Time => Time
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This module updates the ice momentum and does ice transport.")
-  call get_param(param_file, mod, "SPECIFIED_ICE", CS%specified_ice, &
+  call get_param(param_file, mdl, "SPECIFIED_ICE", CS%specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
-  call get_param(param_file, mod, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn, &
+  call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn, &
                  "If true, use a C-grid discretization of the sea-ice \n"//&
                  "dynamics; if false use a B-grid discretization.", &
                  default=.false.)
-  call get_param(param_file, mod, "DT_ICE_DYNAMICS", CS%dt_ice_dyn, &
+  call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt_ice_dyn, &
                  "The time step used for the slow ice dynamics, including \n"//&
                  "stepping the continuity equation and interactions \n"//&
                  "between the ice mass field and velocities.  If 0 or \n"//&
                  "negative the coupling time step will be used.", &
                  units="seconds", default=-1.0)
-  call get_param(param_file, mod, "DO_RIDGING", CS%do_ridging, &
+  call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
                  "If true, apply a ridging scheme to the convergent ice. \n"//&
                  "Otherwise, ice is compressed proportionately if the \n"//&
                  "concentration exceeds 1.  The original SIS2 implementation \n"//&
                  "is based on work by Torge Martin.", default=.false.)
 
-  call get_param(param_file, mod, "ICEBERG_WINDSTRESS_BUG", CS%berg_windstress_bug, &
+  call get_param(param_file, mdl, "ICEBERG_WINDSTRESS_BUG", CS%berg_windstress_bug, &
                  "If true, use older code that applied an old ice-ocean \n"//&
                  "stress to the icebergs in place of the current air-ocean \n"//&
                  "stress.  This option is here for backward compatibility, \n"//&
                  "but should be avoided.", default=.false.)
 
-  call get_param(param_file, mod, "TIMEUNIT", Time_unit, &
+  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
                  "The time unit for ICE_STATS_INTERVAL.", &
                  units="s", default=86400.0)
-  call get_param(param_file, mod, "ICE_STATS_INTERVAL", CS%ice_stats_interval, &
+  call get_param(param_file, mdl, "ICE_STATS_INTERVAL", CS%ice_stats_interval, &
                  "The interval in units of TIMEUNIT between writes of the \n"//&
                  "globally summed ice statistics and conservation checks.", &
                  default=set_time(0,1), timeunit=Time_unit)
 
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "COLUMN_CHECK", CS%column_check, &
+  call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
                  "can increase model run time.", default=.false.)
-  call get_param(param_file, mod, "IMBALANCE_TOLERANCE", CS%imb_tol, &
+  call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9)
-  call get_param(param_file, mod, "ICE_BOUNDS_CHECK", CS%bounds_check, &
+  call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
                  "sensible, and issue warnings if they are not.  This \n"//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
-  call get_param(param_file, mod, "VERBOSE", CS%verbose, &
+  call get_param(param_file, mdl, "VERBOSE", CS%verbose, &
                  "If true, write out verbose diagnostics.", default=.false.)
 
   if (CS%Cgrid_dyn) then

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -1323,7 +1323,7 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_fast_thermo" ! This module's name.
+  character(len=40) :: mdl = "SIS_fast_thermo" ! This module's name.
   logical           :: debug
 
   call callTree_enter("SIS_fast_thermo_init(), SIS_fast_thermo.F90")
@@ -1336,39 +1336,39 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This module applies rapidly varying heat fluxes to the ice and does an "//&
      "implicit surface temperature calculation.")
 
-  call get_param(param_file, mod, "REORDER_0C_HEATFLUX", CS%Reorder_0C_heatflux, &
+  call get_param(param_file, mdl, "REORDER_0C_HEATFLUX", CS%Reorder_0C_heatflux, &
                  "If true, rearrange the calculation of the heat fluxes \n"//&
                  "projected back to 0C to work on each contribution \n"//&
                  "separately, so that they can be indentically replicated \n"//&
                  "if there is a single fast timestep per coupled timestep \n"//&
                  "and REDO_FAST_ICE_UPDATE=True.", default=.false.)
-  call get_param(param_file, mod, "MAX_TSKIN_ITT", CS%max_tskin_itt, &
+  call get_param(param_file, mdl, "MAX_TSKIN_ITT", CS%max_tskin_itt, &
                  "The maximum number of iterations of the skin temperature \n"//&
                  "and optical properties during redo_update_ice_model_fast.", &
                  default=10)
-  call get_param(param_file, mod, "COLUMN_CHECK", CS%column_check, &
+  call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
                  "can increase model run time.", default=.false.)
-  call get_param(param_file, mod, "IMBALANCE_TOLERANCE", CS%imb_tol, &
+  call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9)
-  call get_param(param_file, mod, "ICE_BOUNDS_CHECK", CS%bounds_check, &
+  call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
                  "sensible, and issue warnings if they are not.  This \n"//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug_slow, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug_slow, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "DEBUG_FAST_ICE", CS%debug_fast, &
+  call get_param(param_file, mdl, "DEBUG_FAST_ICE", CS%debug_fast, &
                  "If true, write out verbose debugging data on the fast ice PEs.", &
                  default=debug)
 

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -43,19 +43,19 @@ subroutine SIS_initialize_fixed(G, PF, write_geom, output_dir)
 
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
-  character(len=40)  :: mod = "SIS_initialize_fixed" ! This module's name.
+  character(len=40)  :: mdl = "SIS_initialize_fixed" ! This module's name.
   logical :: debug
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
 
   call callTree_enter("SIS_initialize_fixed(), SIS_fixed_initialization.F90")
-  call log_version(PF, mod, version, "")
-  call get_param(PF, mod, "DEBUG", debug, default=.false.)
-  call get_param(PF, mod, "DEBUG_SLOW_ICE", debug, &
+  call log_version(PF, mdl, version, "")
+  call get_param(PF, mdl, "DEBUG", debug, default=.false.)
+  call get_param(PF, mdl, "DEBUG_SLOW_ICE", debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
 
-  call get_param(PF, mod, "INPUTDIR", inputdir, &
+  call get_param(PF, mdl, "INPUTDIR", inputdir, &
          "The directory in which input files are found.", default=".")
   inputdir = slasher(inputdir)
 
@@ -81,7 +81,7 @@ subroutine SIS_initialize_fixed(G, PF, write_geom, output_dir)
   endif
 
 ! Modulate geometric scales according to geography.
-  call get_param(PF, mod, "CHANNEL_CONFIG", config, &
+  call get_param(PF, mdl, "CHANNEL_CONFIG", config, &
                  "A parameter that determines which set of channels are \n"//&
                  "restricted to specific  widths.  Options are:\n"//&
                  " \t none - All channels have the grid width.\n"//&
@@ -137,10 +137,10 @@ subroutine SIS_initialize_topography(D, max_depth, G, PF)
 !  This is a separate subroutine so that it can be made public and shared with
 !  the ice-sheet code or other components.
 ! Set up the bottom depth, G%bathyT either analytically or from file
-  character(len=40)  :: mod = "SIS_initialize_topography" ! This subroutine's name.
+  character(len=40)  :: mdl = "SIS_initialize_topography" ! This subroutine's name.
   character(len=200) :: config
 
-  call get_param(PF, mod, "TOPO_CONFIG", config, &
+  call get_param(PF, mdl, "TOPO_CONFIG", config, &
                  "This specifies how bathymetry is specified: \n"//&
                  " \t file - read bathymetric information from the file \n"//&
                  " \t\t specified by (TOPO_FILE).\n"//&
@@ -173,11 +173,11 @@ subroutine SIS_initialize_topography(D, max_depth, G, PF)
       "Unrecognized topography setup '"//trim(config)//"'")
   end select
   if (max_depth>0.) then
-    call log_param(PF, mod, "MAXIMUM_DEPTH", max_depth, &
+    call log_param(PF, mdl, "MAXIMUM_DEPTH", max_depth, &
                    "The maximum depth of the ocean.", units="m")
   else
     max_depth = diagnoseMaximumDepth(D,G)
-    call log_param(PF, mod, "!MAXIMUM_DEPTH", max_depth, &
+    call log_param(PF, mdl, "!MAXIMUM_DEPTH", max_depth, &
                    "The (diagnosed) maximum depth of the ocean.", units="m")
   endif
   if (trim(config) .ne. "DOME") then

--- a/src/SIS_optics.F90
+++ b/src/SIS_optics.F90
@@ -69,80 +69,80 @@ subroutine SIS_optics_init(param_file, CS, slab_optics)
   real :: T_range_dflt, alb_ice_dflt
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_optics" ! This module's name.
+  character(len=40)  :: mdl = "SIS_optics" ! This module's name.
 
   if (.not.associated(CS)) allocate(CS)
 
   CS%slab_optics = .false. ; if (present(slab_optics)) CS%slab_optics = slab_optics
 
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This module calculates the albedo and absorption profiles for shortwave radiation.")
 
   if (CS%slab_optics) then
-    call log_param(param_file, mod, "! USE_SLAB_ICE_OPTICS", CS%slab_optics, &
+    call log_param(param_file, mdl, "! USE_SLAB_ICE_OPTICS", CS%slab_optics, &
                  "Using the very old slab-style ice optics.")
   endif
 
-  call get_param(param_file, mod, "DO_DELTA_EDDINGTON_SW", CS%do_deltaEdd, &
+  call get_param(param_file, mdl, "DO_DELTA_EDDINGTON_SW", CS%do_deltaEdd, &
                  "If true, a delta-Eddington radiative transfer calculation \n"//&
                  "for the shortwave radiation within the sea-ice.", &
                  default=.not.CS%slab_optics)
-  call get_param(param_file, mod, "DO_POND", CS%do_pond, &
+  call get_param(param_file, mdl, "DO_POND", CS%do_pond, &
                  "If true, calculate melt ponds and use them for\n"//&
                  "shortwave radiation calculation.", default=.false.)
-  call get_param(param_file, mod, "MIN_POND_FRAC", CS%min_pond_frac, &
+  call get_param(param_file, mdl, "MIN_POND_FRAC", CS%min_pond_frac, &
                  "Minimum melt pond cover (by ponds at sea level)\n"//&
                  "pond drains to this when ice is porous.", default=0.2)
-  call get_param(param_file, mod, "MAX_POND_FRAC", CS%max_pond_frac, &
+  call get_param(param_file, mdl, "MAX_POND_FRAC", CS%max_pond_frac, &
                  "Maximum melt pond cover - associated with pond volume\n"//&
                  "that suppresses ice top to waterline", default=0.5)
 
-  call get_param(param_file, mod, "ICE_DELTA_EDD_R_ICE", deltaEdd_R_ice, &
+  call get_param(param_file, mdl, "ICE_DELTA_EDD_R_ICE", deltaEdd_R_ice, &
                  "A dreadfully documented tuning parameter for the radiative \n"//&
                  "propeties of sea ice with the delta-Eddington radiative \n"//&
                  "transfer calculation.", units="nondimensional", default=0.0, &
                  do_not_log=.not.CS%do_deltaEdd)
-  call get_param(param_file, mod, "ICE_DELTA_EDD_R_SNOW", deltaEdd_R_snow, &
+  call get_param(param_file, mdl, "ICE_DELTA_EDD_R_SNOW", deltaEdd_R_snow, &
                  "A dreadfully documented tuning parameter for the radiative \n"//&
                  "propeties of snow on sea ice with the delta-Eddington \n"//&
                  "radiative transfer calculation.", units="nondimensional", &
                  default=0.0, do_not_log=.not.CS%do_deltaEdd)
-  call get_param(param_file, mod, "ICE_DELTA_EDD_R_POND", deltaEdd_R_pond, &
+  call get_param(param_file, mdl, "ICE_DELTA_EDD_R_POND", deltaEdd_R_pond, &
                  "A dreadfully documented tuning parameter for the radiative \n"//&
                  "propeties of meltwater ponds on sea ice with the delta-Eddington \n"//&
                  "radiative transfer calculation.", units="nondimensional", &
                  default=0.0, do_not_log=.not.CS%do_deltaEdd)
   call shortwave_dEdd0_set_params(deltaEdd_R_ice, deltaEdd_R_snow, deltaEdd_R_pond)
 
-  call get_param(param_file, mod, "SNOW_ALBEDO", CS%alb_snow, &
+  call get_param(param_file, mdl, "SNOW_ALBEDO", CS%alb_snow, &
                  "The albedo of dry snow atop sea ice.", units="nondim", &
                  default=0.85, do_not_log=CS%do_deltaEdd)
   alb_ice_dflt = 0.5826 ; if (CS%slab_optics) alb_ice_dflt = 0.8
-  call get_param(param_file, mod, "ICE_ALBEDO", CS%alb_ice, &
+  call get_param(param_file, mdl, "ICE_ALBEDO", CS%alb_ice, &
                  "The albedo of dry bare sea ice.", units="nondim", &
                  default=alb_ice_dflt, do_not_log=CS%do_deltaEdd)
-  call get_param(param_file, mod, "ICE_SW_PEN_FRAC", CS%pen_ice, &
+  call get_param(param_file, mdl, "ICE_SW_PEN_FRAC", CS%pen_ice, &
                  "The fraction of the unreflected shortwave radiation that \n"//&
                  "penetrates into the ice.", units="Nondimensional", &
                  default=0.3, do_not_log=CS%do_deltaEdd)
-  call get_param(param_file, mod, "ICE_OPTICAL_DEPTH", CS%opt_dep_ice, &
+  call get_param(param_file, mdl, "ICE_OPTICAL_DEPTH", CS%opt_dep_ice, &
                  "The optical depth of shortwave radiation in sea ice.", &
                  units="m", default=0.67, do_not_log=CS%do_deltaEdd)
   T_range_dflt = 1.0 ; if (CS%slab_optics) T_range_dflt = 10.0
-  call get_param(param_file, mod, "ALBEDO_T_MELT_RANGE", CS%t_range_melt, &
+  call get_param(param_file, mdl, "ALBEDO_T_MELT_RANGE", CS%t_range_melt, &
                  "The temperature range below freezing over which the \n"//&
                  "albedos are changed by partial melting.", units="degC", &
                  default=1.0, do_not_log=CS%do_deltaEdd)
 
   ! These parameters pertain only to the ancient slab ice optics parameterization.
-  call get_param(param_file, mod, "SLAB_OPTICS_CRITICAL_THICK", CS%slab_crit_thick, &
+  call get_param(param_file, mdl, "SLAB_OPTICS_CRITICAL_THICK", CS%slab_crit_thick, &
                  "The thickness beyond which the slab ice optics no longer \n"//&
                  "exhibits a thickness dependencs on albedo.", units="m", &
                  default=1.0, do_not_log=.not.CS%slab_optics)
-  call get_param(param_file, mod, "SLAB_OPTICS_OCEAN_ALBEDO", CS%slab_alb_ocean, &
+  call get_param(param_file, mdl, "SLAB_OPTICS_OCEAN_ALBEDO", CS%slab_alb_ocean, &
                  "The ocean albedo as used in the slab ice optics.", units="nondim", &
                  default=0.1, do_not_log=.not.CS%slab_optics)
-  call get_param(param_file, mod, "SLAB_OPTICS_MIN_ICE_ALBEDO", CS%slab_min_ice_alb, &
+  call get_param(param_file, mdl, "SLAB_OPTICS_MIN_ICE_ALBEDO", CS%slab_min_ice_alb, &
                  "The minimum thick ice albedo with the slab ice optics.", &
                  units="nondim", default=0.55, do_not_log=.not.CS%slab_optics)
 

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1342,7 +1342,7 @@ subroutine SIS_slow_thermo_init(Time, G, IG, param_file, diag, CS, tracer_flow_C
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40) :: mod = "SIS_slow_thermo" ! This module's name.
+  character(len=40) :: mdl = "SIS_slow_thermo" ! This module's name.
   logical           :: debug
   real, parameter   :: missing = -1e34
 
@@ -1359,20 +1359,20 @@ subroutine SIS_slow_thermo_init(Time, G, IG, param_file, diag, CS, tracer_flow_C
   if (associated(tracer_flow_CSp)) CS%tracer_flow_CSp => tracer_flow_CSp
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, &
+  call log_version(param_file, mdl, version, &
      "This module calculates the slow evolution of the ice mass, heat, and salt budgets.")
 
-  call get_param(param_file, mod, "SPECIFIED_ICE", CS%specified_ice, &
+  call get_param(param_file, mdl, "SPECIFIED_ICE", CS%specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
-  call get_param(param_file, mod, "DO_RIDGING", CS%do_ridging, &
+  call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
                  "If true, apply a ridging scheme to the convergent ice. \n"//&
                  "Otherwise, ice is compressed proportionately if the \n"//&
                  "concentration exceeds 1.  The original SIS2 implementation \n"//&
                  "is based on work by Torge Martin.", default=.false.)
-  call get_param(param_file, mod, "ICE_BULK_SALINITY", CS%ice_bulk_salin, &
+  call get_param(param_file, mdl, "ICE_BULK_SALINITY", CS%ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", units = "g/kg", default=4.0)
-  call get_param(param_file, mod, "ICE_RELATIVE_SALINITY", CS%ice_rel_salin, &
+  call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", CS%ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the \n"//&
                  "salinity of the seawater from which it formed.", &
                  units = "nondim", default=0.0)
@@ -1381,65 +1381,65 @@ subroutine SIS_slow_thermo_init(Time, G, IG, param_file, diag, CS, tracer_flow_C
                    "and ICE_RELATIVE_SALINITY set to positive values.")
   if (CS%ice_bulk_salin < 0.0) CS%ice_bulk_salin = 0.0
 
-  call get_param(param_file, mod, "SIS2_FILLING_FRAZIL", CS%filling_frazil, &
+  call get_param(param_file, mdl, "SIS2_FILLING_FRAZIL", CS%filling_frazil, &
                "If true, apply frazil to fill as many categories as \n"//&
                "possible to fill in a uniform (minimum) amount of ice \n"//&
                "in all the thinnest categories. Otherwise the frazil is \n"//&
                "always assigned to a single category.", default=.true.)
-  call get_param(param_file, mod, "FILLING_FRAZIL_TIMESCALE", CS%fraz_fill_time, &
+  call get_param(param_file, mdl, "FILLING_FRAZIL_TIMESCALE", CS%fraz_fill_time, &
                "A timescale with which the filling frazil causes the \n"//&
                "thinest cells to attain similar thicknesses, or a negative \n"//&
                "number to apply the frazil flux uniformly.", default=0.0, &
                units="s", do_not_log=.not.CS%filling_frazil)
 
-  call get_param(param_file, mod, "APPLY_ICE_LIMIT", CS%do_ice_limit, &
+  call get_param(param_file, mdl, "APPLY_ICE_LIMIT", CS%do_ice_limit, &
                  "If true, restore the sea ice state toward climatology.", &
                  default=.false.)
-  call get_param(param_file, mod, "MAX_ICE_THICK_LIMIT", CS%max_ice_limit, &
+  call get_param(param_file, mdl, "MAX_ICE_THICK_LIMIT", CS%max_ice_limit, &
                  "The maximum permitted sea ice thickness when \n"//&
                  "APPLY_ICE_LIMIT is true.", units="m", default=4.0, &
                  do_not_log=.not.CS%do_ice_limit)
 
-  call get_param(param_file, mod, "DO_ICE_RESTORE", CS%do_ice_restore, &
+  call get_param(param_file, mdl, "DO_ICE_RESTORE", CS%do_ice_restore, &
                  "If true, restore the sea ice state toward climatology.", &
                  default=.false.)
-  call get_param(param_file, mod, "ICE_RESTORE_TIMESCALE", CS%ice_restore_timescale, &
+  call get_param(param_file, mdl, "ICE_RESTORE_TIMESCALE", CS%ice_restore_timescale, &
                  "The restoring timescale when DO_ICE_RESTORE is true.", &
                  units="days", default=5.0, do_not_log=.not.CS%do_ice_restore)
 
-  call get_param(param_file, mod, "NUDGE_SEA_ICE", CS%nudge_sea_ice, &
+  call get_param(param_file, mdl, "NUDGE_SEA_ICE", CS%nudge_sea_ice, &
                  "If true, constrain the sea ice concentrations using observations.", &
                  default=.false.)
-  call get_param(param_file, mod, "NUDGE_SEA_ICE_RATE", CS%nudge_sea_ice_rate, &
+  call get_param(param_file, mdl, "NUDGE_SEA_ICE_RATE", CS%nudge_sea_ice_rate, &
                  "The rate of cooling of ice-free water that should be ice \n"//&
                  "covered in order to constrained the ice concentration to \n"//&
                  "track observations.  A suggested value is ~10000 W m-2.", &
                  units = "W m-2", default=0.0, do_not_log=.not.CS%nudge_sea_ice)
-  call get_param(param_file, mod, "NUDGE_SEA_ICE_TOLERANCE", CS%nudge_conc_tol, &
+  call get_param(param_file, mdl, "NUDGE_SEA_ICE_TOLERANCE", CS%nudge_conc_tol, &
                  "The tolerance for mismatch in the sea ice concentations \n"//&
                  "before nudging begins to be applied.  Values of order 0.1\n"//&
                  "should work well.", units = "nondim", default=0.0, &
                  do_not_log=.not.CS%nudge_sea_ice)
-  call get_param(param_file, mod, "NUDGE_SEA_ICE_STABILITY", CS%nudge_stab_fac, &
+  call get_param(param_file, mdl, "NUDGE_SEA_ICE_STABILITY", CS%nudge_stab_fac, &
                  "A factor that determines whether the buoyancy flux \n"//&
                  "associated with the sea ice nudging of warm water includes \n"//&
                  "a freshwater flux so as to be destabilizing on net (<1), \n"//&
                  "stabilizing (>1), or neutral (=1).", units="nondim", &
                  default=1.0, do_not_log=.not.CS%nudge_sea_ice)
 
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "COLUMN_CHECK", CS%column_check, &
+  call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
                  "can increase model run time.", default=.false.)
-  call get_param(param_file, mod, "IMBALANCE_TOLERANCE", CS%imb_tol, &
+  call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9)
-  call get_param(param_file, mod, "ICE_BOUNDS_CHECK", CS%bounds_check, &
+  call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
                  "sensible, and issue warnings if they are not.  This \n"//&

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -123,7 +123,7 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, CS, &
   real :: Rho_0, maxvel
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_sum_output" ! This module's name.
+  character(len=40)  :: mdl = "SIS_sum_output" ! This module's name.
   character(len=200) :: statsfile  ! The name of the statistics file.
 
   if (associated(CS)) then
@@ -136,44 +136,44 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, CS, &
   CS%ntrunc = 0
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "WRITE_STOCKS", CS%write_stocks, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "WRITE_STOCKS", CS%write_stocks, &
                  "If true, write the integrated tracer amounts to stdout \n"//&
                  "when the statistics files are written.", default=.true.)
-  call get_param(param_file, mod, "STDOUT_HEARTBEAT", CS%write_stdout, &
+  call get_param(param_file, mdl, "STDOUT_HEARTBEAT", CS%write_stdout, &
                  "If true, periodically write sea ice statistics to \n"//&
                  "stdout to allow the progress to be seen.", default=.true.)
-  call get_param(param_file, mod, "DT_ICE_DYNAMICS", CS%dt, &
+  call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt, &
                  "The time step used for the slow ice dynamics, including "//&
                  "stepping the continuity equation and interactions between "//&
                  "the ice mass field and velocities.", units="s", &
                  default=-1.0, do_not_log=.true.)
-  call get_param(param_file, mod, "MAXTRUNC", CS%maxtrunc, &
+  call get_param(param_file, mdl, "MAXTRUNC", CS%maxtrunc, &
                  "The run will be stopped, and the day set to a very \n"//&
                  "large value if the velocity is truncated more than \n"//&
                  "MAXTRUNC times between  writing ice statistics. \n"//&
                  "Set MAXTRUNC to 0 to stop if there is any truncation \n"//&
                  "of sea ice velocities.", units="truncations save_interval-1", default=0)
 
-  call get_param(param_file, mod, "STATISTICS_FILE", statsfile, &
+  call get_param(param_file, mdl, "STATISTICS_FILE", statsfile, &
                  "The file to use to write the globally integrated \n"//&
                  "statistics.", default="seaice.stats")
 
   CS%statsfile = trim(slasher(directory))//trim(statsfile)
-  call log_param(param_file, mod, "output_path/STATISTICS_FILE", CS%statsfile)
+  call log_param(param_file, mdl, "output_path/STATISTICS_FILE", CS%statsfile)
 #ifdef STATSLABEL
   CS%statsfile = trim(CS%statsfile)//"."//trim(adjustl(STATSLABEL))
 #endif
 
-  call get_param(param_file, mod, "TIMEUNIT", CS%Timeunit, &
+  call get_param(param_file, mdl, "TIMEUNIT", CS%Timeunit, &
                  "The time unit in seconds a number of input fields", &
                  units="s", default=86400.0)
   if (CS%Timeunit < 0.0) CS%Timeunit = 86400.0
-  call get_param(param_file, mod, "COLUMN_CHECK", CS%column_check, &
+  call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
                  "can increase model run time.", default=.false.)
-  call get_param(param_file, mod, "IMBALANCE_TOLERANCE", CS%imb_tol, &
+  call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9)
 

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -1810,7 +1810,7 @@ subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
   logical :: debug
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_tracer_advect" ! This module's name.
+  character(len=40)  :: mdl = "SIS_tracer_advect" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (associated(CS)) then
@@ -1823,18 +1823,18 @@ subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
 
   ! Read all relevant parameters and write them to the model log.
   if ((first_call) .or. .not.present(scheme)) &
-    call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DT_ICE_DYNAMICS", CS%dt, &
+    call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt, &
                  "The time step used for the slow ice dynamics, including "//&
                  "stepping the continuity equation and interactions between "//&
                  "the ice mass field and velocities.", units="s", &
                  default=-1.0, do_not_log=.true.)
-  call get_param(param_file, mod, "DEBUG", debug, default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", CS%debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
   if (present(scheme)) then ; mesg = scheme ; else
-    call get_param(param_file, mod, "SIS_TRACER_ADVECTION_SCHEME", mesg, &
+    call get_param(param_file, mdl, "SIS_TRACER_ADVECTION_SCHEME", mesg, &
           desc="The horizontal transport scheme for tracers:\n"//&
           "  UPWIND_2D - Non-directionally split upwind\n"//&
           "  PCM    - Directionally split piecewise constant\n"//&

--- a/src/SIS_tracer_flow_control.F90
+++ b/src/SIS_tracer_flow_control.F90
@@ -122,7 +122,7 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
   !
   ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_tracer_flow_control" ! This module's name.
+  character(len=40)  :: mdl = "SIS_tracer_flow_control" ! This module's name.
 
   if (associated(CS)) then
       call SIS_error(WARNING, "SIS_call_tracer_register called with an associated "// &
@@ -131,8 +131,8 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
   else ; allocate(CS) ; endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "USE_ICE_AGE_TRACER", CS%use_ice_age, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "USE_ICE_AGE_TRACER", CS%use_ice_age, &
       "If true, use the concentration based age tracer package.", &
       default=.false.)
 

--- a/src/SIS_tracer_registry.F90
+++ b/src/SIS_tracer_registry.F90
@@ -640,14 +640,14 @@ subroutine SIS_tracer_registry_init(param_file, TrReg)
   integer, save :: init_calls = 0
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_tracer_registry" ! This module's name.
+  character(len=40)  :: mdl = "SIS_tracer_registry" ! This module's name.
   character(len=256) :: mesg    ! Message for error messages.
 
   if (.not.associated(TrReg)) then ; allocate(TrReg)
   else ; return ; endif
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
+  call log_version(param_file, mdl, version, "")
 
   init_calls = init_calls + 1
   if (init_calls > 1) then

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1029,7 +1029,7 @@ subroutine SIS_transport_init(Time, G, param_file, diag, CS)
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "SIS_transport" ! This module's name.
+  character(len=40)  :: mdl = "SIS_transport" ! This module's name.
   character(len=80)  :: scheme   ! A string for identifying an advection scheme.
   real, parameter :: missing = -1e34
 
@@ -1043,28 +1043,28 @@ subroutine SIS_transport_init(Time, G, param_file, diag, CS)
   CS%Time => Time
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version)
-  call get_param(param_file, mod, "SPECIFIED_ICE", CS%specified_ice, &
+  call log_version(param_file, mdl, version)
+  call get_param(param_file, mdl, "SPECIFIED_ICE", CS%specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   if ( CS%specified_ice ) then
     CS%adv_sub_steps = 0
-    call log_param(param_file, mod, "NSTEPS_ADV", CS%adv_sub_steps, &
+    call log_param(param_file, mdl, "NSTEPS_ADV", CS%adv_sub_steps, &
                  "The number of advective iterations for each slow time \n"//&
                  "step.  With SPECIFIED_ICE this is always 0.")
     CS%slab_ice = .true.
-    call log_param(param_file, mod, "USE_SLAB_ICE", CS%slab_ice, &
+    call log_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
                  "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
                  "USE_SLAB_ICE is always true.")
   else
-    call get_param(param_file, mod, "NSTEPS_ADV", CS%adv_sub_steps, &
+    call get_param(param_file, mdl, "NSTEPS_ADV", CS%adv_sub_steps, &
                  "The number of advective iterations for each slow time \n"//&
                  "step.", default=1)
-    call get_param(param_file, mod, "USE_SLAB_ICE", CS%SLAB_ICE, &
+    call get_param(param_file, mdl, "USE_SLAB_ICE", CS%SLAB_ICE, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
   call obsolete_logical(param_file, "ADVECT_TSURF", warning_val=.false.)
-  call get_param(param_file, mod, "RECATEGORIZE_ICE", CS%readjust_categories, &
+  call get_param(param_file, mdl, "RECATEGORIZE_ICE", CS%readjust_categories, &
                  "If true, readjust the distribution into ice thickness \n"//&
                  "categories after advection.", default=.true.)
 
@@ -1072,14 +1072,14 @@ subroutine SIS_transport_init(Time, G, param_file, diag, CS)
   call obsolete_real(param_file, "ICE_CHANNEL_VISCOSITY", warning_val=0.15)
   call obsolete_real(param_file, "ICE_CHANNEL_CFL_LIMIT", warning_val=0.25)
 
-  call get_param(param_file, mod, "RHO_ICE", CS%Rho_ice, &
+  call get_param(param_file, mdl, "RHO_ICE", CS%Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0)
-  call get_param(param_file, mod, "RHO_SNOW", CS%Rho_snow, &
+  call get_param(param_file, mdl, "RHO_SNOW", CS%Rho_snow, &
                  "The nominal density of snow as used by SIS.", &
                  units="kg m-3", default=330.0)
 
-  call get_param(param_file, mod, "SEA_ICE_ROLL_FACTOR", CS%Roll_factor, &
+  call get_param(param_file, mdl, "SEA_ICE_ROLL_FACTOR", CS%Roll_factor, &
                  "A factor by which the propensity of small amounts of \n"//&
                  "thick sea-ice to become thinner by rolling is increased \n"//&
                  "or 0 to disable rolling.  This can be thought of as the \n"//&
@@ -1087,25 +1087,25 @@ subroutine SIS_transport_init(Time, G, param_file, diag, CS)
                  "the horizontal floe aspect ratio.  Sensible values are \n"//&
                  "0 (no rolling) or larger than 1.", units="Nondim",default=1.0)
 
-  call get_param(param_file, mod, "CHECK_ICE_TRANSPORT_CONSERVATION", CS%check_conservation, &
+  call get_param(param_file, mdl, "CHECK_ICE_TRANSPORT_CONSERVATION", CS%check_conservation, &
                  "If true, use add multiple diagnostics of ice and snow \n"//&
                  "mass conservation in the sea-ice transport code.  This \n"//&
                  "is expensive and should be used sparingly.", default=.false.)
-  call get_param(param_file, mod, "DO_RIDGING", CS%do_ridging, &
+  call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
                  "If true, apply a ridging scheme to the convergent ice. \n"//&
                  "Otherwise, ice is compressed proportionately if the \n"//&
                  "concentration exceeds 1.  The original SIS2 implementation \n"//&
                  "is based on work by Torge Martin.", default=.false.)
   call obsolete_logical(param_file, "USE_SIS_CONTINUITY", .true.)
   call obsolete_logical(param_file, "USE_SIS_THICKNESS_ADVECTION", .true.)
-  call get_param(param_file, mod, "SIS_THICKNESS_ADVECTION_SCHEME", scheme, &
+  call get_param(param_file, mdl, "SIS_THICKNESS_ADVECTION_SCHEME", scheme, &
           desc="The horizontal transport scheme for thickness:\n"//&
           "  UPWIND_2D - Non-directionally split upwind\n"//&
           "  PCM    - Directionally split piecewise constant\n"//&
           "  PLM    - Piecewise Linear Method\n"//&
           "  PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)", &
           default='UPWIND_2D')
-  call get_param(param_file, mod, "ICE_BOUNDS_CHECK", CS%bounds_check, &
+  call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
                  "sensible, and issue warnings if they are not.  This \n"//&

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -68,7 +68,7 @@ subroutine ice_ocean_driver_init(CS, Time_init, Time_in)
 !     real :: Time_unit   ! The time unit in seconds for ENERGYSAVEDAYS.
 !   ! This include declares and sets the variable "version".
 !   #include "version_variable.h"
-!     character(len=40)  :: mod = "ice_ocean_driver_init"  ! This module's name.
+!     character(len=40)  :: mdl = "ice_ocean_driver_init"  ! This module's name.
 !     character(len=48)  :: stagger
 !     integer :: secs, days
 !  type(param_file_type) :: param_file !< A structure to parse for run-time parameters
@@ -85,18 +85,18 @@ subroutine ice_ocean_driver_init(CS, Time_init, Time_in)
 !     if (.not.OS%is_ocean_pe) return
 
 !     ! Read all relevant parameters and write them to the model log.
-!     call log_version(param_file, mod, version, "")
-!     call get_param(param_file, mod, "RESTART_CONTROL", OS%Restart_control, &
+!     call log_version(param_file, mdl, version, "")
+!     call get_param(param_file, mdl, "RESTART_CONTROL", OS%Restart_control, &
 !                    "An integer whose bits encode which restart files are \n"//&
 !                    "written. Add 2 (bit 1) for a time-stamped file, and odd \n"//&
 !                    "(bit 0) for a non-time-stamped file.  A restart file \n"//&
 !                    "will be saved at the end of the run segment for any \n"//&
 !                    "non-negative value.", default=1)
-!     call get_param(param_file, mod, "TIMEUNIT", Time_unit, &
+!     call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
 !                    "The time unit for ENERGYSAVEDAYS.", &
 !                    units="s", default=86400.0)
 
-!     call get_param(param_file, mod, "OCEAN_SURFACE_STAGGER", stagger, &
+!     call get_param(param_file, mdl, "OCEAN_SURFACE_STAGGER", stagger, &
 !                    "A case-insensitive character string to indicate the \n"//&
 !                    "staggering of the surface velocity field that is \n"//&
 !                    "returned to the coupler.  Valid values include \n"//&

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -169,7 +169,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
 
   ! This include declares and sets the variable "version".
 #include "version_variable.h"
-  character(len=40)  :: mod = "ice_age_tracer" ! This module's name.
+  character(len=40)  :: mdl = "ice_age_tracer" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
   real, dimension(:,:,:), pointer :: ocean_BC_ptr, snow_BC_ptr
@@ -185,17 +185,17 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
   allocate(CS)
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "DO_ICE_AGE_AREAL", CS%do_ice_age_areal, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "DO_ICE_AGE_AREAL", CS%do_ice_age_areal, &
       "If true, use an ice age tracer that ages at \n"//&
       "a unit rate if the ice exists.", &
       default=.false.)
-  call get_param(param_file, mod, "DO_ICE_AGE_MASS", CS%do_ice_age_mass, &
+  call get_param(param_file, mdl, "DO_ICE_AGE_MASS", CS%do_ice_age_mass, &
       "If true, use an ice age tracer that is set to 0 age \n"//&
       "when ice is first formed, ages at unit rate in the ice pack \n"// &
       "and any new ice added to the ice pack represents a decrease in age", &
       default=.false.)
-  call get_param(param_file, mod, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
+  call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
       "If true, tracers may go through the initialization code \n"//&
       "if they are not found in the restart files.  Otherwise \n"//&
       "it is a fatal error if the tracers are not found in the \n"//&
@@ -204,7 +204,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
   CS%ntr = 0
   if (CS%do_ice_age_areal) then
       CS%ntr = CS%ntr + 1 ; m = CS%ntr
-      CS%tr_desc(m) = var_desc("ice_age_areal", "years", "Area based ice age tracer", caller=mod)
+      CS%tr_desc(m) = var_desc("ice_age_areal", "years", "Area based ice age tracer", caller=mdl)
       CS%tracer_ages(m) = .true.
       CS%new_ice_is_sink(m) = .false.
       CS%uniform_vertical(m) = .true.
@@ -214,7 +214,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
   endif
   if (CS%do_ice_age_mass) then
       CS%ntr = CS%ntr + 1 ; m = CS%ntr
-      CS%tr_desc(m) = var_desc("ice_age_mass", "years", "Mass-based ice age tracer", caller=mod)
+      CS%tr_desc(m) = var_desc("ice_age_mass", "years", "Mass-based ice age tracer", caller=mdl)
       CS%tracer_ages(m) = .true.
       CS%new_ice_is_sink(m) = .true.
       CS%uniform_vertical(m) = .false.

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1630,7 +1630,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   logical :: spec_thermo_sal
   character(len=120) :: restart_file, fast_rest_file
   character(len=240) :: restart_path, fast_rest_path
-  character(len=40)  :: mod = "ice_model" ! This module's name.
+  character(len=40)  :: mdl = "ice_model" ! This module's name.
   character(len=8)   :: nstr
   type(directories)  :: dirs   ! A structure containing several relevant directory paths.
 
@@ -1772,29 +1772,29 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   call callTree_enter("ice_model_init(), ice_model.F90")
 
   ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mod, version, "")
-  call get_param(param_file, mod, "SPECIFIED_ICE", specified_ice, &
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "SPECIFIED_ICE", specified_ice, &
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
-  call get_param(param_file, mod, "CGRID_ICE_DYNAMICS", Cgrid_dyn, &
+  call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", Cgrid_dyn, &
                  "If true, use a C-grid discretization of the sea-ice \n"//&
                  "dynamics; if false use a B-grid discretization.", &
                  default=.false.)
   if (specified_ice) then
     slab_ice = .true.
-    call log_param(param_file, mod, "USE_SLAB_ICE", slab_ice, &
+    call log_param(param_file, mdl, "USE_SLAB_ICE", slab_ice, &
                  "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
                  "USE_SLAB_ICE is always true.")
   else
-    call get_param(param_file, mod, "USE_SLAB_ICE", slab_ice, &
+    call get_param(param_file, mdl, "USE_SLAB_ICE", slab_ice, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
-  call get_param(param_file, mod, "SINGLE_ICE_STATE_TYPE", single_IST, &
+  call get_param(param_file, mdl, "SINGLE_ICE_STATE_TYPE", single_IST, &
                  "If true, the fast and slow portions of the ice use a \n"//&
                  "single common ice_state_type.  Otherwise they point to \n"//&
                  "different ice_state_types that need to be explicitly \n"//&
                  "copied back and forth.", default=.true.)
-  call get_param(param_file, mod, "EULERIAN_TSURF", Eulerian_tsurf, &
+  call get_param(param_file, mdl, "EULERIAN_TSURF", Eulerian_tsurf, &
                  "If true, use previous calculations of the ice-top surface \n"//&
                  "skin temperature for tsurf at the start of atmospheric \n"//&
                  "time stepping, including interpolating between tsurf \n"//&
@@ -1805,7 +1805,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   call obsolete_logical(param_file, "AREA_WEIGHTED_STRESSES", warning_val=.true.)
 
   dflt_stagger = "B" ; if (Cgrid_dyn) dflt_stagger = "C"
-  call get_param(param_file, mod, "ICE_OCEAN_STRESS_STAGGER", stagger, &
+  call get_param(param_file, mdl, "ICE_OCEAN_STRESS_STAGGER", stagger, &
                  "A case-insensitive character string to indicate the \n"//&
                  "staggering of the stress field on the ocean that is \n"//&
                  "returned to the coupler.  Valid values include \n"//&
@@ -1815,69 +1815,69 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   ! Rho_ocean is not actually used here, but it used from later get_param
   ! calls in other modules.  This call is here to avoid changing the order of
   ! the entries in the SIS_parameter_doc files.
-  call get_param(param_file, mod, "RHO_OCEAN", Rho_ocean, &
+  call get_param(param_file, mdl, "RHO_OCEAN", Rho_ocean, &
                  "The nominal density of sea water as used by SIS.", &
                  units="kg m-3", default=1030.0)
-  call get_param(param_file, mod, "RHO_ICE", Rho_ice, &
+  call get_param(param_file, mdl, "RHO_ICE", Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0)
-  call get_param(param_file, mod, "RHO_SNOW", Rho_snow, &
+  call get_param(param_file, mdl, "RHO_SNOW", Rho_snow, &
                  "The nominal density of snow as used by SIS.", &
                  units="kg m-3", default=330.0)
 
-  call get_param(param_file, mod, "G_EARTH", g_Earth, &
+  call get_param(param_file, mdl, "G_EARTH", g_Earth, &
                  "The gravitational acceleration of the Earth.", &
                  units="m s-2", default = 9.80)
 
-  call get_param(param_file, mod, "MOMENTUM_ROUGH_ICE", mom_rough_ice, &
+  call get_param(param_file, mdl, "MOMENTUM_ROUGH_ICE", mom_rough_ice, &
                  "The default momentum roughness length scale for the ocean.", &
                  units="m", default=1.0e-4)
-  call get_param(param_file, mod, "HEAT_ROUGH_ICE", heat_rough_ice, &
+  call get_param(param_file, mdl, "HEAT_ROUGH_ICE", heat_rough_ice, &
                  "The default roughness length scale for the turbulent \n"//&
                  "transfer of heat into the ocean.", units="m", default=1.0e-4)
 
-  call get_param(param_file, mod, "CONSTANT_COSZEN_IC", coszen_IC, &
+  call get_param(param_file, mdl, "CONSTANT_COSZEN_IC", coszen_IC, &
                  "A constant value to use to initialize the cosine of \n"//&
                  "the solar zenith angle for the first radiation step, \n"//&
                  "or a negative number to use the current time and astronomy.", &
                  units="nondim", default=-1.0)
-  call get_param(param_file, mod, "DT_RADIATION", dt_Rad_real, &
+  call get_param(param_file, mdl, "DT_RADIATION", dt_Rad_real, &
                  "The time step with which the shortwave radiation and \n"//&
                  "fields like albedos are updated.  Currently this is only \n"//&
                  "used to initialize albedos when there is no restart file.", &
                  units="s", default=time_type_to_real(Time_step_slow))
   dt_Rad = real_to_time_type(dt_Rad_real)
-  call get_param(param_file, mod, "ICE_KMELT", kmelt, &
+  call get_param(param_file, mdl, "ICE_KMELT", kmelt, &
                  "A constant giving the proportionality of the ocean/ice \n"//&
                  "base heat flux to the tempature difference, given by \n"//&
                  "the product of the heat capacity per unit volume of sea \n"//&
                  "water times a molecular diffusive piston velocity.", &
                  units="W m-2 K-1", default=6e-5*4e6)
-  call get_param(param_file, mod, "SNOW_CONDUCT", k_snow, &
+  call get_param(param_file, mdl, "SNOW_CONDUCT", k_snow, &
                  "The conductivity of heat in snow.", units="W m-1 K-1", &
                  default=0.31)
-  call get_param(param_file, mod, "COLUMN_CHECK", column_check, &
+  call get_param(param_file, mdl, "COLUMN_CHECK", column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
                  "can increase model run time.", default=.false.)
-  call get_param(param_file, mod, "IMBALANCE_TOLERANCE", imb_tol, &
+  call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9)
-  call get_param(param_file, mod, "ICE_BOUNDS_CHECK", bounds_check, &
+  call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
                  "sensible, and issue warnings if they are not.  This \n"//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
-  call get_param(param_file, mod, "DEBUG", debug, &
+  call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false.)
-  call get_param(param_file, mod, "DEBUG_SLOW_ICE", debug_slow, &
+  call get_param(param_file, mdl, "DEBUG_SLOW_ICE", debug_slow, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "DEBUG_FAST_ICE", debug_fast, &
+  call get_param(param_file, mdl, "DEBUG_FAST_ICE", debug_fast, &
                  "If true, write out verbose debugging data on the fast ice PEs.", &
                  default=debug)
-  call get_param(param_file, mod, "GLOBAL_INDEXING", global_indexing, &
+  call get_param(param_file, mdl, "GLOBAL_INDEXING", global_indexing, &
                  "If true, use a global lateral indexing convention, so \n"//&
                  "that corresponding points on different processors have \n"//&
                  "the same index. This does not work with static memory.", &
@@ -1886,74 +1886,74 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   if (global_indexing) call SIS_error(FATAL, "ice_model_init: "//&
        "GLOBAL_INDEXING can not be true with STATIC_MEMORY.")
 #endif
-  call get_param(param_file, mod, "FIRST_DIRECTION", first_direction, &
+  call get_param(param_file, mdl, "FIRST_DIRECTION", first_direction, &
                  "An integer that indicates which direction goes first \n"//&
                  "in parts of the code that use directionally split \n"//&
                  "updates, with even numbers (or 0) used for x- first \n"//&
                  "and odd numbers used for y-first.", default=0)
-  call log_param(param_file, mod, "! VERONA_COUPLER", Verona, &
+  call log_param(param_file, mdl, "! VERONA_COUPLER", Verona, &
                  "If true, carry out all of the sea ice calls so that SIS2 \n"//&
                  "will work with the Verona and earlier releases of the \n"//&
                  "FMS coupler code in configurations that use the exchange \n"//&
                  "grid to communicate with the atmosphere or land.", &
                  layoutParam=.true.)
 
-  call get_param(param_file, mod, "ICE_SEES_ATMOS_WINDS", atmos_winds, &
+  call get_param(param_file, mdl, "ICE_SEES_ATMOS_WINDS", atmos_winds, &
                  "If true, the sea ice is being given wind stresses with \n"//&
                  "the atmospheric sign convention, and need to have their \n"//&
                  "sign changed.", default=.true.)
-  call get_param(param_file, mod, "ICE_BULK_SALINITY", ice_bulk_salin, &
+  call get_param(param_file, mdl, "ICE_BULK_SALINITY", ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", units = "g/kg", &
                  default=4.0, do_not_log=.true.)
-  call get_param(param_file, mod, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
+  call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the \n"//&
                  "salinity of the seawater from which it formed.", &
                  units = "nondim", default=0.0, do_not_log=.true.)
   if ((ice_bulk_salin < 0.0) .or. (ice_rel_salin > 0.0)) ice_bulk_salin = 0.0
 
-  call get_param(param_file, mod, "APPLY_SLP_TO_OCEAN", slp2ocean, &
+  call get_param(param_file, mdl, "APPLY_SLP_TO_OCEAN", slp2ocean, &
                  "If true, apply the atmospheric sea level pressure to \n"//&
                  "the ocean.", default=.false.)
-  call get_param(param_file, mod, "MIN_H_FOR_TEMP_CALC", h_lo_lim, &
+  call get_param(param_file, mdl, "MIN_H_FOR_TEMP_CALC", h_lo_lim, &
                  "The minimum ice thickness at which to do temperature \n"//&
                  "calculations.", units="m", default=0.0)
-  call get_param(param_file, mod, "DO_ICEBERGS", do_icebergs, &
+  call get_param(param_file, mdl, "DO_ICEBERGS", do_icebergs, &
                  "If true, call the iceberg module.", default=.false.)
   if (do_icebergs) then
-    call get_param(param_file, mod, "PASS_ICEBERG_AREA_TO_OCEAN", pass_iceberg_area_to_ocean, &
+    call get_param(param_file, mdl, "PASS_ICEBERG_AREA_TO_OCEAN", pass_iceberg_area_to_ocean, &
                  "If true, iceberg area is passed through coupler", default=.false.)
   else ; pass_iceberg_area_to_ocean = .false. ; endif
 
-  call get_param(param_file, mod, "ADD_DIURNAL_SW", add_diurnal_sw, &
+  call get_param(param_file, mdl, "ADD_DIURNAL_SW", add_diurnal_sw, &
                  "If true, add a synthetic diurnal cycle to the shortwave \n"//&
                  "radiation.", default=.false.)
-  call get_param(param_file, mod, "DO_SUN_ANGLE_FOR_ALB", do_sun_angle_for_alb, &
+  call get_param(param_file, mdl, "DO_SUN_ANGLE_FOR_ALB", do_sun_angle_for_alb, &
                  "If true, find the sun angle for calculating the ocean \n"//&
                  "albedo within the sea ice model.", default=.false.)
-  call get_param(param_file, mod, "DO_RIDGING", do_ridging, &
+  call get_param(param_file, mdl, "DO_RIDGING", do_ridging, &
                  "If true, call the ridging routines.", default=.false.)
 
-  call get_param(param_file, mod, "RESTARTFILE", restart_file, &
+  call get_param(param_file, mdl, "RESTARTFILE", restart_file, &
                  "The name of the restart file.", default="ice_model.res.nc")
   if (fast_ice_PE.eqv.slow_ice_PE) then
-    call get_param(param_file, mod, "FAST_ICE_RESTARTFILE", fast_rest_file, &
+    call get_param(param_file, mdl, "FAST_ICE_RESTARTFILE", fast_rest_file, &
                    "The name of the restart file for those elements of the \n"//&
                    "the sea ice that are handled by the fast ice PEs.", &
                    default=restart_file)
   else
-    call get_param(param_file, mod, "FAST_ICE_RESTARTFILE", fast_rest_file, &
+    call get_param(param_file, mdl, "FAST_ICE_RESTARTFILE", fast_rest_file, &
                    "The name of the restart file for those elements of the \n"//&
                    "the sea ice that are handled by the fast ice PEs.", &
                    default="ice_model_fast.res.nc")
   endif
 
-  call get_param(param_file, mod, "MASSLESS_ICE_ENTH", massless_ice_enth, &
+  call get_param(param_file, mdl, "MASSLESS_ICE_ENTH", massless_ice_enth, &
                  "The ice enthalpy fill value for massless categories.", &
                  units="J kg-1", default=0.0, do_not_log=.true.)
-  call get_param(param_file, mod, "MASSLESS_SNOW_ENTH", massless_snow_enth, &
+  call get_param(param_file, mdl, "MASSLESS_SNOW_ENTH", massless_snow_enth, &
                  "The snow enthalpy fill value for massless categories.", &
                  units="J kg-1", default=0.0, do_not_log=.true.)
-  call get_param(param_file, mod, "MASSLESS_ICE_SALIN", massless_ice_salin, &
+  call get_param(param_file, mdl, "MASSLESS_ICE_SALIN", massless_ice_salin, &
                  "The ice salinity fill value for massless categories.", &
                  units="g kg-1", default=0.0, do_not_log=.true.)
   call get_param(param_file, "MOM", "WRITE_GEOM", write_geom, &
@@ -2537,7 +2537,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
   ! Initialize icebergs
     if (Ice%sCS%do_icebergs) then
-      call get_param(param_file, mod, "ICEBERG_WINDSTRESS_BUG", Ice%sCS%berg_windstress_bug, &
+      call get_param(param_file, mdl, "ICEBERG_WINDSTRESS_BUG", Ice%sCS%berg_windstress_bug, &
                  "If true, use older code that applied an old ice-ocean \n"//&
                  "stress to the icebergs in place of the current air-ocean \n"//&
                  "stress.  This option is here for backward compatibility, \n"//&


### PR DESCRIPTION
  The name "mod" had been used for various module name variables throughout the
MOM6 code, but this can cause name-space conflicts with the mod intrinsic
function, so "mod" has been renamed "mdl" throughout the MOM6 code.  All answers
are bitwise identical.