### PR TITLE
SIS2: Dimensional consistency testing for time and lengths

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -368,7 +368,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   if (id_geo_lat>0) call post_data(id_geo_lat, G%geoLatT, diag, is_static=.true.)
   if (id_cell_area>0) then
     I_area_Earth = 1.0 / (16.0*atan(1.0)*G%Rad_Earth**2)
-!$OMP parallel do default(none) shared(isc,iec,jsc,jec,G,I_area_Earth,tmp_diag)
+    !$OMP parallel do default(shared)
     do j=jsc,jec ; do i=isc,iec
       tmp_diag(i,j) = (US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)) * I_area_Earth
     enddo ; enddo

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -26,6 +26,7 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MO
 use MOM_file_parser,   only : param_file_type
 use MOM_hor_index,     only : hor_index_type
 use MOM_time_manager,  only : time_type, time_type_to_real
+use MOM_unit_scaling,  only : unit_scale_type
 use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_sum_output, only : SIS_sum_out_CS
@@ -74,6 +75,7 @@ type SIS_fast_CS
                             !! shortwave radiation.
 
   type(SIS_hor_grid_type), pointer :: G => NULL() !< A structure containing metrics and grid info.
+  type(unit_scale_type), pointer :: US => NULL()  !< A structure containing various unit conversion factors.
   type(ice_grid_type),  pointer :: IG => NULL() !< A structure containing sea-ice specific grid info.
   type(simple_OSS_type), pointer :: sOSS => NULL() !< A structure containing the arrays
                             !! that describe the ocean's surface state, as it is revealed
@@ -148,6 +150,7 @@ type SIS_slow_CS
   type(SIS_diag_ctrl) :: diag !< A structure that regulates diagnostics.
 
   type(SIS_hor_grid_type), pointer :: G => NULL() !< A structure containing metrics and grid info.
+  type(unit_scale_type), pointer :: US => NULL()  !< A structure containing various unit conversion factors.
   type(ice_grid_type),  pointer :: IG => NULL() !< A structure containing sea-ice specific grid info.
   type(ocean_sfc_state_type), pointer :: OSS => NULL() !< A structure containing the arrays
                             !! that describe the ocean's surface state, as it is revealed
@@ -175,7 +178,7 @@ contains
 
 !> ice_diagnostics_init does the registration for a variety of sea-ice model
 !! diagnostics and saves several static diagnotic fields.
-subroutine ice_diagnostics_init(IOF, OSS, FIA, G, IG, diag, Time, Cgrid)
+subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   type(ice_ocean_flux_type),  intent(inout) :: IOF !< A structure containing fluxes from the ice to
                                                    !! the ocean that are calculated by the ice model.
   type(ocean_sfc_state_type), intent(inout) :: OSS !< A structure containing the arrays that describe
@@ -183,6 +186,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, IG, diag, Time, Cgrid)
   type(fast_ice_avg_type),    intent(inout) :: FIA !< A type containing averages of fields
                                                    !! (mostly fluxes) over the fast updates
   type(SIS_hor_grid_type),    intent(inout) :: G   !< The horizontal grid type
+  type(unit_scale_type),      intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),        intent(in)    :: IG  !< The sea-ice specific grid type
   type(SIS_diag_ctrl),        intent(in)    :: diag !< A structure that is used to regulate diagnostic output
   type(time_type),            intent(inout) :: Time !< The sea-ice model's clock,
@@ -320,18 +324,18 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, IG, diag, Time, Cgrid)
 
   if (Cgrid_dyn) then
     OSS%id_uo     = register_SIS_diag_field('ice_model', 'UO', diag%axesCu1, Time, &
-               'surface current - x component', 'm/s', missing_value=missing, &
-               interp_method='none')
+               'surface current - x component', 'm/s', conversion=US%L_T_to_m_s, &
+               missing_value=missing, interp_method='none')
     OSS%id_vo     = register_SIS_diag_field('ice_model', 'VO', diag%axesCv1, Time, &
-               'surface current - y component', 'm/s', missing_value=missing, &
-               interp_method='none')
+               'surface current - y component', 'm/s', conversion=US%L_T_to_m_s, &
+               missing_value=missing, interp_method='none')
   else
     OSS%id_uo     = register_SIS_diag_field('ice_model', 'UO', diag%axesB1, Time, &
-               'surface current - x component', 'm/s', missing_value=missing, &
-               interp_method='none')
+               'surface current - x component', 'm/s', conversion=US%L_T_to_m_s, &
+               missing_value=missing, interp_method='none')
     OSS%id_vo     = register_SIS_diag_field('ice_model', 'VO', diag%axesB1, Time, &
-               'surface current - y component', 'm/s', missing_value=missing, &
-               interp_method='none')
+               'surface current - y component', 'm/s', conversion=US%L_T_to_m_s, &
+               missing_value=missing, interp_method='none')
   endif
 
   OSS%id_frazil   = register_SIS_diag_field('ice_model', 'FRAZIL', diag%axesT1, Time, &
@@ -366,7 +370,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, IG, diag, Time, Cgrid)
     I_area_Earth = 1.0 / (16.0*atan(1.0)*G%Rad_Earth**2)
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,G,I_area_Earth,tmp_diag)
     do j=jsc,jec ; do i=isc,iec
-      tmp_diag(i,j) = (G%areaT(i,j) * G%mask2dT(i,j)) * I_area_Earth
+      tmp_diag(i,j) = (US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)) * I_area_Earth
     enddo ; enddo
     call post_data(id_cell_area, tmp_diag, diag, is_static=.true.)
   endif

--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -554,7 +554,7 @@ end subroutine  check_redundant_vT2d
 ! =====================================================================
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),           intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
@@ -562,12 +562,13 @@ subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                 optional, intent(in)    :: scalars !< If true this is a pair of
                                                               !! scalars that are being checked.
+  real,                    optional, intent(in)    :: scale  !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -580,7 +581,7 @@ subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars)
 end subroutine uvchksum_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars, scale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),         intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
@@ -588,12 +589,13 @@ subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,               optional, intent(in)    :: scalars !< If true this is a pair of
                                                             !! scalars that are being checked.
