### PR TITLE
Fix NaN after a restart when DO_ICE_RESTORE=True

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2475,6 +2475,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       do k=1,CatIce
         sIST%mH_snow(:,:,k) = sIST%mH_snow(:,:,k) * H_rescale_snow * sG%mask2dT(:,:)
         sIST%mH_ice(:,:,k) = sIST%mH_ice(:,:,k) * H_rescale_ice * sG%mask2dT(:,:)
+        sIST%part_size(:,:,k) = sIST%part_size(:,:,k) * sG%mask2dT(:,:)
       enddo
 
       if (sIG%ocean_part_min > 0.0) then ; do j=jsc,jec ; do i=isc,iec

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2477,6 +2477,11 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
         sIST%mH_ice(:,:,k) = sIST%mH_ice(:,:,k) * H_rescale_ice * sG%mask2dT(:,:)
         sIST%part_size(:,:,k) = sIST%part_size(:,:,k) * sG%mask2dT(:,:)
       enddo
+      ! Since we masked out the part_size on land we should set 
+      ! part_size(:,:,0) = 1. on land to satisfy the summation check
+      do j=jsc,jec ; do i=isc,iec
+        if (sG%mask2dT(i,j) < 0.5) sIST%part_size(i,j,0) = 1.      
+      enddo ; enddo
 
       if (sIG%ocean_part_min > 0.0) then ; do j=jsc,jec ; do i=isc,iec
         sIST%part_size(i,j,0) = max(sIST%part_size(i,j,0), sIG%ocean_part_min)


### PR DESCRIPTION
- This update avoids a crash by masking the part_size that is read from restart (as is already done for mH_ice). It also ensures that pasrt_size adds up to 1 on land points to pass the SIS2 checks at initialization.

  The long story is:
- A model with AM4+slab_ocean+SIS2 runs into a restart issue when DO_ICE_RESTORE is set to True
      The model crashes after any restart with "NaN in input field of reproducing_sum(_2d)" pointing
      to a NaN in checksum for freshwater diagnostics in SIS_sum_output.F90 line 511.
      Runing with debugger shows that for some reason IST%part_size=1 for category k=3 at some land points
      on the map where h_ice=0 and model crashes because of division by zero
      (before the model hits the NaN in chesksum issue of the prod mode).
      The bad points of IST%part_size=1 on land (mask=0) are  probably coming from the initCond of this model.

