### PR TITLE
+Remove the old Verona sea-ice coupling interfaces

### DIFF
--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -125,7 +125,7 @@ type slow_thermo_CS ; private
   real    :: imb_tol        !< The tolerance for imbalances to be flagged by column_check [nondim].
   logical :: bounds_check   !< If true, check for sensible values of thicknesses temperatures, fluxes, etc.
 
-  integer :: n_calls = 0    !< The number of times update_ice_model_slow_down has been called.
+  integer :: n_calls = 0    !< The number of times slow_thermodynamics has been called.
 
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(SIS_diag_ctrl), pointer :: diag => NULL() !< A structure that is used to


### PR DESCRIPTION
  Eliminated the obsolete interfaces to the sea-ice that were used by the Verona
and older versions of the FMS coupler.  Specifically, the publicly visible
routines update_ice_model_slow_dn and update_ice_model_slow_up were eliminated,
the default value for the Verona_coupler argument was changed from true to false
with a fatal error if it is set to true, and several unused arguments were
eliminated from set_ocean_top_dyn_fluxes.  All answers are bitwise identical,
but one logged variable is eliminated from SIS_parameter_doc.layout.