+  real,                  optional, intent(in)    :: scale  !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -606,35 +608,37 @@ subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars)
 end subroutine uvchksum_2d
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine uvchksum_3d_dG(mesg, u_comp, v_comp, G, halos)
+subroutine uvchksum_3d_dG(mesg, u_comp, v_comp, G, halos, scale)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(dyn_horgrid_type),            intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
   real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
+  real,                    optional, intent(in)    :: scale  !< A scaling factor for these arrays.
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
 
 end subroutine uvchksum_3d_dG
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine uvchksum_2d_dG(mesg, u_comp, v_comp, G, halos)
+subroutine uvchksum_2d_dG(mesg, u_comp, v_comp, G, halos, scale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(dyn_horgrid_type),          intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
   real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
+  real,                  optional, intent(in)    :: scale  !< A scaling factor for these arrays.
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
 
 end subroutine uvchksum_2d_dG
 
 !> This subroutine does a checksum and redundant point check on a 3d B-grid vector.
-subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
   character(len=*),                   intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),            intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: u_comp !< The u-component of the vector
@@ -642,12 +646,13 @@ subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                  optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                  optional, intent(in)    :: scalars !< If true this is a pair of
                                                                !! scalars that are being checked.
+  real,                     optional, intent(in)    :: scale  !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -660,7 +665,7 @@ subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
 end subroutine Bchksum_pair_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d B-grid vector.
-subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
+subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, scale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector
@@ -670,12 +675,13 @@ subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
                                                              !! scalars that are being checked.
   logical,                optional, intent(in)    :: symmetric !< If true, do the checksums on the
                                                                !! full symmetric computational domain.
+  real,                   optional, intent(in)    :: scale   !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, symmetric=symmetric, haloshift=halos)
+    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, symmetric=symmetric, haloshift=halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -688,7 +694,7 @@ subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric)
 end subroutine Bchksum_pair_2d
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%isd:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
@@ -696,12 +702,13 @@ subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                              !! scalars that are being checked.
+  real,                   optional, intent(in)    :: scale   !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
@@ -714,7 +721,7 @@ subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars)
 end subroutine hchksum_pair_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine hchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars)
+subroutine hchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, scale)
   character(len=*),               intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),        intent(inout) :: G      !< The ocean's grid structure
   real, dimension(G%isd:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
@@ -722,12 +729,13 @@ subroutine hchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars)
   integer,              optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,              optional, intent(in)    :: scalars !< If true this is a pair of
                                                            !! scalars that are being checked.
+  real,                  optional, intent(in)   :: scale   !< A scaling factor for these arrays.
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos)
+    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
   endif
   if (debug_redundant) then
     if (are_scalars) then

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -673,7 +673,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, &
 
   m_neglect = H_subroundoff*CS%Rho_ice
   m_neglect2 = m_neglect**2 ; m_neglect4 = m_neglect**4
-!$OMP parallel default(none) shared(isc,iec,jsc,jec,G,CS,dt_slow,ui_min_trunc,u_IC,ui,   &
+!$OMP parallel default(none) shared(isc,iec,jsc,jec,G,US,CS,dt_slow,ui_min_trunc,u_IC,ui,   &
 !$OMP                               ui_max_trunc,vi_min_trunc,vi_max_trunc,v_IC,vi,mice, &
 !$OMP                               mis,ci,dt,Tdamp,I_2EC,ci_proj,pres_mice,       &
 !$OMP                               dx2B,dy2B,dx_dyB,dy_dxB,dx2T,dy2T,dx_dyT,dy_dxT,     &

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -658,7 +658,7 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
   endif
 
   if (CS%debug_fast) &
-    call IST_chksum("Start do_update_ice_model_fast", IST, G, IG)
+    call IST_chksum("Start do_update_ice_model_fast", IST, G, G%US, IG)
 
   !$OMP parallel do default(shared) private(i2,j2,k2)
   do j=jsc,jec
@@ -826,7 +826,7 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
                           sh_T0, evap_T0, lw_T0, dshdt, devapdt, dlwdt, G, IG )
 
   if (CS%debug_fast) &
-    call IST_chksum("End do_update_ice_model_fast", IST, G, IG)
+    call IST_chksum("End do_update_ice_model_fast", IST, G, G%US, IG)
 
   if (CS%bounds_check) &
     call IST_bounds_check(IST, G, IG, "End of update_ice_fast", Rad=Rad) !, OSS=sOSS)
