### PR TITLE
Bug fix for do_ice_limit

### DIFF
--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1220,7 +1220,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
         qflx_lim_ice(i,j) = enth_to_melt * I_enth_units * Idt_slow
         IOF%Enth_Mass_out_ocn(i,j) = IOF%Enth_Mass_out_ocn(i,j) - enth_ice_to_ocn
         if (CS%ice_rel_salin > 0.0) then
-          salt_change(i,j) = salt_change(i,j) + IST%part_size(i,j,k) * salt_to_ice
+          salt_change(i,j) = salt_change(i,j) + salt_to_ice
         endif
       endif
 


### PR DESCRIPTION
salt_to_ice already includes the IST%part_size factor at line 1197.

This extra factor (with an effectively out of bound k=ncat+1) causes the ice limiting simulations (sm4p1) to crash for some processor layouts with:
FATAL from PE   812: NaN in input field of reproducing_sum(_2d).
where the reproducing_sum refers to the ice salinity.

I verified that this mod fixes the issue with sm4p1 and luckily reproduces the answers for the layouts that did work before the fix.