### PR TITLE
User/mjh/fia mass adjust

### DIFF
--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -123,7 +123,7 @@ type slow_thermo_CS ; private
                             ! do_ice_limit is true.
 
   logical :: nudge_sea_ice = .false. ! If true, nudge sea ice concentrations towards observations.
-  real    :: nudge_sea_ice_rate = 0.0 ! The rate of cooling of ice-free water that
+  real, dimension(2)    :: nudge_sea_ice_rate = 0.0 ! The rate of cooling of ice-free water that
                               ! should be ice  covered in order to constrained the
                               ! ice concentration to track observations.  A suggested
                               ! value is of order 10000 W m-2.
@@ -691,7 +691,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
     call get_SIS2_thermo_coefs(IST%ITV, Cp_Water=Cp_water, EOS=EOS)
     do j=jsc,jec ; do i=isc,iec
       if (icec(i,j) < icec_obs(i,j) - CS%nudge_conc_tol) then
-        cool_nudge(i,j) = CS%nudge_sea_ice_rate * &
+        cool_nudge(i,j) = CS%nudge_sea_ice_rate(1) * &
              ((icec_obs(i,j)-CS%nudge_conc_tol) - icec(i,j))**2.0 ! W/m2
         if (CS%nudge_stab_fac /= 0.0) then
           if (OSS%SST_C(i,j) > OSS%T_fr_ocn(i,j)) then
@@ -703,7 +703,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
         endif
       elseif (icec(i,j) > icec_obs(i,j) + CS%nudge_conc_tol) then
         ! Heat the ice but do not apply a fresh water flux.
-        cool_nudge(i,j) = -CS%nudge_sea_ice_rate * &
+        cool_nudge(i,j) = -CS%nudge_sea_ice_rate(2) * &
              (icec(i,j) - (icec_obs(i,j)+CS%nudge_conc_tol))**2.0 ! W/m2
       endif
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -376,9 +376,6 @@ subroutine ice_model_fast_cleanup(Ice)
   call avg_top_quantities(Ice%fCS%FIA, Ice%fCS%Rad, Ice%fCS%IST, &
                           Ice%fCS%G, Ice%fCS%IG)
 
-  ! If applying a surface mass balance constraint, then make the adjustments here
-  call constrain_surface_mass_balance(Ice)
-
   call total_top_quantities(Ice%fCS%FIA, Ice%fCS%TSF, Ice%fCS%IST%part_size, &
                             Ice%fCS%G, Ice%fCS%IG)
 
@@ -1996,47 +1993,6 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
      ((dirs%input_filename(1:1)=='n') .and. (LEN_TRIM(dirs%input_filename)==1))))
 
   nudge_sea_ice = .false. ; call read_param(param_file, "NUDGE_SEA_ICE", nudge_sea_ice)
-
-  call get_param(param_file, mdl, "CONSTRAIN_MOISTURE_TRANSPORT", Ice%constrain_mmt, &
-                 "If true, constrain the meridional moisture transport implied by by \n"// &
-                 "the surface mass fluxes."// &
-                 default=.false.)
-  if (Ice%constrain_mmt) then
-     call get_param(param_file, mdl, "PMT_LATITUDE_NORTH", Ice%pmt_lat_north, &
-       "The northern latitude used to apply the moisture transport constraint.", &
-       default=40., units="degrees")
-     call get_param(param_file, mdl, "PMT_LATITUDE_SOUTH", Ice%pmt_lat_south, &
-       "The southern latitude used to apply the moisture transport constraint.", &
-       default=-40., units="degrees")
-     call get_param(param_file, mdl, "READ_PMT", Ice%read_pmt, &
-       "If true, read time-varying moisture transports from a file.", &
-       default=.false.)
-     if ( Ice%read_pmt) then
-        Ice%pmt_north_file = 'pmt_north.nc'
-        call get_param(param_file, mdl, "PMT_NORTH_FILE", Ice%pmt_north_file, &
-        "A case-sensitive filename for reading the northern hemisphere \n"//&
-        "moisture transport constraint in Sv.",default=Ice%pmt_north_file)
-        Ice%pmt_south_file = 'pmt_south.nc'
-        call get_param(param_file, mdl, "PMT_SOUTH_FILE", Ice%pmt_south_file, &
-        "A case-sensitive filename for reading the southern hemisphere \n"//&
-        "moisture transport constraint in Sv.",default=Ice%pmt_south_file)
-        call get_param(param_file, mdl, "PMT_FILE_VARIABLE", Ice%pmt_file_variable, &
-        "A case-sensitive filename for the file variable containing \n"//&
-        "the moisture transport constraint.",default='poleward_moisture_transport')
-        Ice%id_pmt_north = init_external_field(trim(Ice%inputdir)//Ice%pmt_north_file,&
-                                               Ice%pmt_file_variable)
-        Ice%id_pmt_north = init_external_field(trim(Ice%inputdir)//Ice%pmt_south_file,&
-                                               Ice%pmt_file_variable)
-     else
-        call get_param(param_file, mod, "PMT_NORTH", Ice%pmt_north, &
-             "The moisture transport constraint at the northern latitude.", &
-         default=0., units="Sv")
-        call get_param(param_file, mod, "PMT_SOUTH", Ice%pmt_south, &
-         "The moisture transport constraint at the southern latitude.", &
-         default=0., units="Sv")
-     endif
-  endif
-
   nCat_dflt = 5 ; if (slab_ice) nCat_dflt = 1
   opm_dflt = 0.0 ; if (redo_fast_update) opm_dflt = 1.0e-40
 #ifdef SYMMETRIC_MEMORY_