@@ -936,7 +936,7 @@ subroutine redo_update_ice_model_fast(IST, sOSS, Rad, FIA, TSF, optics_CSp, &
   T_bright = bright_ice_temp(optics_CSp, IST%ITV)
 
   if (CS%debug_slow) then
-    call IST_chksum("Start redo_update_ice_model_fast", IST, G, IG)
+    call IST_chksum("Start redo_update_ice_model_fast", IST, G, G%US, IG)
   endif
 
   call get_SIS2_thermo_coefs(IST%ITV, ice_salinity=S_col, enthalpy_units=enth_units, &
@@ -1188,7 +1188,7 @@ subroutine redo_update_ice_model_fast(IST, sOSS, Rad, FIA, TSF, optics_CSp, &
   endif ; enddo
 
   if (CS%debug_slow) &
-    call IST_chksum("End redo_update_ice_model_fast", IST, G, IG)
+    call IST_chksum("End redo_update_ice_model_fast", IST, G, G%US, IG)
 
   if (CS%bounds_check) &
     call IST_bounds_check(IST, G, IG, "End of redo_update_ice_fast", Rad=Rad) !, OSS=sOSS)

--- a/src/SIS_hor_grid.F90
+++ b/src/SIS_hor_grid.F90
@@ -16,6 +16,7 @@ use MOM_domains, only : MOM_domain_type, get_domain_extent, compute_block_extent
 use MOM_domains, only : MOM_domains_init, clone_MOM_domain
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
+use MOM_unit_scaling, only : unit_scale_type
 
 implicit none ; private
 
@@ -75,12 +76,12 @@ type, public :: SIS_hor_grid_type
     mask2dT, &   !< 0 for land points and 1 for ocean points on the h-grid [nondim].
     geoLatT, &   !< The geographic latitude at q points in degrees of latitude or m.
     geoLonT, &   !< The geographic longitude at q points in degrees of longitude or m.
-    dxT, &       !< dxT is delta x at h points [m].
-    IdxT, &      !< 1/dxT [m-1].
-    dyT, &       !< dyT is delta y at h points [m], and IdyT is 1/dyT [m-1].
-    IdyT, &      !< dyT is delta y at h points [m], and IdyT is 1/dyT [m-1].
-    areaT, &     !< The area of an h-cell [m2].
-    IareaT       !< 1/areaT [m-2].
+    dxT, &       !< dxT is delta x at h points [L ~> m].
+    IdxT, &      !< 1/dxT [L-1 ~> m-1].
+    dyT, &       !< dyT is delta y at h points [L ~> m].
+    IdyT, &      !< IdyT is 1/dyT [L-1 ~> m-1].
+    areaT, &     !< The area of an h-cell [L2 ~> m2].
+    IareaT       !< 1/areaT [L-2 ~> m-2].
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: sin_rot
                  !< The sine of the angular rotation between the local model grid northward
                  !! and the true northward directions.
@@ -92,36 +93,36 @@ type, public :: SIS_hor_grid_type
     mask2dCu, &  !< 0 for boundary points and 1 for ocean points on the u grid [nondim].
     geoLatCu, &  !< The geographic latitude at u points in degrees of latitude or m.
     geoLonCu, &  !< The geographic longitude at u points in degrees of longitude or m.
-    dxCu, &      !< dxCu is delta x at u points [m].
-    IdxCu, &     !< 1/dxCu [m-1].
-    dyCu, &      !< dyCu is delta y at u points [m].
-    IdyCu, &     !< 1/dyCu [m-1].
-    dy_Cu, &     !< The unblocked lengths of the u-faces of the h-cell in m.
-    IareaCu, &   !< The masked inverse areas of u-grid cells [m2].
-    areaCu       !< The areas of the u-grid cells [m2].
+    dxCu, &      !< dxCu is delta x at u points [L ~> m].
+    IdxCu, &     !< 1/dxCu [L-1 ~> m-1].
+    dyCu, &      !< dyCu is delta y at u points [L ~> m].
+    IdyCu, &     !< 1/dyCu [L-1 ~> m-1].
+    dy_Cu, &     !< The unblocked lengths of the u-faces of the h-cell [L ~> m].
+    IareaCu, &   !< The masked inverse areas of u-grid cells [L-2 ~> m-2].
+    areaCu       !< The areas of the u-grid cells [L2 ~> m2].
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_) :: &
     mask2dCv, &  !< 0 for boundary points and 1 for ocean points on the v grid [nondim].
     geoLatCv, &  !< The geographic latitude at v points in degrees of latitude or m.
     geoLonCv, &  !<  The geographic longitude at v points in degrees of longitude or m.
-    dxCv, &      !< dxCv is delta x at v points [m].
-    IdxCv, &     !< 1/dxCv [m-1].
-    dyCv, &      !< dyCv is delta y at v points [m].
-    IdyCv, &     !< 1/dyCv [m-1].
-    dx_Cv, &     !< The unblocked lengths of the v-faces of the h-cell in m.
-    IareaCv, &   !< The masked inverse areas of v-grid cells [m2].
-    areaCv       !< The areas of the v-grid cells [m2].
+    dxCv, &      !< dxCv is delta x at v points [L ~> m].
+    IdxCv, &     !< 1/dxCv [L-1 ~> m-1].
+    dyCv, &      !< dyCv is delta y at v points [L ~> m].
+    IdyCv, &     !< 1/dyCv [L-1 ~> m-1].
+    dx_Cv, &     !< The unblocked lengths of the v-faces of the h-cell [L ~> m].
+    IareaCv, &   !< The masked inverse areas of v-grid cells [L-2 ~> m-2].
+    areaCv       !< The areas of the v-grid cells [L2 ~> m2].
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
     mask2dBu, &  !< 0 for boundary points and 1 for ocean points on the q grid [nondim].
     geoLatBu, &  !< The geographic latitude at q points in degrees of latitude or m.
     geoLonBu, &  !< The geographic longitude at q points in degrees of longitude or m.
-    dxBu, &      !< dxBu is delta x at q points [m].
-    IdxBu, &     !< 1/dxBu [m-1].
-    dyBu, &      !< dyBu is delta y at q points [m].
-    IdyBu, &     !< 1/dyBu [m-1].
-    areaBu, &    !< areaBu is the area of a q-cell [m2]
-    IareaBu      !< IareaBu = 1/areaBu [m-2].
+    dxBu, &      !< dxBu is delta x at q points [L ~> m].
+    IdxBu, &     !< 1/dxBu [L-1 ~> m-1].
+    dyBu, &      !< dyBu is delta y at q points [L ~> m].
+    IdyBu, &     !< 1/dyBu [L-1 ~> m-1].
+    areaBu, &    !< areaBu is the area of a q-cell [L2 ~> m2]
+    IareaBu      !< IareaBu = 1/areaBu [L-2 ~> m-2].
 
   real, pointer, dimension(:) :: gridLatT => NULL()
         !< The latitude of T points for the purpose of labeling the output axes.
@@ -141,13 +142,15 @@ type, public :: SIS_hor_grid_type
     ! Except on a Cartesian grid, these are usually  some variant of "degrees".
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    bathyT        !< Ocean bottom depth at tracer points [m].
+    bathyT        !< Ocean bottom depth at tracer points [Z ~> m].
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
-    CoriolisBu    !< The Coriolis parameter at corner points [s-1].
+    CoriolisBu    !< The Coriolis parameter at corner points [T-1 ~> s-1].
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    df_dx, &      !< Derivative d/dx f (Coriolis parameter) at h-points [s-1 m-1].
-    df_dy         !< Derivative d/dy f (Coriolis parameter) at h-points [s-1 m-1].
+    df_dx, &      !< Derivative d/dx f (Coriolis parameter) at h-points [T-1 L-1 ~> s-1 m-1].
+    df_dy         !< Derivative d/dy f (Coriolis parameter) at h-points [T-1 L-1 ~> s-1 m-1].
   real :: g_Earth !<   The gravitational acceleration [m s-2].
+
+  type(unit_scale_type), pointer :: US => NULL() !< A dimensional unit scaling type
 
   ! These variables are for block structures.
   integer :: nblocks  !< The number of sub-PE blocks on this PE

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1220,7 +1220,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, IG)
         qflx_lim_ice(i,j) = enth_to_melt * I_enth_units * Idt_slow
         IOF%Enth_Mass_out_ocn(i,j) = IOF%Enth_Mass_out_ocn(i,j) - enth_ice_to_ocn
         if (CS%ice_rel_salin > 0.0) then
