### PR TITLE
Fix for specified ice restart issue #107

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2500,11 +2500,10 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       !However it is not an ice state variable and hence is not in ice restarts.
       !Updating it from specified_ice data avoids restart issues for such models.
       if (specified_ice) then
-        allocate(dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec))
+        allocate(dummy2d(isc:iec,jsc:jec))
         allocate(dummy3d(isc:iec,jsc:jec,2))
         call get_sea_surface(Ice%sCS%Time, Ice%sCS%OSS%SST_C(isc:iec,jsc:jec), &
-                             dummy3d(isc:iec,jsc:jec,:), &
-                             dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec), ice_domain=Ice%slow_domain_NH, ts_in_K=.false. )
+                             dummy3d,dummy2d, ice_domain=Ice%slow_domain_NH, ts_in_K=.false. )
         deallocate(dummy2d,dummy3d)
       endif
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2281,6 +2281,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     restart_path = trim(dirs%restart_input_dir)//trim(restart_file)
 
     if (file_exist(restart_path)) then
+      call callTree_enter("ice_model_init():restore_from_restart_files "//trim(restart_file))
       ! Set values of IG%H_to_kg_m2 that will permit its absence from the restart
       ! file to be detected, and its difference from the value in this run to
       ! be corrected for.
@@ -2494,6 +2495,10 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                             query_initialized(Ice%Ice_fast_restart, 'rough_moist'))
       endif
 
+      !When SPECIFIED_ICE=True variable Ice%sCS%OSS%SST_C is used for the skin temperature
+      !and should be updated during each restart.
+      !However it is not an ice state variable and hence is not in ice restarts.
+      !Updating it from specified_ice data avoids restart issues for such models.
       if (specified_ice) then
         allocate(dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec))
         allocate(dummy3d(isc:iec,jsc:jec,2))
@@ -2502,6 +2507,8 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                              dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec), ice_domain=Ice%slow_domain_NH, ts_in_K=.false. )
         deallocate(dummy2d,dummy3d)
       endif
+
+      call callTree_leave("ice_model_init():restore_from_restart_files")
     else ! no restart file implies initialization with no ice
       sIST%part_size(:,:,:) = 0.0
       sIST%part_size(:,:,0) = 1.0

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1663,7 +1663,9 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                          ! model run and the input files.
 
   real, allocatable, dimension(:,:) :: &
-    h_ice_input, dummy  ! Temporary arrays.
+    h_ice_input, dummy,dummy2d  ! Temporary arrays.
+  real, allocatable, dimension(:,:,:) :: &
+    dummy3d ! Temporary arrays.
   real, allocatable, dimension(:,:) :: &
     str_x, str_y, stress_mag ! Temporary stress arrays
 
@@ -2492,6 +2494,14 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                             query_initialized(Ice%Ice_fast_restart, 'rough_moist'))
       endif
 
+      if (specified_ice) then
+        allocate(dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec))
+        allocate(dummy3d(isc:iec,jsc:jec,2))
+        call get_sea_surface(Ice%sCS%Time, Ice%sCS%OSS%SST_C(isc:iec,jsc:jec), &
+                             dummy3d(isc:iec,jsc:jec,:), &
+                             dummy2d(sG%isc:sG%iec,sG%jsc:sG%jec), ice_domain=Ice%slow_domain_NH, ts_in_K=.false. )
+        deallocate(dummy2d,dummy3d)
+      endif
     else ! no restart file implies initialization with no ice
       sIST%part_size(:,:,:) = 0.0
       sIST%part_size(:,:,0) = 1.0


### PR DESCRIPTION
- Variable Ice%sCS%OSS%SST_C is not an ice state and hence is not in ice_model.res.nc
  However for SPECIFIED_ICE=True it should be updated after restart, otherwise the model
  would have a restart issue #107 
  In specified ice this variable is read from data_table every time step. So that is also
  the easiest way to update it after a restart.
- This update resolves issue #107 .

- This update also addresses issue #101 by adding some indication 
  that SIS2 is being restored from restart files.
  Currently with input_filename being 'n' or 'r'  having no effect, there is no
  indication in stdout whether restart files are being read or not.
  This would make it a little easier to debug restart issues.
