### PR TITLE
+Log debugging params to SIS_param_doc.debugging

### DIFF
--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -97,13 +97,16 @@ subroutine SIS_debugging_init(param_file)
 
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
                  "If true, checksums are performed on arrays in the \n"//&
-                 "various vec_chksum routines.", default=debug)
+                 "various vec_chksum routines.", default=debug, &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
                  "If true, debug redundant data points during calls to \n"//&
-                 "the various vec_chksum routines.", default=debug)
+                 "the various vec_chksum routines.", default=debug, &
+                 debuggingParam=.true.)
 
   call MOM_checksums_init(param_file)
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -158,12 +158,14 @@ subroutine SIS_B_dyn_init(Time, G, param_file, diag, CS)
   CS%p0_rho = CS%p0 / CS%Rho_ice
 
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", CS%debug_redundant, &
-                 "If true, debug redundant data points.", default=CS%debug)
+                 "If true, debug redundant data points.", default=CS%debug, &
+                 debuggingParam=.true.)
   if ( CS%specified_ice ) then
     CS%slab_ice = .true.
     call log_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -266,15 +266,17 @@ subroutine SIS_C_dyn_init(Time, G, param_file, diag, CS, ntrunc)
                  "are used for transport are checked.", &
                  default=.false.)
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_EVP_SUBSTEPS", CS%debug_EVP, &
                  "If true, write out verbose debugging data for each of the \n"//&
-                 "steps within the EVP solver.", default=debug)
+                 "steps within the EVP solver.", default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", CS%debug_redundant, &
-                 "If true, debug redundant data points.", default=CS%debug)
+                 "If true, debug redundant data points.", default=CS%debug, &
+                 debuggingParam=.true.)
   if ( CS%specified_ice ) then
     CS%slab_ice = .true.
     call log_param(param_file, mdl, "USE_SLAB_ICE", CS%slab_ice, &
@@ -288,15 +290,15 @@ subroutine SIS_C_dyn_init(Time, G, param_file, diag, CS, ntrunc)
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to zonal velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
-                 "not needed.", default="")
+                 "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
                  "The absolute path to the file where the accelerations \n"//&
                  "leading to meridional velocity truncations are written. \n"//&
                  "Leave this empty for efficiency if this diagnostic is \n"//&
-                 "not needed.", default="")
+                 "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
                  "The maximum number of colums of truncations that any PE \n"//&
-                 "will write out during a run.", default=50)
+                 "will write out during a run.", default=50, debuggingParam=.true.)
 
 !  if (len_trim(dirs%output_directory) > 0) then
 !    if (len_trim(CS%u_trunc_file) > 0) &

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1316,17 +1316,19 @@ subroutine SIS_dyn_trans_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
                  default=set_time(0,1), timeunit=Time_unit)
 
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
-                 "can increase model run time.", default=.false.)
+                 "can increase model run time.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
-                 units="nondim", default=1.0e-9)
+                 units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
@@ -1334,7 +1336,8 @@ subroutine SIS_dyn_trans_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "VERBOSE", CS%verbose, &
-                 "If true, write out verbose diagnostics.", default=.false.)
+                 "If true, write out verbose diagnostics.", default=.false., &
+                 debuggingParam=.true.)
 
   if (CS%Cgrid_dyn) then
     call SIS_C_dyn_init(CS%Time, G, param_file, CS%diag, CS%SIS_C_dyn_CSp, CS%ntrunc)

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -272,7 +272,7 @@ subroutine avg_top_quantities(FIA, Rad, IST, G, IG)
 !        FIA%evap_top(i,j,k) = 0.0
 !      endif
     enddo ; enddo
-    
+
     do b=1,nb ; do i=isc,iec
       FIA%flux_sw_dn(i,j,b) = FIA%flux_sw_dn(i,j,b)*I_avc
     enddo ; enddo

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -1294,10 +1294,11 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
-                 "can increase model run time.", default=.false.)
+                 "can increase model run time.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
-                 units="nondim", default=1.0e-9)
+                 units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
@@ -1305,13 +1306,14 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug_slow, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_FAST_ICE", CS%debug_fast, &
                  "If true, write out verbose debugging data on the fast ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
 
   call SIS2_ice_thm_init(param_file, CS%ice_thm_CSp)
 

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -53,7 +53,7 @@ subroutine SIS_initialize_fixed(G, PF, write_geom, output_dir)
   call get_param(PF, mdl, "DEBUG", debug, default=.false.)
   call get_param(PF, mdl, "DEBUG_SLOW_ICE", debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
 
   call get_param(PF, mdl, "INPUTDIR", inputdir, &
          "The directory in which input files are found.", default=".")

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1415,17 +1415,19 @@ subroutine SIS_slow_thermo_init(Time, G, IG, param_file, diag, CS, tracer_flow_C
                  default=1.0, do_not_log=.not.CS%nudge_sea_ice)
 
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
-                 "can increase model run time.", default=.false.)
+                 "can increase model run time.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
-                 units="nondim", default=1.0e-9)
+                 units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -172,10 +172,11 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, CS, &
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
-                 "can increase model run time.", default=.false.)
+                 "can increase model run time.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
-                 units="nondim", default=1.0e-9)
+                 units="nondim", default=1.0e-9, debuggingParam=.true.)
 
   CS%Start_time = Input_start_time
 

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -1832,7 +1832,7 @@ subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
   call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   if (present(scheme)) then ; mesg = scheme ; else
     call get_param(param_file, mdl, "SIS_TRACER_ADVECTION_SCHEME", mesg, &
           desc="The horizontal transport scheme for tracers:\n"//&

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1095,7 +1095,8 @@ subroutine SIS_transport_init(Time, G, param_file, diag, CS)
   call get_param(param_file, mdl, "CHECK_ICE_TRANSPORT_CONSERVATION", CS%check_conservation, &
                  "If true, use add multiple diagnostics of ice and snow \n"//&
                  "mass conservation in the sea-ice transport code.  This \n"//&
-                 "is expensive and should be used sparingly.", default=.false.)
+                 "is expensive and should be used sparingly.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
                  "If true, apply a ridging scheme to the convergent ice. \n"//&
                  "Otherwise, ice is compressed proportionately if the \n"//&

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1876,10 +1876,11 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   call get_param(param_file, mdl, "COLUMN_CHECK", column_check, &
                  "If true, add code to allow debugging of conservation \n"//&
                  "column-by-column.  This does not change answers, but \n"//&
-                 "can increase model run time.", default=.false.)
+                 "can increase model run time.", default=.false., &
+                 debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
-                 units="nondim", default=1.0e-9)
+                 units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", bounds_check, &
                  "If true, periodically check the values of ice and snow \n"//&
                  "temperatures and thicknesses to ensure that they are \n"//&
@@ -1887,13 +1888,14 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, &
-                 "If true, write out verbose debugging data.", default=.false.)
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", debug_slow, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_FAST_ICE", debug_fast, &
                  "If true, write out verbose debugging data on the fast ice PEs.", &
-                 default=debug)
+                 default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "GLOBAL_INDEXING", global_indexing, &
                  "If true, use a global lateral indexing convention, so \n"//&
                  "that corresponding points on different processors have \n"//&


### PR DESCRIPTION
  Moved the logging of runtime parameters used only for debugging into
SIS_parameter_doc.debugging, by adding the debuggingParam flag to their
get_param calls.  This is only applied to parameters whose values do not alter
the solutions, if the model is working properly, so the SIS_parameter_doc.all or
SIS_parameter_doc.short are still sufficient to exactly reproduce a simulation.
All answers are bitwise identical, but the SIS_parameter_doc files change in
MOM6_examples.