-          salt_change(i,j) = salt_change(i,j) + IST%part_size(i,j,k) * salt_to_ice
+          salt_change(i,j) = salt_change(i,j) + salt_to_ice
         endif
       endif
 

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -33,6 +33,7 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MO
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_hor_index, only : hor_index_type
+use MOM_unit_scaling,   only : unit_scale_type
 use MOM_EOS, only : EOS_type, calculate_density_derivs
 
 use coupler_types_mod, only : coupler_type_spawn, coupler_type_initialized
@@ -303,7 +304,7 @@ end subroutine post_flux_diagnostics
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> slow_thermodynamics takes care of slow ice thermodynamics and mass changes
-subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, IG)
+subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, US, IG)
 
   type(ice_state_type),       intent(inout) :: IST !< A type describing the state of the sea ice
   real,                       intent(in)    :: dt_slow !< The thermodynamic step [s].
@@ -318,6 +319,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, IG)
   type(ice_ocean_flux_type),  intent(inout) :: IOF !< A structure containing fluxes from the ice to
                                                    !! the ocean that are calculated by the ice model.
   type(SIS_hor_grid_type),    intent(inout) :: G   !< The horizontal grid type
+  type(unit_scale_type),      intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),        intent(inout) :: IG  !< The sea-ice specific grid type
 
   ! Local variables
@@ -344,7 +346,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, IG)
   CS%n_calls = CS%n_calls + 1
 
   if (CS%debug) then
-    call IST_chksum("Start update_ice_model_slow", IST, G, IG)
+    call IST_chksum("Start update_ice_model_slow", IST, G, US, IG)
   endif
 
   if (CS%bounds_check) &
@@ -363,7 +365,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, IG)
   call mpp_clock_begin(iceClock7)
   call accumulate_input_1(IST, FIA, OSS, dt_slow, G, IG, CS%sum_output_CSp)
   if (CS%column_check) &
-    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp, &
+    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, US, IG, CS%sum_output_CSp, &
                               message="    SIS_slow_thermo", check_column=.true.)
   call mpp_clock_end(iceClock7)
 
@@ -461,19 +463,19 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, IG)
   call SIS_call_tracer_column_fns(dt_slow, G, IG, CS%tracer_flow_CSp, IST%mH_ice, mi_old)
   call disable_SIS_averaging(CS%diag)
 
-  call accumulate_bottom_input(IST, OSS, FIA, IOF, dt_slow, G, IG, CS%sum_output_CSp)
+  call accumulate_bottom_input(IST, OSS, FIA, IOF, dt_slow, G, US, IG, CS%sum_output_CSp)
 
   ! This needs to go after accumulate_bottom_input.
   if (associated(XSF)) call add_excess_fluxes(IOF, XSF, G)
 
   if (CS%column_check) &
-    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp, &
+    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, US, IG, CS%sum_output_CSp, &
                               message="      Post_thermo A", check_column=.true.)
   call adjust_ice_categories(IST%mH_ice, IST%mH_snow, IST%mH_pond, IST%part_size, &
                              IST%TrReg, G, IG, CS%SIS_transport_CSp) !Niki: add ridging?
 
   if (CS%column_check) &
-    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, IG, CS%sum_output_CSp, &
+    call write_ice_statistics(IST, CS%Time, CS%n_calls, G, US, IG, CS%sum_output_CSp, &
                               message="      Post_thermo B ", check_column=.true.)
 
 end subroutine slow_thermodynamics

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -24,6 +24,7 @@ use MOM_io, only : APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_string_functions, only : slasher
 use MOM_time_manager, only : time_type, get_time, operator(>), operator(-)
 use MOM_time_manager, only : get_date, get_calendar_type, NO_CALENDAR
+use MOM_unit_scaling, only : unit_scale_type
 use SIS_types, only : ice_state_type, ice_ocean_flux_type, fast_ice_avg_type
 use SIS_types, only : ocean_sfc_state_type
 use SIS_hor_grid, only : SIS_hor_grid_type
@@ -80,7 +81,7 @@ type, public :: SIS_sum_out_CS ; private
   type(EFP_type) :: heat_prev_EFP !< An extended fixed point version of heat_prev
   type(EFP_type) :: salt_prev_EFP !< An extended fixed point version of salt_prev
   type(EFP_type) :: mass_prev_EFP !< An extended fixed point version of mass_prev
-  real    :: dt                 !< The baroclinic dynamics time step [s].
+  real    :: dt                 !< The baroclinic dynamics time step [T ~> s].
   real    :: timeunit           !<   The length of the units for the time axis [s].
   type(time_type) :: Start_time !< The start time of the simulation.
                                 !< Start_time is set in SIS_initialization.F90
@@ -109,11 +110,12 @@ end type SIS_sum_out_CS
 contains
 
 !> Initialize the SIS_sum_output control structure, allocate memory and store runtime parameters.
-subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, CS, ntrunc)
+subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, CS, ntrunc)
   type(SIS_hor_grid_type),  intent(in)    :: G      !< The horizontal grid type
   type(param_file_type),    intent(in)    :: param_file !< A structure to parse for run-time parameters
   character(len=*),         intent(in)    :: directory  !<  The directory where the statistics file goes
   type(time_type),          intent(in)    :: Input_start_time !< The start time of the simulation
+  type(unit_scale_type),    intent(in)    :: US     !< A structure with unit conversion factors
   type(SIS_sum_out_CS),     pointer       :: CS     !< A pointer that is set to point to the control
                                                     !! structure for this module
   integer, target, optional,intent(inout) :: ntrunc !< The integer that stores the number of times
@@ -147,7 +149,7 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, CS, n
   call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt, &
                  "The time step used for the slow ice dynamics, including "//&
                  "stepping the continuity equation and interactions between "//&