@@ -2845,119 +2801,6 @@ subroutine update_ice_atm_deposition_flux( Atmos_boundary, Ice )
   call accumulate_deposition_fluxes(Atmos_boundary, Ice%fCS%FIA, Ice%fCS%G, Ice%fCS%IG)
 
 end subroutine update_ice_atm_deposition_flux
-
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-!> If applying a surface mass balance constraint, most commonly in force ice/ocean
-!! simulations, then do so here.
-subroutine constrain_surface_mass_balance(Ice)
-  type(ice_data_type),       intent(inout) :: Ice
-
-
-  if (.not.associated(Ice%fCS)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS must be associated in constrain_surface_mass_balance.")
-  if (.not.associated(Ice%fCS%G)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS%G must be associated in constrain_surface_mass_balance.")
-  if (.not.associated(Ice%fCS%FIA)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS%FIA must be associated in constrain_surface_mass_balance.")
-
-  G => Ice%fCS%G
-  FIA => Ice%fCS%FIA
-
-  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
-
-  if (CS%constrain_moisture_transport) then
-    if (Ice%read_pmt) then
-       ! read mmt constraint (kg s-1)
-       call time_interp_external(Ice%id_pmt_north,Ice%Time,Ice%pmt_north)
-    endif
-    ! adjust northern hemisphere region mass balance
-    call adjust_top_mass(FIA, G, Ice%pmt_north,Ice%pmt_lat_north)
-    if (Ice%read_pmt) then
-       ! read mmt constraint (kg s-1)
-       call time_interp_external(Ice%id_pmt_south,Ice%Time,Ice%pmt_south)
-    endif
-    ! adjust northern hemisphere region mass balance
-    call adjust_top_mass(FIA, G, Ice%pmt_south,Ice%pmt_lat_south)
-    ! after adjusting PmE at high latitudes to match the prescribed value, make a corresponding adjustment to the
-    ! lower latitudes
-    call adjust_top_mass(FIA, G, Ice%pmt_north+Ice%pmt_south,Ice%pmt_lat_south,Ice%pmt_lat_north)
-  endif
-
-contains
-
-  subroutine adjust_top_mass(FIA, G, pmt,lat1, lat2)
-    type(fast_ice_avg_type), pointer :: FIA => NULL()
-    type(SIS_hor_grid_type), pointer :: G => NULL()
-    real                             :: pmt  !< the moisture constraint for the region (kg s-1)
-    real                             :: lat1 !< the dividing latitude for high-latitude region
-                                           !! or the southern latitude for low-latitude region
-                                           !! if lat2 is present
-    real, optional                   :: lat2
-
-    integer :: i,j,k,isc,iec,jsc,jec
-
-    real, dimension(SZI_(G),SZJ_(G))   :: net_in !< rate of incoming mass at the top of the sea-ice
-                                               !! in units of kg m-2 s-1
-    real, dimension(SZI_(G),SZJ_(G))   :: net_out !< rate of incoming mass at the top of the sea-ice
-    !! in units of kg m-2 s-1
-    real, dimension(SZI_(G),SZJ_(G))   :: work_sum !< temporary work array
-    real, dimension(SZI_(G),SZJ_(G))   :: mask   !< A mask for dividing the surface into high-latitude
-    !! and low-latitude domains for adjustment (non. dim)
-
-    real :: total_mass_in, total_mass_out, area_sum
-    real :: fw_diff, fw_scaling
-    logical :: debug
-
-    debug=.true.
-    net_in(:,:) = 0.0; net_out(:,:) = 0.0; work_sum(:,:) = 0.0; mask(:,:) = 0.0
-    ! calculate FW in (precip) and out (evap) in units of kg s-1 for the northern hemisphere
-    do j=js,je ; do i=is,ie
-      net_in(i,j) = ((FIA%lprec_ocn_top(i,j)   + FIA%fprec_ocn_top(i,j)) ) * &
-           G%areaT(i,j) * G%mask2dT(i,j)
-      net_out(i,j) = FIA%evap_ocn_top(i,j) * G%areaT(i,j) * G%mask2dT(i,j)
-      if (lat1>0. .and. G%geoLatT(i,j)>=lat1) then
-         mask(i,j)=1.0
-      else if (lat1<0. .and. .not.PRESENT(lat2)) then
-         if (G%geoLatT(i,j)<=lat1) mask(i,j)=1.0
-      else if (PRESENT(lat2)) then
-         if (lat1>lat2) call SIS_error(FATAL,'lat1 must be less than lat2 in adjust_top_mass')
-         if (lat1<G%geoLatT(i,j) .and. G%geoLatT(i,j)<lat2) mask(i,j)=1.0
-      endif
-      net_in(i,j) = net_in(i,j)*mask(i,j)
-      net_out(i,j) = net_out(i,j)*mask(i,j)
-      work_sum(i,j) = G%mask2dT(i,j)*G%areaT(i,j)*mask(i,j)
-    enddo; enddo
-    total_mass_in = reproducing_sum(net_in(:,:))   ! positive quantity
-    total_mass_out = reproducing_sum(net_out(:,:)) ! negative quantity
-    area_sum = reproducing_sum(work_sum(:,:))
-    fw_diff = (pmt - (total_mass_in + total_mass_out)) ! difference from constraint (kg s-1)
-    fw_scaling = 1.0
-    if (fw_diff>0 .and. total_mass_in > fw_diff) then
-       ! the total precipitation exceeds the required adjustment
-       fw_scaling =pmt/total_mass_in
-    else if (fw_diff<0 .and. total_mass_out > fw_diff) then ! only apply the scaling adjustment if
-       ! the total evaporation exceeds the required adjustment
-       fw_scaling = pmt/total_mass_out
-    endif
-    if (fw_adj>0.0) then  ! The adjustment will be applied to liquid and frozen precipitation
-       do j=js,je ; do i=is,ie
-         FIA%lprec_ocn_top(i,j) = IOB%lprec_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
-         FIA%fprec_ocn_top(i,j) = IOB%fprec_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
-       enddo; enddo
-    else if (fw_adj<0.0)  ! The adjustment will be applied to evaporation
-       do j=js,je ; do i=is,ie
-         FIA%evap_ocn_top(i,j) = FIA%evap_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
-       enddo; enddo
-    endif
-    if (debug .and. is_root_pe()) then
-       print *,' fw_in= ',fw_in*1.e-9
-       print *,' fw_out= ',fw_out*1.e-9
-       print *,' fw_adj= ',fw_adj*area_sum*1.e-9
-    endif
-
-  end subroutine adjust_top_mass
-end subroutine constrain_surface_mass_balance
-
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -376,6 +376,9 @@ subroutine ice_model_fast_cleanup(Ice)
   call avg_top_quantities(Ice%fCS%FIA, Ice%fCS%Rad, Ice%fCS%IST, &
                           Ice%fCS%G, Ice%fCS%IG)
 
+  ! If applying a surface mass balance constraint, then make the adjustments here
+  call constrain_surface_mass_balance(Ice)
+
   call total_top_quantities(Ice%fCS%FIA, Ice%fCS%TSF, Ice%fCS%IST%part_size, &
                             Ice%fCS%G, Ice%fCS%IG)
 
@@ -1993,6 +1996,47 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
      ((dirs%input_filename(1:1)=='n') .and. (LEN_TRIM(dirs%input_filename)==1))))
 
   nudge_sea_ice = .false. ; call read_param(param_file, "NUDGE_SEA_ICE", nudge_sea_ice)
+
+  call get_param(param_file, mdl, "CONSTRAIN_MOISTURE_TRANSPORT", Ice%constrain_mmt, &
+                 "If true, constrain the meridional moisture transport implied by by \n"// &
+                 "the surface mass fluxes."// &
+                 default=.false.)
+  if (Ice%constrain_mmt) then
+     call get_param(param_file, mdl, "PMT_LATITUDE_NORTH", Ice%pmt_lat_north, &
+       "The northern latitude used to apply the moisture transport constraint.", &
+       default=40., units="degrees")
+     call get_param(param_file, mdl, "PMT_LATITUDE_SOUTH", Ice%pmt_lat_south, &
+       "The southern latitude used to apply the moisture transport constraint.", &
+       default=-40., units="degrees")
+     call get_param(param_file, mdl, "READ_PMT", Ice%read_pmt, &
+       "If true, read time-varying moisture transports from a file.", &
+       default=.false.)
+     if ( Ice%read_pmt) then
+        Ice%pmt_north_file = 'pmt_north.nc'
+        call get_param(param_file, mdl, "PMT_NORTH_FILE", Ice%pmt_north_file, &
+        "A case-sensitive filename for reading the northern hemisphere \n"//&
+        "moisture transport constraint in Sv.",default=Ice%pmt_north_file)
+        Ice%pmt_south_file = 'pmt_south.nc'
+        call get_param(param_file, mdl, "PMT_SOUTH_FILE", Ice%pmt_south_file, &
+        "A case-sensitive filename for reading the southern hemisphere \n"//&
+        "moisture transport constraint in Sv.",default=Ice%pmt_south_file)
+        call get_param(param_file, mdl, "PMT_FILE_VARIABLE", Ice%pmt_file_variable, &
+        "A case-sensitive filename for the file variable containing \n"//&
+        "the moisture transport constraint.",default='poleward_moisture_transport')
+        Ice%id_pmt_north = init_external_field(trim(Ice%inputdir)//Ice%pmt_north_file,&
+                                               Ice%pmt_file_variable)
+        Ice%id_pmt_north = init_external_field(trim(Ice%inputdir)//Ice%pmt_south_file,&
+                                               Ice%pmt_file_variable)
+     else
+        call get_param(param_file, mod, "PMT_NORTH", Ice%pmt_north, &
+             "The moisture transport constraint at the northern latitude.", &
+         default=0., units="Sv")
+        call get_param(param_file, mod, "PMT_SOUTH", Ice%pmt_south, &
+         "The moisture transport constraint at the southern latitude.", &
+         default=0., units="Sv")
+     endif
+  endif
+
   nCat_dflt = 5 ; if (slab_ice) nCat_dflt = 1
   opm_dflt = 0.0 ; if (redo_fast_update) opm_dflt = 1.0e-40
 #ifdef SYMMETRIC_MEMORY_
@@ -2801,6 +2845,119 @@ subroutine update_ice_atm_deposition_flux( Atmos_boundary, Ice )
   call accumulate_deposition_fluxes(Atmos_boundary, Ice%fCS%FIA, Ice%fCS%G, Ice%fCS%IG)
 
 end subroutine update_ice_atm_deposition_flux
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+!> If applying a surface mass balance constraint, most commonly in force ice/ocean
+!! simulations, then do so here.
+subroutine constrain_surface_mass_balance(Ice)
+  type(ice_data_type),       intent(inout) :: Ice
+
+
+  if (.not.associated(Ice%fCS)) call SIS_error(FATAL, &
+      "The pointer to Ice%fCS must be associated in constrain_surface_mass_balance.")
+  if (.not.associated(Ice%fCS%G)) call SIS_error(FATAL, &
+      "The pointer to Ice%fCS%G must be associated in constrain_surface_mass_balance.")
+  if (.not.associated(Ice%fCS%FIA)) call SIS_error(FATAL, &
+      "The pointer to Ice%fCS%FIA must be associated in constrain_surface_mass_balance.")
+
+  G => Ice%fCS%G
+  FIA => Ice%fCS%FIA
+
+  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
+
+  if (CS%constrain_moisture_transport) then
+    if (Ice%read_pmt) then
+       ! read mmt constraint (kg s-1)
+       call time_interp_external(Ice%id_pmt_north,Ice%Time,Ice%pmt_north)
+    endif
+    ! adjust northern hemisphere region mass balance
+    call adjust_top_mass(FIA, G, Ice%pmt_north,Ice%pmt_lat_north)
+    if (Ice%read_pmt) then
+       ! read mmt constraint (kg s-1)
+       call time_interp_external(Ice%id_pmt_south,Ice%Time,Ice%pmt_south)
+    endif
+    ! adjust northern hemisphere region mass balance
+    call adjust_top_mass(FIA, G, Ice%pmt_south,Ice%pmt_lat_south)
+    ! after adjusting PmE at high latitudes to match the prescribed value, make a corresponding adjustment to the
+    ! lower latitudes
+    call adjust_top_mass(FIA, G, Ice%pmt_north+Ice%pmt_south,Ice%pmt_lat_south,Ice%pmt_lat_north)
+  endif
+
+contains
+
+  subroutine adjust_top_mass(FIA, G, pmt,lat1, lat2)
+    type(fast_ice_avg_type), pointer :: FIA => NULL()
+    type(SIS_hor_grid_type), pointer :: G => NULL()
+    real                             :: pmt  !< the moisture constraint for the region (kg s-1)
+    real                             :: lat1 !< the dividing latitude for high-latitude region
+                                           !! or the southern latitude for low-latitude region
+                                           !! if lat2 is present
+    real, optional                   :: lat2
+
+    integer :: i,j,k,isc,iec,jsc,jec
+
+    real, dimension(SZI_(G),SZJ_(G))   :: net_in !< rate of incoming mass at the top of the sea-ice
+                                               !! in units of kg m-2 s-1
+    real, dimension(SZI_(G),SZJ_(G))   :: net_out !< rate of incoming mass at the top of the sea-ice
+    !! in units of kg m-2 s-1
+    real, dimension(SZI_(G),SZJ_(G))   :: work_sum !< temporary work array
+    real, dimension(SZI_(G),SZJ_(G))   :: mask   !< A mask for dividing the surface into high-latitude
+    !! and low-latitude domains for adjustment (non. dim)
+
+    real :: total_mass_in, total_mass_out, area_sum
+    real :: fw_diff, fw_scaling
+    logical :: debug
+
+    debug=.true.
+    net_in(:,:) = 0.0; net_out(:,:) = 0.0; work_sum(:,:) = 0.0; mask(:,:) = 0.0
+    ! calculate FW in (precip) and out (evap) in units of kg s-1 for the northern hemisphere
+    do j=js,je ; do i=is,ie
+      net_in(i,j) = ((FIA%lprec_ocn_top(i,j)   + FIA%fprec_ocn_top(i,j)) ) * &
+           G%areaT(i,j) * G%mask2dT(i,j)
+      net_out(i,j) = FIA%evap_ocn_top(i,j) * G%areaT(i,j) * G%mask2dT(i,j)
+      if (lat1>0. .and. G%geoLatT(i,j)>=lat1) then
+         mask(i,j)=1.0
+      else if (lat1<0. .and. .not.PRESENT(lat2)) then
+         if (G%geoLatT(i,j)<=lat1) mask(i,j)=1.0
+      else if (PRESENT(lat2)) then
+         if (lat1>lat2) call SIS_error(FATAL,'lat1 must be less than lat2 in adjust_top_mass')
+         if (lat1<G%geoLatT(i,j) .and. G%geoLatT(i,j)<lat2) mask(i,j)=1.0
+      endif
+      net_in(i,j) = net_in(i,j)*mask(i,j)
+      net_out(i,j) = net_out(i,j)*mask(i,j)
+      work_sum(i,j) = G%mask2dT(i,j)*G%areaT(i,j)*mask(i,j)
+    enddo; enddo
+    total_mass_in = reproducing_sum(net_in(:,:))   ! positive quantity
+    total_mass_out = reproducing_sum(net_out(:,:)) ! negative quantity
+    area_sum = reproducing_sum(work_sum(:,:))
+    fw_diff = (pmt - (total_mass_in + total_mass_out)) ! difference from constraint (kg s-1)
+    fw_scaling = 1.0
+    if (fw_diff>0 .and. total_mass_in > fw_diff) then
+       ! the total precipitation exceeds the required adjustment
+       fw_scaling =pmt/total_mass_in
+    else if (fw_diff<0 .and. total_mass_out > fw_diff) then ! only apply the scaling adjustment if
+       ! the total evaporation exceeds the required adjustment
+       fw_scaling = pmt/total_mass_out
+    endif
+    if (fw_adj>0.0) then  ! The adjustment will be applied to liquid and frozen precipitation
+       do j=js,je ; do i=is,ie
+         FIA%lprec_ocn_top(i,j) = IOB%lprec_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
+         FIA%fprec_ocn_top(i,j) = IOB%fprec_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
+       enddo; enddo
+    else if (fw_adj<0.0)  ! The adjustment will be applied to evaporation
+       do j=js,je ; do i=is,ie
+         FIA%evap_ocn_top(i,j) = FIA%evap_ocn_top(i,j)*fw_scaling*mask(i,j)*G%mask2dT(i,j)
+       enddo; enddo
+    endif
+    if (debug .and. is_root_pe()) then
+       print *,' fw_in= ',fw_in*1.e-9
+       print *,' fw_out= ',fw_out*1.e-9
+       print *,' fw_adj= ',fw_adj*area_sum*1.e-9
+    endif
+
+  end subroutine adjust_top_mass
+end subroutine constrain_surface_mass_balance
+
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -146,6 +146,37 @@ type ice_data_type !  ice_public_type
   type(SIS_slow_CS), pointer :: sCS => NULL()
   type(restart_file_type), pointer :: Ice_restart => NULL()
   type(restart_file_type), pointer :: Ice_fast_restart => NULL()
+
+  logical :: constrain_pmt! If true, then apply constraints to the meridional
+                          ! moisture transport implied by the surface mass
+                          ! balance at the top of the sea-ice
+  real    :: pmt_lat_north ! If constrain_pmt is True, the northern hemisphere
+                          ! latitude poleward of which the surface mass balance
+                          ! is constrained by the externally specified moisture
+                          ! transport at this latitude.
+  real    :: pmt_lat_south ! If constrain_pmt is True, the southern hemisphere
+                          ! latitude poleward of which the surface mass balance
+                          ! is constrained by the externally specified moisture
+                          ! transport at this latitude.
+  logical :: read_pmt     ! If True, read moisture transport constraint from a
+                          ! file containing time-varying values which will
+                          ! be interpolated to the current model timestep.
+  real    :: pmt_north    ! If read_pmt if False, then use this value for the
+                          ! northern hemisphere constraint.
+  real    :: pmt_south    ! If read_pmt if False, then use this value for the
+                          ! southern hemisphere constraint.
+  character(len=128)  :: pmt_north_file ! If read_pmt is True, then read from
+                          ! this file.
+  character(len=128)  :: pmt_south_file ! If read_pmt is True, then read from
+                          ! this file.
+  character(len=32)   :: pmt_file_variable ! If read_pmt is True, the variable
+                          ! name of the moisture transport constraint contained
+                          ! in the file.
+  integer :: id_pmt_north ! The handle for PMT_NORTH_FILE used for reading and
+                          ! time interpolation to the current model time.
+  integer :: id_pmt_south ! The handle for PMT_SOUTH_FILE used for reading and
+                          ! time interpolation to the current model time.
+
 end type ice_data_type !  ice_public_type
 
 contains

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -146,37 +146,6 @@ type ice_data_type !  ice_public_type
   type(SIS_slow_CS), pointer :: sCS => NULL()
   type(restart_file_type), pointer :: Ice_restart => NULL()
   type(restart_file_type), pointer :: Ice_fast_restart => NULL()
-
-  logical :: constrain_mmt ! If true, then apply constraints to the meridional
-                          ! moisture transport implied by the surface mass
-                          ! balance at the top of the sea-ice
-  real    :: pmt_lat_north ! If constrain_mmt is True, the northern hemisphere
-                          ! latitude poleward of which the surface mass balance
-                          ! is constrained by the externally specified moisture
-                          ! transport at this latitude.
-  real    :: pmt_lat_south ! If constrain_mmt is True, the southern hemisphere
-                          ! latitude poleward of which the surface mass balance
-                          ! is constrained by the externally specified moisture
-                          ! transport at this latitude.
-  logical :: read_pmt     ! If True, read moisture transport constraint from a
-                          ! file containing time-varying values which will
-                          ! be interpolated to the current model timestep.
-  real    :: pmt_north    ! If read_pmt if False, then use this value for the
-                          ! northern hemisphere constraint.
-  real    :: pmt_south    ! If read_pmt if False, then use this value for the
-                          ! southern hemisphere constraint.
-  character(len=128)  :: pmt_north_file ! If read_pmt is True, then read from
-                          ! this file.
-  character(len=128)  :: pmt_south_file ! If read_pmt is True, then read from
-                          ! this file.
-  character(len=32)   :: pmt_file_variable ! If read_pmt is True, the variable
-                          ! name of the moisture transport constraint contained
-                          ! in the file.
-  integer :: id_pmt_north ! The handle for PMT_NORTH_FILE used for reading and
-                          ! time interpolation to the current model time.
-  integer :: id_pmt_south ! The handle for PMT_SOUTH_FILE used for reading and
-                          ! time interpolation to the current model time.
-
 end type ice_data_type !  ice_public_type
 
 contains

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -146,6 +146,37 @@ type ice_data_type !  ice_public_type
   type(SIS_slow_CS), pointer :: sCS => NULL()
   type(restart_file_type), pointer :: Ice_restart => NULL()
   type(restart_file_type), pointer :: Ice_fast_restart => NULL()
+
+  logical :: constrain_mmt ! If true, then apply constraints to the meridional
+                          ! moisture transport implied by the surface mass
+                          ! balance at the top of the sea-ice
+  real    :: pmt_lat_north ! If constrain_mmt is True, the northern hemisphere
+                          ! latitude poleward of which the surface mass balance
+                          ! is constrained by the externally specified moisture
+                          ! transport at this latitude.
+  real    :: pmt_lat_south ! If constrain_mmt is True, the southern hemisphere
+                          ! latitude poleward of which the surface mass balance
+                          ! is constrained by the externally specified moisture
+                          ! transport at this latitude.
+  logical :: read_pmt     ! If True, read moisture transport constraint from a
+                          ! file containing time-varying values which will
+                          ! be interpolated to the current model timestep.
+  real    :: pmt_north    ! If read_pmt if False, then use this value for the
+                          ! northern hemisphere constraint.
+  real    :: pmt_south    ! If read_pmt if False, then use this value for the
+                          ! southern hemisphere constraint.
+  character(len=128)  :: pmt_north_file ! If read_pmt is True, then read from
+                          ! this file.
+  character(len=128)  :: pmt_south_file ! If read_pmt is True, then read from
+                          ! this file.
+  character(len=32)   :: pmt_file_variable ! If read_pmt is True, the variable
+                          ! name of the moisture transport constraint contained
+                          ! in the file.
+  integer :: id_pmt_north ! The handle for PMT_NORTH_FILE used for reading and
+                          ! time interpolation to the current model time.
+  integer :: id_pmt_south ! The handle for PMT_SOUTH_FILE used for reading and
+                          ! time interpolation to the current model time.
+
 end type ice_data_type !  ice_public_type
 
 contains


### PR DESCRIPTION
This PR adds a new feature which introduces a constraint on the atmospheric moisture transport implied by the surface mass balance poleward of specified latitudes in each hemisphere. The spatially integrated downward surface mass flux into  these two regions bounded by the poles is automatically balanced by an upward mass flux in the central region such that the global mass balance is identically zero at the top of the ice.  The constraint is satisfied by scaling the precipitation.  This feature should supersede global adjustments which are currently being done in the ocean model for forced ocean/sea-ice simulations.