### PR TITLE
slow/fast mask bug fix

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2723,7 +2723,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       Ice%fCS%Rad%t_skin(:,:,:) = 0.0
     elseif (do_mask_restart) then
       do k=1,CatIce
-        Ice%fCS%Rad%t_skin(:,:,k) = Ice%fCS%Rad%t_skin(:,:,k) * sG%mask2dT(:,:)
+        Ice%fCS%Rad%t_skin(:,:,k) = Ice%fCS%Rad%t_skin(:,:,k) * fG%mask2dT(:,:)
       enddo
     endif
     if (init_rough) then


### PR DESCRIPTION
t_skin is masked with slow grid mask instead of fast grid. Results in seg fault.

@Hallberg-NOAA @adcroft @marshallward  