-                 "the ice mass field and velocities.", units="s", &
+                 "the ice mass field and velocities.", units="s", scale=US%s_to_T, &
                  default=-1.0, do_not_log=.true.)
   call get_param(param_file, mdl, "MAXTRUNC", CS%maxtrunc, &
                  "The run will be stopped, and the day set to a very \n"//&
@@ -205,11 +207,12 @@ end subroutine SIS_sum_output_end
 
 !> Write out the sea ice statistics of the total sea-ice mass, heat and salt by
 !! hemisphere and other globally integrated quantities.
-subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, tracer_CSp)
+subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_column, tracer_CSp)
   type(ice_state_type),       intent(inout) :: IST !< A type describing the state of the sea ice
   type(time_type),            intent(inout) :: day !< The current model time.
   integer,                    intent(in)    :: n   !< The time step number of the current execution
   type(SIS_hor_grid_type),    intent(inout) :: G   !< The horizontal grid type
+  type(unit_scale_type),      intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),        intent(inout) :: IG  !< The sea-ice specific grid type
   type(SIS_sum_out_CS),       pointer       :: CS  !< The control structure returned by a previous
                                                    !! call to SIS_sum_output_init
@@ -286,7 +289,7 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, t
 
   real :: CFL_trans    ! A transport-based definition of the CFL number [nondim].
   real :: CFL_u, CFL_v ! Simple CFL numbers for u- and v- advection [nondim].
-  real :: dt_CFL       ! The timestep for calculating the CFL number [s].
+  real :: dt_CFL       ! The timestep for calculating the CFL number [T ~> s].
   real :: max_CFL      ! The maximum of the CFL numbers [nondim].
   real, dimension(SZI_(G),SZJ_(G)) :: &
     Temp_int, Salt_int
@@ -428,7 +431,7 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, t
   do j=js,je ; do i=is,ie
     hem = 1 ; if (G%geolatT(i,j) < 0.0) hem = 2
     do k=1,ncat ; if (G%mask2dT(i,j) * IST%part_size(i,j,k) > 0.0) then
-      area_pt = G%areaT(i,j) * G%mask2dT(i,j) * IST%part_size(i,j,k)
+      area_pt = US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j) * IST%part_size(i,j,k)
 
       ice_area(i,j,hem) = ice_area(i,j,hem) + area_pt
       col_mass(i,j,hem) = col_mass(i,j,hem) + area_pt * IG%H_to_kg_m2 * &
@@ -446,11 +449,11 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, t
       enddo
     endif ; enddo
     if (allocated(IST%snow_to_ocn)) then ; if (IST%snow_to_ocn(i,j) > 0.0) then
-      area_pt = G%areaT(i,j) * G%mask2dT(i,j)
+      area_pt = US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)
       col_mass(i,j,hem) = col_mass(i,j,hem) + area_pt * IST%snow_to_ocn(i,j)
       col_heat(i,j,hem) = col_heat(i,j,hem) + area_pt * (IST%snow_to_ocn(i,j) * IST%enth_snow_to_ocn(i,j))
     endif ; endif
-    if (ice_area(i,j,hem) > 0.1*G%AreaT(i,j)) ice_extent(i,j,hem) = G%AreaT(i,j)
+    if (ice_area(i,j,hem) > 0.1*US%L_to_m**2*G%areaT(i,j)) ice_extent(i,j,hem) = US%L_to_m**2*G%areaT(i,j)
 
   enddo ; enddo
   Area = reproducing_sum(ice_area, sums=Area_NS)
@@ -507,7 +510,7 @@ subroutine write_ice_statistics(IST, day, n, G, IG, CS, message, check_column, t
     CS%heat_prev_EFP = heat_EFP ; CS%net_heat_in_EFP = real_to_EFP(0.0)
   else
     do j=js,je ; do i=is,ie
-      area_h = G%areaT(i,j) * G%mask2dT(i,j)
+      area_h = US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)
       CS%water_in_col(i,j) = area_h * CS%water_in_col(i,j)
       CS%heat_in_col(i,j) = area_h * CS%heat_in_col(i,j)
       CS%salt_in_col(i,j) = area_h * CS%salt_in_col(i,j)
@@ -714,7 +717,7 @@ end subroutine write_ice_statistics
 
 !> Accumulate the net input of fresh water and heat through the bottom of the
 !! sea-ice for conservation checks.
-subroutine accumulate_bottom_input(IST, OSS, FIA, IOF, dt, G, IG, CS)
+subroutine accumulate_bottom_input(IST, OSS, FIA, IOF, dt, G, US, IG, CS)
   type(SIS_hor_grid_type),    intent(in) :: G   !< The horizontal grid type
   type(ice_grid_type),        intent(in) :: IG  !< The sea-ice specific grid type
   type(ice_state_type),       intent(in) :: IST !< A type describing the state of the sea ice
@@ -725,6 +728,7 @@ subroutine accumulate_bottom_input(IST, OSS, FIA, IOF, dt, G, IG, CS)
   type(ice_ocean_flux_type),  intent(in) :: IOF !< A structure containing fluxes from the ice to
                                                 !! the ocean that are calculated by the ice model.
   real,                       intent(in) :: dt  !< The amount of time over which to average.
+  type(unit_scale_type),      intent(in) :: US  !< A structure with unit conversion factors
   type(SIS_sum_out_CS),       pointer    :: CS  !< The control structure returned by a previous call
                                                 !! to SIS_sum_output_init.
 
@@ -738,7 +742,7 @@ subroutine accumulate_bottom_input(IST, OSS, FIA, IOF, dt, G, IG, CS)
 
   call get_SIS2_thermo_coefs(IST%ITV, enthalpy_units=enth_units, Latent_fusion=LI)
 
-  if (CS%dt < 0.0) CS%dt = dt
+  if (CS%dt < 0.0) CS%dt = US%s_to_T*dt
 
   do j=jsc,jec ; do i=isc,iec
     CS%water_in_col(i,j) = CS%water_in_col(i,j) - dt * &

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -298,9 +298,7 @@ subroutine advect_tracer(Tr, h_prev, h_end, uhtr, vhtr, ntr, dt, G, US, IG, CS) 
     ! Set the range of valid points after this iteration.
     isv = isv + stensil ; iev = iev - stensil
     jsv = jsv + stensil ; jev = jev - stensil
-!$OMP parallel do default(none) shared(ncat,domore_k,x_first,Tr,hprev,uhr,uh_neglect, &
-!$OMP                                  domore_u,ntr,nL_max,Idt,isv,iev,jsv,jev,       &
-!$OMP                                  stensil,G,CS,vhr,vh_neglect,domore_v,IG)
+    !$OMP parallel do default(shared)
     do k=1,ncat ; if (domore_k(k) > 0) then
 !    To ensure positive definiteness of the thickness at each iteration, the
 !  mass fluxes out of each layer are checked each step, and limited to keep
