### PR TITLE
Fix ice restore issues

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2475,6 +2475,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       do k=1,CatIce
         sIST%mH_snow(:,:,k) = sIST%mH_snow(:,:,k) * H_rescale_snow * sG%mask2dT(:,:)
         sIST%mH_ice(:,:,k) = sIST%mH_ice(:,:,k) * H_rescale_ice * sG%mask2dT(:,:)
+        sIST%part_size(:,:,k) = sIST%part_size(:,:,k) * sG%mask2dT(:,:)
       enddo
 
       if (sIG%ocean_part_min > 0.0) then ; do j=jsc,jec ; do i=isc,iec

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2477,6 +2477,11 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
         sIST%mH_ice(:,:,k) = sIST%mH_ice(:,:,k) * H_rescale_ice * sG%mask2dT(:,:)
         sIST%part_size(:,:,k) = sIST%part_size(:,:,k) * sG%mask2dT(:,:)
       enddo
+      ! Since we masked out the part_size on land we should set 
+      ! part_size(:,:,0) = 1. on land to satisfy the summation check
+      do j=jsc,jec ; do i=isc,iec
+        if (sG%mask2dT(i,j) < 0.5) sIST%part_size(i,j,0) = 1.      
+      enddo ; enddo
 
       if (sIG%ocean_part_min > 0.0) then ; do j=jsc,jec ; do i=isc,iec
         sIST%part_size(i,j,0) = max(sIST%part_size(i,j,0), sIG%ocean_part_min)


### PR DESCRIPTION
    Fix the ice restoring issues
    
    - This update addresses two independent issues with the ice restoring mechanism:

      1. SM4p model blows up with too much ice when it tries to do ice restoring to climatology.
         This only happens when SIS1 is replaced by SIS2.
         Upon investigation I found that the algorithm in SIS_slow_thermo.F90 has an update ordering issue.
         At the point when qflx_res_ice is calculated it updates the heat input to ice through bheat.
         But this does not to have an immediate direct effect on the ice thickness
         and its effect is delayed till the next timestep through other fluxes (flux_sh_ocn_top).
         This leads to a runaway increasing of the ice thickness (wrong feedback).
         To get around this we can increase bmelt instead of bheat which will decrease the ice thickness
         subsequently in the same timestep , in the same module through call ice_resize_SIS2().
         Standalone tests shows this has the correct restoring effect on the ice.
    
      2. SM4p has a restart issue, the answers of straight runs and restarted runs do not match (1x8days != 2x4days)
         I tracked this to a bit of code in ice_model.F90 that applies land mask to mH_ice.
         We subsequently tried applying lad mask to part_size (PR !95). It fixed a NaN issue but did not
         fix the restart issue.
         Applying masks to state variables such as mH_ice is leading to the restart issue because these
         state variables are being modified only after restarts and not in straight (no-restart) runs.
         I provided a switch to avoid this masking if the user needs to. With it SM4p reproduces.