@@ -547,9 +545,7 @@ subroutine advect_scalar(scalar, h_prev, h_end, uhtr, vhtr, dt, G, US, IG, CS) !
       ! Set the range of valid points after this iteration.
       isv = isv + stensil ; iev = iev - stensil
       jsv = jsv + stensil ; jev = jev - stensil
-!$OMP parallel do default(none) shared(ncat,isv,iev,jsv,jev,x_first,domore_k,scalar, &
-!$OMP                                  hprev,uhr,uh_neglect,domore_u,Idt,stensil,G,  &
-!$OMP                                  CS,vhr,vh_neglect,domore_v,IG)
+      !$OMP parallel do default(shared)
       do k=1,ncat ; if (domore_k(k) > 0) then
   !    To ensure positive definiteness of the thickness at each iteration, the
   !  mass fluxes out of each layer are checked each step, and limited to keep

--- a/src/SIS_tracer_registry.F90
+++ b/src/SIS_tracer_registry.F90
@@ -50,20 +50,20 @@ type, public :: SIS_tracer_type
   real :: massless_val = 0.0 !< A value to use in massless layers.
   real, dimension(:,:), &
     pointer :: ad2d_x => NULL() !< The x-direction advective flux summed vertically and across
-                                !! ice category [Conc kg s-1].
+                                !! ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:), &
     pointer :: ad2d_y => NULL() !< The y-direction advective flux summed vertically and across
-                                !! ice category [Conc kg s-1].
+                                !! ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
-    pointer :: ad3d_x => NULL() !< The vertically summed x-direction advective flux [Conc kg s-1].
+    pointer :: ad3d_x => NULL() !< The vertically summed x-direction advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
-    pointer :: ad3d_y => NULL() !< The vertically summed y-direction advective flux [Conc kg s-1].
+    pointer :: ad3d_y => NULL() !< The vertically summed y-direction advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
     pointer :: ad4d_x => NULL() !< The x-direction advective flux by ice category and layer in
-                                !! units of CONC m3 s-1.
+                                !! units of [Conc H L2 T-1 ~> CONC kg s-1].
   real, dimension(:,:,:,:), &
     pointer :: ad4d_y => NULL() !< The y-direction advective flux by ice category and layer in
-                                !! units of CONC m3 s-1.
+                                !! units of [Conc H L2 T-1 ~> CONC kg s-1].
 !  real, dimension(:,:), &
 !    pointer :: snow_flux_tr => NULL() !< Concentration of the tracer in snow (for salinity = 0.0)
   real, dimension(:,:,:), &
@@ -120,22 +120,22 @@ subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_t
   real,          optional, intent(in) :: massless_val !< The value to use to fill in massless categories.
   real, dimension(:,:), &
                  optional, pointer    :: ad_2d_x !< An array for the x-direction advective flux summed
-                                             !! vertically and across ice category [Conc kg s-1].
+                                             !! vertically and across ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:), &
                  optional, pointer    :: ad_2d_y !< An array for the Y-direction advective flux summed
-                                             !! vertically and across ice category [Conc kg s-1].
+                                             !! vertically and across ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
                  optional, pointer    :: ad_3d_x !< An array for the vertically summed x-direction
-                                             !! advective flux [Conc kg s-1].
+                                             !! advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
                  optional, pointer    :: ad_3d_y !< An array for the vertically summed y-direction
-                                             !! advective flux [Conc kg s-1].
+                                             !! advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
                  optional, pointer    :: ad_4d_x !< An array for the x-direction advective flux by
-                                             !! ice category and layer [Conc kg s-1].
+                                             !! ice category and layer [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
                  optional, pointer    :: ad_4d_y  !< An array for the x-direction advective flux by
-                                             !! ice category and layer [Conc kg s-1].
+                                             !! ice category and layer [Conc H L2 T-1 ~> Conc kg s-1].
   real,          optional, intent(in) :: OBC_inflow !<  The value of the tracer for all inflows via
                                              !! the open boundary conditions for which OBC_in_u or
                                              !! OBC_in_v are not specified, in the same units as tr [Conc].
@@ -544,22 +544,22 @@ subroutine add_SIS_tracer_diagnostics(name, TrReg, ad_2d_x, ad_2d_y, ad_3d_x, &
                            pointer    :: TrReg !< A pointer to the SIS tracer registry
   real, dimension(:,:), &
                  optional, pointer    :: ad_2d_x !< An array for the x-direction advective flux summed
-                                             !! vertically and across ice category [Conc kg s-1].
+                                             !! vertically and across ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:), &
                  optional, pointer    :: ad_2d_y !< An array for the Y-direction advective flux summed
-                                             !! vertically and across ice category [Conc kg s-1].
+                                             !! vertically and across ice category [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
                  optional, pointer    :: ad_3d_x !< An array for the vertically summed x-direction
-                                             !! advective flux [Conc kg s-1].
+                                             !! advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:), &
                  optional, pointer    :: ad_3d_y !< An array for the vertically summed y-direction
-                                             !! advective flux [Conc kg s-1].
+                                             !! advective flux [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
                  optional, pointer    :: ad_4d_x !< An array for the x-direction advective flux by
-                                             !! ice category and layer [Conc kg s-1].
+                                             !! ice category and layer [Conc H L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
                  optional, pointer    :: ad_4d_y  !< An array for the x-direction advective flux by
-                                             !! ice category and layer [Conc kg s-1].
+                                             !! ice category and layer [Conc H L2 T-1 ~> Conc kg s-1].
 
 ! This subroutine adds diagnostic arrays for a tracer that has previously been
 ! registered by a call to register_SIS_tracer.

--- a/src/SIS_utils.F90
+++ b/src/SIS_utils.F90
@@ -8,6 +8,7 @@ use MOM_domains,        only : SCALAR_PAIR, CGRID_NE, BGRID_NE, To_All
 use MOM_error_handler,  only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler,  only : is_root_pe
 use MOM_time_manager,   only : time_type, get_date, get_time, set_date, operator(-)
+use MOM_unit_scaling,   only : unit_scale_type
 use SIS_diag_mediator,  only : post_SIS_data, SIS_diag_ctrl
 use SIS_debugging,      only : hchksum, Bchksum, uvchksum, hchksum_pair, Bchksum_pair
 use SIS_debugging,      only : check_redundant_B
@@ -104,12 +105,12 @@ subroutine ice_line(Time, cn_ocn, sst, G)
     do j=jsc,jec ; do i=isc,iec
       x(i,j) = 0.0
       if (cn_ocn(i,j)<0.85 .and. n*G%geoLatT(i,j)>0.0) &
-        x(i,j) = G%mask2dT(i,j)*G%areaT(i,j)
+        x(i,j) = G%mask2dT(i,j)*G%US%L_to_m**2*G%areaT(i,j)
     enddo ; enddo
     gx((n+3)/2) = g_sum(x(isc:iec,jsc:jec))/1e12
   enddo
   gx(3) = g_sum(sst(isc:iec,jsc:jec)*G%mask2dT(isc:iec,jsc:jec)*G%areaT(isc:iec,jsc:jec)) / &
-         (g_sum(G%mask2dT(isc:iec,jsc:jec)*G%areaT(isc:iec,jsc:jec)) + 1e-10)
+         (g_sum(G%mask2dT(isc:iec,jsc:jec)*G%areaT(isc:iec,jsc:jec)) + G%US%m_to_L**2*1e-10)
   !
   ! print info every 5 days
   !
@@ -288,9 +289,10 @@ subroutine post_avg_4d(id, val, part, diag, G, mask, scale, offset, wtd)
 end subroutine post_avg_4d
 
 !> Write checksums of the elements of the sea-ice grid
-subroutine ice_grid_chksum(G, haloshift)
-  type(SIS_hor_grid_type), optional, intent(inout) :: G   !< The horizontal grid type
-  integer,                 optional, intent(in)    :: haloshift !< The size of the halo to check
+subroutine ice_grid_chksum(G, US, haloshift)
+  type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
+  type(unit_scale_type),   intent(in)    :: US  !< A structure with unit conversion factors
+  integer,       optional, intent(in)    :: haloshift !< The size of the halo to check
 
   integer :: isc, iec, jsc, jec, hs
   isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
@@ -301,10 +303,10 @@ subroutine ice_grid_chksum(G, haloshift)
   call hchksum(G%geoLatT, "G%geoLatT", G%HI, haloshift=hs)
   call hchksum(G%geoLonT, "G%geoLonT", G%HI, haloshift=hs)
 
-  call hchksum_pair("G%d[xy]T", G%dxT, G%dyT, G, halos=hs)
-  call hchksum_pair("G%Id[xy]T", G%IdxT, G%IdyT, G, halos=hs)
-  call hchksum(G%areaT, "G%areaT", G%HI, haloshift=hs)
-  call hchksum(G%IareaT, "G%IareaT", G%HI, haloshift=hs)
+  call hchksum_pair("G%d[xy]T", G%dxT, G%dyT, G, halos=hs, scale=US%L_to_m)
+  call hchksum_pair("G%Id[xy]T", G%IdxT, G%IdyT, G, halos=hs, scale=US%m_to_L)
+  call hchksum(G%areaT, "G%areaT", G%HI, haloshift=hs, scale=US%L_to_m**2)
+  call hchksum(G%IareaT, "G%IareaT", G%HI, haloshift=hs, scale=US%m_to_L**2)
   call hchksum(G%mask2dT, "G%mask2dT", G%HI, haloshift=hs)
   call hchksum(G%cos_rot, "G%cos_rot", G%HI)
   call hchksum(G%sin_rot, "G%sin_rot", G%HI)
@@ -314,11 +316,11 @@ subroutine ice_grid_chksum(G, haloshift)
   call Bchksum(G%geoLatBu, "G%geoLatBu", G%HI, haloshift=hs)
   call Bchksum(G%geoLonBu, "G%geoLonBu", G%HI, haloshift=hs)
 
-  call Bchksum_pair("G%d[xy]Bu", G%dxBu, G%dyBu, G, halos=hs, scalars=.true.)
-  call Bchksum_pair("G%Id[xy]Bu", G%IdxBu, G%IdyBu, G, halos=hs, scalars=.true.)
+  call Bchksum_pair("G%d[xy]Bu", G%dxBu, G%dyBu, G, halos=hs, scalars=.true., scale=US%L_to_m)
+  call Bchksum_pair("G%Id[xy]Bu", G%IdxBu, G%IdyBu, G, halos=hs, scalars=.true., scale=US%m_to_L)
 
-  call Bchksum(G%areaBu, "G%areaBu", G%HI, haloshift=hs)
-  call Bchksum(G%IareaBu, "G%IareaBu", G%HI, haloshift=hs)
+  call Bchksum(G%areaBu, "G%areaBu", G%HI, haloshift=hs, scale=US%L_to_m**2)
+  call Bchksum(G%IareaBu, "G%IareaBu", G%HI, haloshift=hs, scale=US%m_to_L**2)
 
   call check_redundant_B("G%areaBu", G%areaBu, G, isc-1, iec+1, jsc-1, jec+1)
   call check_redundant_B("G%IareaBu", G%IareaBu, G, isc-1, iec+1, jsc-1, jec+1)
@@ -328,17 +330,17 @@ subroutine ice_grid_chksum(G, haloshift)
   call uvchksum("G%geoLatC[uv]", G%geoLatCu, G%geoLatCv, G, halos=hs)
   call uvchksum("G%geolonC[uv]", G%geoLonCu, G%geoLonCv, G, halos=hs)
 
-  call uvchksum("G%d[xy]C[uv]", G%dxCu, G%dyCv, G, halos=hs, scalars=.true.)
-  call uvchksum("G%d[yx]C[uv]", G%dyCu, G%dxCv, G, halos=hs, scalars=.true.)
-  call uvchksum("G%Id[xy]C[uv]", G%IdxCu, G%IdyCv, G, halos=hs, scalars=.true.)
-  call uvchksum("G%Id[yx]C[uv]", G%IdyCu, G%IdxCv, G, halos=hs, scalars=.true.)
+  call uvchksum("G%d[xy]C[uv]", G%dxCu, G%dyCv, G, halos=hs, scalars=.true., scale=US%L_to_m)
+  call uvchksum("G%d[yx]C[uv]", G%dyCu, G%dxCv, G, halos=hs, scalars=.true., scale=US%L_to_m)
+  call uvchksum("G%Id[xy]C[uv]", G%IdxCu, G%IdyCv, G, halos=hs, scalars=.true., scale=US%m_to_L)
+  call uvchksum("G%Id[yx]C[uv]", G%IdyCu, G%IdxCv, G, halos=hs, scalars=.true., scale=US%m_to_L)
 
-  call uvchksum("G%areaC[uv]", G%areaCu, G%areaCv, G, halos=hs)
-  call uvchksum("G%IareaC[uv]", G%IareaCu, G%IareaCv, G, halos=hs)
+  call uvchksum("G%areaC[uv]", G%areaCu, G%areaCv, G, halos=hs, scale=US%L_to_m**2)
+  call uvchksum("G%IareaC[uv]", G%IareaCu, G%IareaCv, G, halos=hs, scale=US%m_to_L**2)
 
-  call hchksum(G%bathyT, "G%bathyT", G%HI, haloshift=hs)
-  call Bchksum(G%CoriolisBu, "G%CoriolisBu", G%HI, haloshift=hs)
-  call hchksum_pair("G%dF_d[xy]", G%dF_dx, G%dF_dy, G, halos=hs)
+  call hchksum(G%bathyT, "G%bathyT", G%HI, haloshift=hs, scale=US%Z_to_m)
+  call Bchksum(G%CoriolisBu, "G%CoriolisBu", G%HI, haloshift=hs, scale=US%s_to_T)
+  call hchksum_pair("G%dF_d[xy]", G%dF_dx, G%dF_dy, G, halos=hs, scale=US%s_to_T*US%m_to_L)
 
 end subroutine ice_grid_chksum
 

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -21,6 +21,7 @@ use MOM_sponge, only            : set_up_sponge_field, sponge_CS
 use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING
 use MOM_error_handler, only     : SIS_mesg=>MOM_mesg
 use MOM_string_functions, only  : slasher
+use MOM_unit_scaling, only      : unit_scale_type
 
 use fms_mod, only               : read_data
 use fms_io_mod, only            : register_restart_field, restore_state
@@ -417,7 +418,7 @@ function ice_age_stock(mi, stocks, G, IG, CS, names, units)
       avg_tr = avg_tr/IG%NkIce
 
       stocks(tr) = stocks(tr) + avg_tr * &
-          (G%mask2dT(i,j) * G%areaT(i,j) * mi(i,j,k))
+          (G%mask2dT(i,j) * G%US%m_to_L**2*G%areaT(i,j) * mi(i,j,k))
     enddo ; enddo ; enddo
 
   enddo

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -219,7 +219,7 @@ subroutine update_ice_slow_thermo(Ice)
       ! This code is only required to reproduce an old bug.
       i_off = LBOUND(Ice%flux_t,1) - sG%isc
       j_off = LBOUND(Ice%flux_t,2) - sG%jsc
-      !$OMP parallel do default(none) shared(Ice,sG,i_off,j_off) private(i2,j2)
+      !$OMP parallel do default(none) shared(Ice,sG,US,i_off,j_off) private(i2,j2)
       do j=sG%jsc,sG%jec ; do i=sG%isc,sG%iec
         i2 = i+i_off ; j2 = j+j_off
         Ice%sCS%IOF%flux_u_ocn(i,j) = US%m_s_to_L_T*US%T_to_s*Ice%flux_u(i2,j2)


### PR DESCRIPTION
  Added dimensional consistency testing capabilities to SIS2, analogous to those
that have been developed for MOM6.  Specifically, these test consistency in time
and length units.  All answers are bitwise identical, and no bugs have been
identified, but there are new arguments to some interfaces and a number of
arguments or elements of types have units that can be dimensionally rescaled.
SIS2 commits with this PR include:

 - NOAA-GFDL/SIS2@f803d26 Minor changes to increase similarity to dev/gfdl
 - NOAA-GFDL/SIS2@4fdb2a4 +Rescaled velocities in the simple_OSS_type
 - NOAA-GFDL/SIS2@132a1c6 Code rescaling simplification and clean-up
 - NOAA-GFDL/SIS2@53217dc +Rescaled some internal timestep variables
 - NOAA-GFDL/SIS2@40ee0ec +Rescaled IOF%flux_u_ocn and IOF%stress_mag
 - NOAA-GFDL/SIS2@8481061 +Rescaled variables used in SIS B-grid dynamics
 - NOAA-GFDL/SIS2@ad86a46 +Rescaled volume transports for tracer advection
 - NOAA-GFDL/SIS2@a79d884 +Rescaled OSS%u_ocn_C
 - NOAA-GFDL/SIS2@9b55f7f +Rescaled transports in proportionate_continuity
 - NOAA-GFDL/SIS2@224a2af +Rescaled variables used in SIS_continuity
 - NOAA-GFDL/SIS2@308c89a +Rescaled the timestep stored in SIS_sum_output
 - NOAA-GFDL/SIS2@bb75a0a +Rescaled C-grid velocities
 - NOAA-GFDL/SIS2@9fa3cfe Generalized some comments documenting arguments
 - NOAA-GFDL/SIS2@d8c52e3 Corrected an error message
 - NOAA-GFDL/SIS2@2197d4a +Rescaled C-grid stresses in SIS_dynamics_trans
 - NOAA-GFDL/SIS2@588ffe1 +Rescaled stresses in SIS_C_dynamics
 - NOAA-GFDL/SIS2@ce9d757 +Pass US to SIS_C_dyn_read_alt_restarts
 - NOAA-GFDL/SIS2@bedeace +Added register_unit_conversion_restarts
 - NOAA-GFDL/SIS2@68e01da +Rescaled many variables in SIS_C_dynamics
 - NOAA-GFDL/SIS2@b5263a4 +Add conversion arg to register_SIS_diag_field
 - NOAA-GFDL/SIS2@62724c7 +Rescaled G%bathyT
 - NOAA-GFDL/SIS2@887f0fa +Rescaled G%CoriolisBu
 - NOAA-GFDL/SIS2@2a5e98a +Rescaled lengths in SIS_hor_grid_type
 - NOAA-GFDL/SIS2@f06c7ba +Added optional scale arguments to chksum routines
