### PR TITLE
SIS2: +Remove carriage returns in parameter descriptions

### DIFF
--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -116,33 +116,33 @@ subroutine SIS2_ice_thm_init(US, param_file, CS)
                  "The conductivity of heat in ice.", &
                  units="W m-1 K-1", default=2.03, scale=US%W_m2_to_QRZ_T*US%m_to_Z)
   call get_param(param_file, mdl, "MIN_H_FOR_TEMP_CALC", CS%H_lo_lim, &
-                 "The minimum ice thickness at which to do temperature \n"//&
+                 "The minimum ice thickness at which to do temperature "//&
                  "calculations.", units="m", default=0.0, scale=US%m_to_Z)
 
   call get_param(param_file, mdl, "DO_POND", CS%do_pond, &
-                 "If true, calculate melt ponds and use them for\n"//&
+                 "If true, calculate melt ponds and use them for "//&
                  "shortwave radiation calculation.", default=.false.)
   call get_param(param_file, mdl, "TDRAIN", CS%tdrain, &
-                 "Melt ponds drain to sea level when ice average temp.\n"//&
+                 "Melt ponds drain to sea level when ice average temp. "//&
                  "exceeds TDRAIN (stand-in for mushy layer thermo)", default=-0.8) !### , units="degC")
   call get_param(param_file, mdl, "R_MIN_POND", CS%r_min_pond, &
-                 "Minimum retention rate of surface water sources in melt pond\n"//&
+                 "Minimum retention rate of surface water sources in melt pond "//&
                  "(retention scales linearly with ice cover)", default=0.15) !### , units="nondim")
   call get_param(param_file, mdl, "R_MAX_POND", CS%r_max_pond, &
-                 "Maximum retention rate of surface water sources in melt pond\n"//&
+                 "Maximum retention rate of surface water sources in melt pond "//&
                  "(retention scales linearly with ice cover)", default=0.9) !### , units="nondim")
   call get_param(param_file, mdl, "MIN_POND_FRAC", CS%min_pond_frac, &
-                 "Minimum melt pond cover (by ponds at sea level)\n"//&
+                 "Minimum melt pond cover (by ponds at sea level) "//&
                  "pond drains to this when ice is porous.", default=0.2) !### , units="nondim")
   call get_param(param_file, mdl, "MAX_POND_FRAC", CS%max_pond_frac, &
-                 "Maximum melt pond cover - associated with pond volume\n"//&
+                 "Maximum melt pond cover - associated with pond volume "//&
                  "that suppresses ice top to waterline", default=0.5) !### , units="nondim")
   call get_param(param_file, mdl, "ICE_TEMP_RANGE_ESTIMATE", CS%temp_range_est,&
-                 "An estimate of the range of snow and ice temperatures \n"//&
-                 "that is used to evaluate whether an explicit diffusive \n"//&
-                 "form of the heat fluxes or an inversion based on the \n"//&
-                 "layer heat budget is more likely to be more accurate. \n"//&
-                 "Setting this to 0 causes the explicit diffusive form. \n"//&
+                 "An estimate of the range of snow and ice temperatures "//&
+                 "that is used to evaluate whether an explicit diffusive "//&
+                 "form of the heat fluxes or an inversion based on the "//&
+                 "layer heat budget is more likely to be more accurate. "//&
+                 "Setting this to 0 causes the explicit diffusive form. "//&
                  "to always be used.", units="degC", default=40.0)
   CS%temp_range_est = abs(CS%temp_range_est)
 
@@ -1699,15 +1699,15 @@ subroutine ice_thermo_init(param_file, ITV, US, init_EOS )
                  "The nominal density of snow as used by SIS.", &
                  units="kg m-3", default=330.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "CP_ICE", ITV%Cp_ice, &
-                 "The heat capacity of fresh ice, approximated as a \n"//&
-                 "constant.", units="J kg-1 K-1", default=2100.0, scale=US%J_kg_to_Q)
+                 "The heat capacity of fresh ice, approximated as a constant.", &
+                 units="J kg-1 K-1", default=2100.0, scale=US%J_kg_to_Q)
   call get_param(param_file, mdl, "CP_SEAWATER", ITV%Cp_Water, &
-                 "The heat capacity of sea water, approximated as a \n"//&
-                 "constant.", units="J kg-1 K-1", default=4200.0, scale=US%J_kg_to_Q)
+                 "The heat capacity of sea water, approximated as a constant.", &
+                 units="J kg-1 K-1", default=4200.0, scale=US%J_kg_to_Q)
   call get_param(param_file, mdl, "CP_BRINE", ITV%Cp_brine, &
-                 "The heat capacity of water in brine pockets within the \n"//&
-                 "sea-ice, approximated as a constant.  CP_BRINE and \n"//&
-                 "CP_SEAWATER should be equal, but for computational \n"//&
+                 "The heat capacity of water in brine pockets within the "//&
+                 "sea-ice, approximated as a constant.  CP_BRINE and "//&
+                 "CP_SEAWATER should be equal, but for computational "//&
                  "convenience CP_BRINE can be set equal to CP_ICE.", &
                  units="J kg-1 K-1", default=US%Q_to_J_kg*ITV%Cp_Water, scale=US%J_kg_to_Q)
   call get_param(param_file, mdl, "DTFREEZE_DS", ITV%dTf_dS, &
@@ -1715,15 +1715,15 @@ subroutine ice_thermo_init(param_file, ITV, US, init_EOS )
                  units="deg C PSU-1", default=-0.054)
 
   call get_param(param_file, mdl, "ENTHALPY_LIQUID_0", ITV%enth_liq_0, &
-                 "The enthalpy of liquid fresh water at 0 C.  The solutions \n"//&
-                 "should be physically consistent when this is adjusted, \n"//&
-                 "because only the relative value is of physical meaning, \n"//&
+                 "The enthalpy of liquid fresh water at 0 C.  The solutions "//&
+                 "should be physically consistent when this is adjusted, "//&
+                 "because only the relative value is of physical meaning, "//&
                  "but roundoff errors can change the solution.", &
                  units="J kg-1", default=0.0, scale=US%J_kg_to_Q)
   call obsolete_real(param_file, "ENTHALPY_UNITS", warning_val=1.0)
   call get_param(param_file, mdl, "SUBLIMATION_BUG", ITV%sublimation_bug, &
-                 "If true use an older calculation that omits the latent \n"//&
-                 "heat of fusion from the latent heat of sublimation. \n"//&
+                 "If true use an older calculation that omits the latent "//&
+                 "heat of fusion from the latent heat of sublimation. "//&
                  "This variable should be obsoleted as soon as possible.", &
                  default=.false.)
 
@@ -1733,7 +1733,7 @@ subroutine ice_thermo_init(param_file, ITV, US, init_EOS )
   if (specified_ice) then
     ITV%slab_ice = .true.
     call log_param(param_file, mdl, "USE_SLAB_ICE", ITV%slab_ice, &
-                 "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
+                 "Use the very old slab-style ice.  With SPECIFIED_ICE, "//&
                  "USE_SLAB_ICE is always true.")
   else
     call get_param(param_file, mdl, "USE_SLAB_ICE", ITV%slab_ice, &

--- a/src/SIS_continuity.F90
+++ b/src/SIS_continuity.F90
@@ -1395,7 +1395,7 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS, CS_cvr)
        hint="Use SIS_CONTINUITY_SCHEME instead.")
 
   call get_param(param_file, mdl, "CONT_PPM_VOLUME_BASED_CFL", CS%vol_CFL, &
-                 "If true, use the ratio of the open face lengths to the \n"//&
+                 "If true, use the ratio of the open face lengths to the "//&
                  "tracer cell areas when estimating CFL numbers.", &
                  default=.false.)
 
@@ -1423,7 +1423,7 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS, CS_cvr)
     end select
 
     call get_param(param_file, mdl, "COVER_PPM_VOLUME_BASED_CFL", CS_cvr%vol_CFL, &
-                   "If true, use the ratio of the open face lengths to the cell\n"//&
+                   "If true, use the ratio of the open face lengths to the cell "//&
                    "areas when estimating CFL numbers in ice cover transport.", &
                    default=.false.)
   endif

--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -90,11 +90,11 @@ subroutine SIS_debugging_init(param_file)
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_CHKSUMS", debug_chksums, &
-                 "If true, checksums are performed on arrays in the \n"//&
+                 "If true, checksums are performed on arrays in the "//&
                  "various vec_chksum routines.", default=debug, &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", debug_redundant, &
-                 "If true, debug redundant data points during calls to \n"//&
+                 "If true, debug redundant data points during calls to "//&
                  "the various vec_chksum routines.", default=debug, &
                  debuggingParam=.true.)
 

--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -144,7 +144,7 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "GRID_CONFIG", grid_config, &
-                 "The method for defining the horizontal grid.  Valid \n"//&
+                 "The method for defining the horizontal grid.  Valid "//&
                  "entries include:\n"//&
                  "\t file - read the grid from GRID_FILE \n"//&
                  "\t mosaic - read the grid from a mosaic grid file \n"//&
@@ -158,10 +158,10 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
     ! This is a cartesian grid, and may have different axis units.
     Cartesian_grid = .true.
     call get_param(param_file, mdl, "AXIS_UNITS", units_temp, &
-                 "The units for the x- and y- axis labels.  AXIS_UNITS \n"//&
-                 "should be defined as 'k' for km, 'm' for m, or 'd' \n"//&
-                 "for degrees of latitude and longitude (the default). \n"//&
-                 "Except on a Cartesian grid, only degrees are currently \n"//&
+                 "The units for the x- and y- axis labels.  AXIS_UNITS "//&
+                 "should be defined as 'k' for km, 'm' for m, or 'd' "//&
+                 "for degrees of latitude and longitude (the default). "//&
+                 "Except on a Cartesian grid, only degrees are currently "//&
                  "implemented.", default='degrees')
     if (units_temp(1:1) == 'k') then
       G%x_axis_units = "kilometers" ; G%y_axis_units = "kilometers"
@@ -820,7 +820,7 @@ subroutine SIS_diag_mediator_init(G, IG, param_file, diag_cs, component, err_msg
       doc_file_param = "AVAILABLE_DIAGS_FILE"
     endif
     call get_param(param_file, mdl, trim(doc_file_param), doc_file, &
-                 "A file into which to write a list of all available \n"//&
+                 "A file into which to write a list of all available "//&
                  "sea ice diagnostics that can be included in a diag_table.", &
                  default=doc_file_dflt)
     if (len_trim(doc_file) > 0) then

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -97,22 +97,22 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "DT_RHEOLOGY", CS%dt_Rheo, &
-                 "The sub-cycling time step for iterating the rheology \n"//&
-                 "and ice momentum equations. If DT_RHEOLOGY is negative, \n"//&
+                 "The sub-cycling time step for iterating the rheology "//&
+                 "and ice momentum equations. If DT_RHEOLOGY is negative, "//&
                  "the time step is set via NSTEPS_DYN.", units="seconds", scale=US%s_to_T, &
                  default=-1.0)
   CS%evp_sub_steps = -1
   if (CS%dt_Rheo <= 0.0) &
     call get_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
-                 "The number of iterations of the rheology and ice \n"//&
+                 "The number of iterations of the rheology and ice "//&
                  "momentum equations for each slow ice time step.", default=432)
 
   call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
-                 "A constant in the expression for the ice strength, \n"//&
+                 "A constant in the expression for the ice strength, "//&
                  "P* in Hunke & Dukowicz 1997.", &
                  units="Pa", scale=US%kg_m3_to_R*US%m_s_to_L_T**2, default=2.75e4)
   call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
-                 "A constant in the exponent of the expression for the \n"//&
+                 "A constant in the exponent of the expression for the "//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
                  units="nondim", default=20.)
   call get_param(param_file, mdl, "ICE_CDRAG_WATER", CS%cdw, &
@@ -140,8 +140,8 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
                  "If true, debug redundant data points.", default=CS%debug, &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "AIR_WATER_STRESS_TURN_ANGLE", CS%blturn, &
-                 "An angle by which to rotate the velocities at the air- \n"//&
-                 "water boundary in calculating stresses.", units="degrees", &
+                 "An angle by which to rotate the velocities at the air-water "//&
+                 "boundary in calculating stresses.", units="degrees", &
                  default=0.0)
 
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -166,59 +166,59 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "DT_RHEOLOGY", CS%dt_Rheo, &
-                 "The sub-cycling time step for iterating the rheology \n"//&
-                 "and ice momentum equations. If DT_RHEOLOGY is negative, \n"//&
+                 "The sub-cycling time step for iterating the rheology "//&
+                 "and ice momentum equations. If DT_RHEOLOGY is negative, "//&
                  "the time step is set via NSTEPS_DYN.", units="seconds", &
                  default=-1.0, scale=US%s_to_T)
   CS%evp_sub_steps = -1
   if (CS%dt_Rheo <= 0.0) &
     call get_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &
-                 "The number of iterations of the rheology and ice \n"//&
+                 "The number of iterations of the rheology and ice "//&
                  "momentum equations for each slow ice time step.", default=432)
   call get_param(param_file, mdl, "ICE_TDAMP_ELASTIC", CS%Tdamp, &
-                 "The damping timescale associated with the elastic terms \n"//&
-                 "in the sea-ice dynamics equations (if positive) or the \n"//&
+                 "The damping timescale associated with the elastic terms "//&
+                 "in the sea-ice dynamics equations (if positive) or the "//&
                  "fraction of DT_ICE_DYNAMICS (if negative).", &
                  units="s or nondim", default=-0.2)
   if (CS%Tdamp > 0.0) CS%Tdamp = CS%Tdamp*US%s_to_T
   call get_param(param_file, mdl, "WEAK_LOW_SHEAR_ICE", CS%weak_low_shear, &
-                 "If true, the divergent stresses go toward 0 in the C-grid \n"//&
-                 "dynamics when the shear magnitudes are very weak. \n"//&
+                 "If true, the divergent stresses go toward 0 in the C-grid "//&
+                 "dynamics when the shear magnitudes are very weak. "//&
                  "Otherwise they go to -P_ice.  This setting is temporary.", &
                  default=.false.)
 
   call get_param(param_file, mdl, "PROJECT_ICE_DRAG_VEL", CS%project_drag_vel, &
-                 "If true, project forward the ice velocity used in the \n"//&
-                 "drag calculation to avoid an instability that can occur \n"//&
-                 "when a finite stress is applied to thin ice moving with \n"//&
+                 "If true, project forward the ice velocity used in the "//&
+                 "drag calculation to avoid an instability that can occur "//&
+                 "when a finite stress is applied to thin ice moving with "//&
                  "the velocity of the ocean.", default=.true.)
   call get_param(param_file, mdl, "ICE_YIELD_ELLIPTICITY", CS%EC, &
-                 "The ellipticity coefficient for the plastic yield curve \n"//&
-                 "in the sea-ice rheology.  For an infinite ellipticity \n"//&
+                 "The ellipticity coefficient for the plastic yield curve "//&
+                 "in the sea-ice rheology.  For an infinite ellipticity "//&
                  "(i.e., a cavitating fluid rheology), use 0.", &
                  units="Nondim", default=2.0)
 
   call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
-                 "A constant in the expression for the ice strength, \n"//&
+                 "A constant in the expression for the ice strength, "//&
                  "P* in Hunke & Dukowicz 1997.", &
                  units="Pa", default=2.75e4, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
   call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
-                 "A constant in the exponent of the expression for the \n"//&
+                 "A constant in the exponent of the expression for the "//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
                  units="nondim", default=20.)
   call get_param(param_file, mdl, "ICE_CDRAG_WATER", CS%cdw, &
                  "The drag coefficient between the sea ice and water.", &
                  units="nondim", default=3.24e-3)
   call get_param(param_file, mdl, "MIN_OCN_INTERTIAL_H", CS%min_ocn_inertial_h, &
-                 "A minimum ocean thickness used to limit the viscous coupling rate\n"//&
+                 "A minimum ocean thickness used to limit the viscous coupling rate "//&
                  "implied for the ocean by the ice-ocean stress. Only used if positive.", &
                  units="m", default=0.0, scale=US%m_to_Z)
   call get_param(param_file, mdl, "ICE_DEL_SH_MIN_SCALE", CS%del_sh_min_scale, &
-                 "A scaling factor for the lower bound on the shear rates \n"//&
-                 "used in the denominator of the stress calculation. This \n"//&
+                 "A scaling factor for the lower bound on the shear rates "//&
+                 "used in the denominator of the stress calculation. This "//&
                  "probably needs to be greater than 1.", units="nondim", default=2.0)
   call get_param(param_file, mdl, "PROJECT_ICE_CONCENTRATION", CS%project_ci, &
-                 "If true, project the evolution of the ice concentration \n"//&
+                 "If true, project the evolution of the ice concentration "//&
                  "due to the convergence or divergence of the ice flow.", default=.true.)
 
   call get_param(param_file, mdl, "RHO_OCEAN", CS%Rho_ocean, &
@@ -230,12 +230,12 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%p0_rho = CS%p0 / CS%Rho_ice
 
   call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
-                 "The value of the CFL number that will cause ice velocity \n"//&
+                 "The value of the CFL number that will cause ice velocity "//&
                  "components to be truncated; instability can occur past 0.5.", &
                  units="nondim", default=0.5)
   call get_param(param_file, mdl, "CFL_TRUNC_DYN_ITS", CS%CFL_check_its, &
-                 "If true, check the CFL number for every iteration of the \n"//&
-                 "rheology solver; otherwise only the final velocities that \n"//&
+                 "If true, check the CFL number for every iteration of the "//&
+                 "rheology solver; otherwise only the final velocities that "//&
                  "are used for transport are checked.", &
                  default=.false.)
   call get_param(param_file, mdl, "DEBUG", debug, &
@@ -245,23 +245,23 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_EVP_SUBSTEPS", CS%debug_EVP, &
-                 "If true, write out verbose debugging data for each of the \n"//&
+                 "If true, write out verbose debugging data for each of the "//&
                  "steps within the EVP solver.", default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "DEBUG_REDUNDANT", CS%debug_redundant, &
                  "If true, debug redundant data points.", default=CS%debug, &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "U_TRUNC_FILE", CS%u_trunc_file, &
-                 "The absolute path to the file where the accelerations \n"//&
-                 "leading to zonal velocity truncations are written. \n"//&
-                 "Leave this empty for efficiency if this diagnostic is \n"//&
+                 "The absolute path to the file where the accelerations "//&
+                 "leading to zonal velocity truncations are written. "//&
+                 "Leave this empty for efficiency if this diagnostic is "//&
                  "not needed.", default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "V_TRUNC_FILE", CS%v_trunc_file, &
-                 "The absolute path to the file where the accelerations \n"//&
-                 "leading to meridional velocity truncations are written. \n"//&
-                 "Leave this empty for efficiency if this diagnostic is \n"//&
-                 "not needed.", default="", debuggingParam=.true.)
+                 "The absolute path to the file where the accelerations "//&
+                 "leading to meridional velocity truncations are written. "//&
+                 "Leave this empty for efficiency if this diagnostic is not needed.", &
+                 default="", debuggingParam=.true.)
   call get_param(param_file, mdl, "MAX_TRUNC_FILE_SIZE_PER_PE", CS%max_writes, &
-                 "The maximum number of colums of truncations that any PE \n"//&
+                 "The maximum number of colums of truncations that any PE "//&
                  "will write out during a run.", default=50, debuggingParam=.true.)
 
 !  if (len_trim(dirs%output_directory) > 0) then

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -2201,45 +2201,45 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
   call log_version(param_file, mdl, version, &
      "This module updates the ice momentum and does ice transport.")
   call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn, &
-                 "If true, use a C-grid discretization of the sea-ice \n"//&
+                 "If true, use a C-grid discretization of the sea-ice "//&
                  "dynamics; if false use a B-grid discretization.", &
                  default=.false.)
   call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt_ice_dyn, &
-                 "The time step used for the slow ice dynamics, including \n"//&
-                 "stepping the continuity equation and interactions \n"//&
-                 "between the ice mass field and velocities.  If 0 or \n"//&
+                 "The time step used for the slow ice dynamics, including "//&
+                 "stepping the continuity equation and interactions "//&
+                 "between the ice mass field and velocities.  If 0 or "//&
                  "negative the coupling time step will be used.", &
                  units="seconds", scale=US%s_to_T, default=-1.0)
   call get_param(param_file, mdl, "MERGED_CONTINUITY", CS%merged_cont, &
-                 "If true, update the continuity equations for the ice, snow, \n"//&
-                 "and melt pond water together summed across categories, with \n"//&
-                 "proportionate fluxes for each part. Otherwise the media are \n"//&
+                 "If true, update the continuity equations for the ice, snow, "//&
+                 "and melt pond water together summed across categories, with "//&
+                 "proportionate fluxes for each part. Otherwise the media are "//&
                  "updated separately.", default=.false.)
   call get_param(param_file, mdl, "DT_ICE_ADVECT", CS%dt_advect, &
-                 "The time step used for the advecting tracers and masses as \n"//&
-                 "partitioned by thickness categories when merged_cont it true. \n"//&
+                 "The time step used for the advecting tracers and masses as "//&
+                 "partitioned by thickness categories when merged_cont it true. "//&
                  "If 0 or negative, the coupling time step will be used.", &
                  units="seconds", scale=US%s_to_T, default=-1.0, do_not_log=.not.CS%merged_cont)
   if (.not.CS%merged_cont) CS%dt_advect = CS%dt_ice_dyn
   call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
-                 "If true, apply a ridging scheme to the convergent ice. \n"//&
-                 "Otherwise, ice is compressed proportionately if the \n"//&
-                 "concentration exceeds 1.  The original SIS2 implementation \n"//&
+                 "If true, apply a ridging scheme to the convergent ice. "//&
+                 "Otherwise, ice is compressed proportionately if the "//&
+                 "concentration exceeds 1.  The original SIS2 implementation "//&
                  "is based on work by Torge Martin.", default=.false.)
   call get_param(param_file, mdl, "NSTEPS_ADV", CS%adv_substeps, &
-                 "The number of advective iterations for each slow dynamics \n"//&
+                 "The number of advective iterations for each slow dynamics "//&
                  "time step.", default=1)
   if (CS%adv_substeps < 1) CS%adv_substeps = 1
 
   call get_param(param_file, mdl, "ICEBERG_WINDSTRESS_BUG", CS%berg_windstress_bug, &
-                 "If true, use older code that applied an old ice-ocean \n"//&
-                 "stress to the icebergs in place of the current air-ocean \n"//&
-                 "stress.  This option is here for backward compatibility, \n"//&
+                 "If true, use older code that applied an old ice-ocean "//&
+                 "stress to the icebergs in place of the current air-ocean "//&
+                 "stress.  This option is here for backward compatibility, "//&
                  "but should be avoided.", default=.false.)
   call get_param(param_file, mdl, "WARSAW_SUM_ORDER", CS%Warsaw_sum_order, &
-                 "If true, use the order of sums in the Warsaw version of SIS2. \n"//&
-                 "The default is the opposite of MERGED_CONTINUITY. \n"//&
-                 "This option exists for backward compatibilty but may \n"//&
+                 "If true, use the order of sums in the Warsaw version of SIS2. "//&
+                 "The default is the opposite of MERGED_CONTINUITY. "//&
+                 "This option exists for backward compatibilty but may "//&
                  "eventually be obsoleted.", &
                  default=.not.CS%merged_cont, do_not_log=CS%merged_cont)
   if (CS%merged_cont .and. CS%Warsaw_sum_order) &
@@ -2249,7 +2249,7 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
                  "The time unit for ICE_STATS_INTERVAL.", &
                  units="s", default=86400.0)
   call get_param(param_file, mdl, "ICE_STATS_INTERVAL", CS%ice_stats_interval, &
-                 "The interval in units of TIMEUNIT between writes of the \n"//&
+                 "The interval in units of TIMEUNIT between writes of the "//&
                  "globally summed ice statistics and conservation checks.", &
                  default=real_to_time(86400.0), timeunit=Time_unit)
 
@@ -2260,17 +2260,17 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
-                 "If true, add code to allow debugging of conservation \n"//&
-                 "column-by-column.  This does not change answers, but \n"//&
+                 "If true, add code to allow debugging of conservation "//&
+                 "column-by-column.  This does not change answers, but "//&
                  "can increase model run time.", default=.false., &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "VERBOSE", CS%verbose, &

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -1287,27 +1287,27 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
      "implicit surface temperature calculation.")
 
   call get_param(param_file, mdl, "REORDER_0C_HEATFLUX", CS%Reorder_0C_heatflux, &
-                 "If true, rearrange the calculation of the heat fluxes \n"//&
-                 "projected back to 0C to work on each contribution \n"//&
-                 "separately, so that they can be indentically replicated \n"//&
-                 "if there is a single fast timestep per coupled timestep \n"//&
+                 "If true, rearrange the calculation of the heat fluxes "//&
+                 "projected back to 0C to work on each contribution "//&
+                 "separately, so that they can be indentically replicated "//&
+                 "if there is a single fast timestep per coupled timestep "//&
                  "and REDO_FAST_ICE_UPDATE=True.", default=.false.)
   call get_param(param_file, mdl, "MAX_TSKIN_ITT", CS%max_tskin_itt, &
-                 "The maximum number of iterations of the skin temperature \n"//&
+                 "The maximum number of iterations of the skin temperature "//&
                  "and optical properties during redo_update_ice_model_fast.", &
                  default=10)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
-                 "If true, add code to allow debugging of conservation \n"//&
-                 "column-by-column.  This does not change answers, but \n"//&
+                 "If true, add code to allow debugging of conservation "//&
+                 "column-by-column.  This does not change answers, but "//&
                  "can increase model run time.", default=.false., &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, &

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -84,8 +84,8 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir)
 
 ! Modulate geometric scales according to geography.
   call get_param(PF, mdl, "CHANNEL_CONFIG", config, &
-                 "A parameter that determines which set of channels are \n"//&
-                 "restricted to specific  widths.  Options are:\n"//&
+                 "A parameter that determines which set of channels are "//&
+                 "restricted to specific widths.  Options are:\n"//&
                  " \t none - All channels have the grid width.\n"//&
                  " \t global_1deg - Sets 16 specific channels appropriate \n"//&
                  " \t\t for a 1-degree model, as used in CM2G.\n"//&

--- a/src/SIS_optics.F90
+++ b/src/SIS_optics.F90
@@ -93,32 +93,32 @@ subroutine SIS_optics_init(param_file, US, CS, slab_optics)
   endif
 
   call get_param(param_file, mdl, "DO_DELTA_EDDINGTON_SW", CS%do_deltaEdd, &
-                 "If true, a delta-Eddington radiative transfer calculation \n"//&
+                 "If true, a delta-Eddington radiative transfer calculation "//&
                  "for the shortwave radiation within the sea-ice.", &
                  default=.not.CS%slab_optics)
   call get_param(param_file, mdl, "DO_POND", CS%do_pond, &
-                 "If true, calculate melt ponds and use them for\n"//&
+                 "If true, calculate melt ponds and use them for "//&
                  "shortwave radiation calculation.", default=.false.)
   call get_param(param_file, mdl, "MIN_POND_FRAC", CS%min_pond_frac, &
-                 "Minimum melt pond cover (by ponds at sea level)\n"//&
+                 "Minimum melt pond cover (by ponds at sea level) "//&
                  "pond drains to this when ice is porous.", default=0.2)
   call get_param(param_file, mdl, "MAX_POND_FRAC", CS%max_pond_frac, &
-                 "Maximum melt pond cover - associated with pond volume\n"//&
+                 "Maximum melt pond cover - associated with pond volume "//&
                  "that suppresses ice top to waterline", default=0.5)
 
   call get_param(param_file, mdl, "ICE_DELTA_EDD_R_ICE", deltaEdd_R_ice, &
-                 "A dreadfully documented tuning parameter for the radiative \n"//&
-                 "propeties of sea ice with the delta-Eddington radiative \n"//&
+                 "A dreadfully documented tuning parameter for the radiative "//&
+                 "propeties of sea ice with the delta-Eddington radiative "//&
                  "transfer calculation.", units="nondimensional", default=0.0, &
                  do_not_log=.not.CS%do_deltaEdd)
   call get_param(param_file, mdl, "ICE_DELTA_EDD_R_SNOW", deltaEdd_R_snow, &
-                 "A dreadfully documented tuning parameter for the radiative \n"//&
-                 "propeties of snow on sea ice with the delta-Eddington \n"//&
+                 "A dreadfully documented tuning parameter for the radiative "//&
+                 "propeties of snow on sea ice with the delta-Eddington "//&
                  "radiative transfer calculation.", units="nondimensional", &
                  default=0.0, do_not_log=.not.CS%do_deltaEdd)
   call get_param(param_file, mdl, "ICE_DELTA_EDD_R_POND", deltaEdd_R_pond, &
-                 "A dreadfully documented tuning parameter for the radiative \n"//&
-                 "propeties of meltwater ponds on sea ice with the delta-Eddington \n"//&
+                 "A dreadfully documented tuning parameter for the radiative "//&
+                 "propeties of meltwater ponds on sea ice with the delta-Eddington "//&
                  "radiative transfer calculation.", units="nondimensional", &
                  default=0.0, do_not_log=.not.CS%do_deltaEdd)
   call shortwave_dEdd0_set_params(deltaEdd_R_ice, deltaEdd_R_snow, deltaEdd_R_pond)
@@ -131,7 +131,7 @@ subroutine SIS_optics_init(param_file, US, CS, slab_optics)
                  "The albedo of dry bare sea ice.", units="nondim", &
                  default=alb_ice_dflt, do_not_log=CS%do_deltaEdd)
   call get_param(param_file, mdl, "ICE_SW_PEN_FRAC", CS%pen_ice, &
-                 "The fraction of the unreflected shortwave radiation that \n"//&
+                 "The fraction of the unreflected shortwave radiation that "//&
                  "penetrates into the ice.", units="Nondimensional", &
                  default=0.3, do_not_log=CS%do_deltaEdd)
   call get_param(param_file, mdl, "ICE_OPTICAL_DEPTH", CS%opt_dep_ice, &
@@ -139,13 +139,13 @@ subroutine SIS_optics_init(param_file, US, CS, slab_optics)
                  units="m", default=0.67, scale=US%m_to_Z, do_not_log=CS%do_deltaEdd)
   T_range_dflt = 1.0 ; if (CS%slab_optics) T_range_dflt = 10.0
   call get_param(param_file, mdl, "ALBEDO_T_MELT_RANGE", CS%t_range_melt, &
-                 "The temperature range below freezing over which the \n"//&
+                 "The temperature range below freezing over which the "//&
                  "albedos are changed by partial melting.", units="degC", &
                  default=1.0, do_not_log=CS%do_deltaEdd)
 
   ! These parameters pertain only to the ancient slab ice optics parameterization.
   call get_param(param_file, mdl, "SLAB_OPTICS_CRITICAL_THICK", CS%slab_crit_thick, &
-                 "The thickness beyond which the slab ice optics no longer \n"//&
+                 "The thickness beyond which the slab ice optics no longer "//&
                  "exhibits a thickness dependencs on albedo.", units="m", scale=US%m_to_Z, &
                  default=1.0, do_not_log=.not.CS%slab_optics)
   call get_param(param_file, mdl, "SLAB_OPTICS_OCEAN_ALBEDO", CS%slab_alb_ocean, &

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1386,14 +1386,14 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
-                 "If true, apply a ridging scheme to the convergent ice. \n"//&
-                 "Otherwise, ice is compressed proportionately if the \n"//&
-                 "concentration exceeds 1.  The original SIS2 implementation \n"//&
+                 "If true, apply a ridging scheme to the convergent ice. "//&
+                 "Otherwise, ice is compressed proportionately if the "//&
+                 "concentration exceeds 1.  The original SIS2 implementation "//&
                  "is based on work by Torge Martin.", default=.false.)
   call get_param(param_file, mdl, "ICE_BULK_SALINITY", CS%ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", units = "g/kg", default=4.0)
   call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", CS%ice_rel_salin, &
-                 "The initial salinity of sea ice as a fraction of the \n"//&
+                 "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
                  units = "nondim", default=0.0)
   if ((CS%ice_bulk_salin > 0.0) .and. (CS%ice_rel_salin > 0.0)) &
@@ -1402,13 +1402,13 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
   if (CS%ice_bulk_salin < 0.0) CS%ice_bulk_salin = 0.0
 
   call get_param(param_file, mdl, "SIS2_FILLING_FRAZIL", CS%filling_frazil, &
-               "If true, apply frazil to fill as many categories as \n"//&
-               "possible to fill in a uniform (minimum) amount of ice \n"//&
-               "in all the thinnest categories. Otherwise the frazil is \n"//&
+               "If true, apply frazil to fill as many categories as "//&
+               "possible to fill in a uniform (minimum) amount of ice "//&
+               "in all the thinnest categories. Otherwise the frazil is "//&
                "always assigned to a single category.", default=.true.)
   call get_param(param_file, mdl, "FILLING_FRAZIL_TIMESCALE", CS%fraz_fill_time, &
-               "A timescale with which the filling frazil causes the \n"//&
-               "thinest cells to attain similar thicknesses, or a negative \n"//&
+               "A timescale with which the filling frazil causes the "//&
+               "thinest cells to attain similar thicknesses, or a negative "//&
                "number to apply the frazil flux uniformly.", default=0.0, &
                units="s", scale=US%s_to_T, do_not_log=.not.CS%filling_frazil)
 
@@ -1416,7 +1416,7 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "If true, restore the sea ice state toward climatology.", &
                  default=.false.)
   call get_param(param_file, mdl, "MAX_ICE_THICK_LIMIT", CS%max_ice_limit, &
-                 "The maximum permitted sea ice thickness when \n"//&
+                 "The maximum permitted sea ice thickness when "//&
                  "APPLY_ICE_LIMIT is true.", units="m", default=4.0, scale=US%m_to_Z, &
                  do_not_log=.not.CS%do_ice_limit)
 
@@ -1431,19 +1431,19 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "If true, constrain the sea ice concentrations using observations.", &
                  default=.false.)
   call get_param(param_file, mdl, "NUDGE_SEA_ICE_RATE", CS%nudge_sea_ice_rate, &
-                 "The rate of cooling of ice-free water that should be ice \n"//&
-                 "covered in order to constrained the ice concentration to \n"//&
+                 "The rate of cooling of ice-free water that should be ice "//&
+                 "covered in order to constrained the ice concentration to "//&
                  "track observations.  A suggested value is ~10000 W m-2.", &
                  units = "W m-2", default=0.0, scale=US%W_m2_to_QRZ_T, do_not_log=.not.CS%nudge_sea_ice)
   call get_param(param_file, mdl, "NUDGE_SEA_ICE_TOLERANCE", CS%nudge_conc_tol, &
-                 "The tolerance for mismatch in the sea ice concentations \n"//&
-                 "before nudging begins to be applied.  Values of order 0.1\n"//&
+                 "The tolerance for mismatch in the sea ice concentations "//&
+                 "before nudging begins to be applied.  Values of order 0.1 "//&
                  "should work well.", units = "nondim", default=0.0, &
                  do_not_log=.not.CS%nudge_sea_ice)
   call get_param(param_file, mdl, "NUDGE_SEA_ICE_STABILITY", CS%nudge_stab_fac, &
-                 "A factor that determines whether the buoyancy flux \n"//&
-                 "associated with the sea ice nudging of warm water includes \n"//&
-                 "a freshwater flux so as to be destabilizing on net (<1), \n"//&
+                 "A factor that determines whether the buoyancy flux "//&
+                 "associated with the sea ice nudging of warm water includes "//&
+                 "a freshwater flux so as to be destabilizing on net (<1), "//&
                  "stabilizing (>1), or neutral (=1).", units="nondim", &
                  default=1.0, do_not_log=.not.CS%nudge_sea_ice)
 
@@ -1454,17 +1454,17 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
-                 "If true, add code to allow debugging of conservation \n"//&
-                 "column-by-column.  This does not change answers, but \n"//&
+                 "If true, add code to allow debugging of conservation "//&
+                 "column-by-column.  This does not change answers, but "//&
                  "can increase model run time.", default=.false., &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
 

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -141,10 +141,10 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "WRITE_STOCKS", CS%write_stocks, &
-                 "If true, write the integrated tracer amounts to stdout \n"//&
+                 "If true, write the integrated tracer amounts to stdout "//&
                  "when the statistics files are written.", default=.true.)
   call get_param(param_file, mdl, "STDOUT_HEARTBEAT", CS%write_stdout, &
-                 "If true, periodically write sea ice statistics to \n"//&
+                 "If true, periodically write sea ice statistics to "//&
                  "stdout to allow the progress to be seen.", default=.true.)
   call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt, &
                  "The time step used for the slow ice dynamics, including "//&
@@ -152,14 +152,14 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
                  "the ice mass field and velocities.", units="s", scale=US%s_to_T, &
                  default=-1.0, do_not_log=.true.)
   call get_param(param_file, mdl, "MAXTRUNC", CS%maxtrunc, &
-                 "The run will be stopped, and the day set to a very \n"//&
-                 "large value if the velocity is truncated more than \n"//&
-                 "MAXTRUNC times between  writing ice statistics. \n"//&
-                 "Set MAXTRUNC to 0 to stop if there is any truncation \n"//&
+                 "The run will be stopped, and the day set to a very "//&
+                 "large value if the velocity is truncated more than "//&
+                 "MAXTRUNC times between  writing ice statistics. "//&
+                 "Set MAXTRUNC to 0 to stop if there is any truncation "//&
                  "of sea ice velocities.", units="truncations save_interval-1", default=0)
 
   call get_param(param_file, mdl, "STATISTICS_FILE", statsfile, &
-                 "The file to use to write the globally integrated \n"//&
+                 "The file to use to write the globally integrated "//&
                  "statistics.", default="seaice.stats")
 
   CS%statsfile = trim(slasher(directory))//trim(statsfile)
@@ -173,8 +173,8 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
                  units="s", default=86400.0)
   if (CS%Timeunit < 0.0) CS%Timeunit = 86400.0
   call get_param(param_file, mdl, "COLUMN_CHECK", CS%column_check, &
-                 "If true, add code to allow debugging of conservation \n"//&
-                 "column-by-column.  This does not change answers, but \n"//&
+                 "If true, add code to allow debugging of conservation "//&
+                 "column-by-column.  This does not change answers, but "//&
                  "can increase model run time.", default=.false., &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", CS%imb_tol, &

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1142,28 +1142,28 @@ subroutine SIS_transport_init(Time, G, US, param_file, diag, CS, continuity_CSp,
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version)
   call get_param(param_file, mdl, "RECATEGORIZE_ICE", CS%readjust_categories, &
-                 "If true, readjust the distribution into ice thickness \n"//&
+                 "If true, readjust the distribution into ice thickness "//&
                  "categories after advection.", default=.true.)
   call get_param(param_file, mdl, "RHO_ICE", CS%Rho_ice, &
                  "The nominal density of sea ice as used by SIS.", &
                  units="kg m-3", default=905.0, scale=US%kg_m3_to_R)
   call get_param(param_file, mdl, "SEA_ICE_ROLL_FACTOR", CS%Roll_factor, &
-                 "A factor by which the propensity of small amounts of \n"//&
-                 "thick sea-ice to become thinner by rolling is increased \n"//&
-                 "or 0 to disable rolling.  This can be thought of as the \n"//&
-                 "minimum number of ice floes in a grid cell divided by \n"//&
-                 "the horizontal floe aspect ratio.  Sensible values are \n"//&
+                 "A factor by which the propensity of small amounts of "//&
+                 "thick sea-ice to become thinner by rolling is increased "//&
+                 "or 0 to disable rolling.  This can be thought of as the "//&
+                 "minimum number of ice floes in a grid cell divided by "//&
+                 "the horizontal floe aspect ratio.  Sensible values are "//&
                  "0 (no rolling) or larger than 1.", units="Nondim", default=1.0)
 
   call get_param(param_file, mdl, "CHECK_ICE_TRANSPORT_CONSERVATION", CS%check_conservation, &
-                 "If true, use add multiple diagnostics of ice and snow \n"//&
-                 "mass conservation in the sea-ice transport code.  This \n"//&
+                 "If true, use add multiple diagnostics of ice and snow "//&
+                 "mass conservation in the sea-ice transport code.  This "//&
                  "is expensive and should be used sparingly.", &
                  default=.false., debuggingParam=.true.)
   call get_param(param_file, mdl, "DO_RIDGING", CS%do_ridging, &
-                 "If true, apply a ridging scheme to the convergent ice. \n"//&
-                 "Otherwise, ice is compressed proportionately if the \n"//&
-                 "concentration exceeds 1.  The original SIS2 implementation \n"//&
+                 "If true, apply a ridging scheme to the convergent ice. "//&
+                 "Otherwise, ice is compressed proportionately if the "//&
+                 "concentration exceeds 1.  The original SIS2 implementation "//&
                  "is based on work by Torge Martin.", default=.false.)
   call get_param(param_file, mdl, "SIS_THICKNESS_ADVECTION_SCHEME", scheme, &
           desc="The horizontal transport scheme for thickness:\n"//&
@@ -1173,18 +1173,18 @@ subroutine SIS_transport_init(Time, G, US, param_file, diag, CS, continuity_CSp,
           "  PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)", &
           default='UPWIND_2D')
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "MERGED_CONTINUITY", merged_cont, &
-               "If true, update the continuity equations for the ice, snow, \n"//&
-               "and melt pond water together summed across categories, with \n"//&
-               "proportionate fluxes for each part. Otherwise the media are \n"//&
+               "If true, update the continuity equations for the ice, snow, "//&
+               "and melt pond water together summed across categories, with "//&
+               "proportionate fluxes for each part. Otherwise the media are "//&
                "updated separately.", default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "INCONSISTENT_COVER_BUG", CS%inconsistent_cover_bug, &
-                 "If true, omit a recalculation of the fractional ice-free \n"//&
+                 "If true, omit a recalculation of the fractional ice-free "//&
                  "areal coverage after the adjustment of the ice categories.", &
                  default=.true., do_not_log=merged_cont)
   if (merged_cont) CS%inconsistent_cover_bug = .false.

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -108,14 +108,14 @@ subroutine ice_ocean_driver_init(CS, Time_init, Time_in)
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "SINGLE_MOM_CALL", CS%single_MOM_call, &
-                 "If true, advance the state of MOM with a single step \n"//&
-                 "including both dynamics and thermodynamics.  If false, \n"//&
+                 "If true, advance the state of MOM with a single step "//&
+                 "including both dynamics and thermodynamics.  If false, "//&
                  "the two phases are advanced with separate calls.", default=.true.)
   call get_param(param_file, mdl, "INTERSPERSE_ICE_OCEAN", CS%intersperse_ice_ocn, &
-                 "If true, intersperse the ice and ocean thermodynamic and \n"//&
+                 "If true, intersperse the ice and ocean thermodynamic and "//&
                  "and dynamic updates.", default=.false.)
   call get_param(param_file, mdl, "DT_COUPLED_ICE_OCEAN_DYN", CS%dt_coupled_dyn, &
-                 "The time step for coupling the ice and ocean dynamics when \n"//&
+                 "The time step for coupling the ice and ocean dynamics when "//&
                  "INTERSPERSE_ICE_OCEAN is true, or <0 to use the coupled timestep.", &
                  units="seconds", default=-1.0, do_not_log=.not.CS%intersperse_ice_ocn)
 

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -132,18 +132,18 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
   ! Read all relevant parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DO_ICE_AGE_AREAL", CS%do_ice_age_areal, &
-      "If true, use an ice age tracer that ages at \n"//&
+      "If true, use an ice age tracer that ages at "//&
       "a unit rate if the ice exists.", &
       default=.false.)
   call get_param(param_file, mdl, "DO_ICE_AGE_MASS", CS%do_ice_age_mass, &
-      "If true, use an ice age tracer that is set to 0 age \n"//&
-      "when ice is first formed, ages at unit rate in the ice pack \n"// &
+      "If true, use an ice age tracer that is set to 0 age "//&
+      "when ice is first formed, ages at unit rate in the ice pack "//&
       "and any new ice added to the ice pack represents a decrease in age", &
       default=.false.)
   call get_param(param_file, mdl, "TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
-      "If true, tracers may go through the initialization code \n"//&
-      "if they are not found in the restart files.  Otherwise \n"//&
-      "it is a fatal error if the tracers are not found in the \n"//&
+      "If true, tracers may go through the initialization code "//&
+      "if they are not found in the restart files.  Otherwise "//&
+      "it is a fatal error if the tracers are not found in the "//&
       "restart files of a restarted run.", default=.false.)
 
   CS%ntr = 0

--- a/src/ice_grid.F90
+++ b/src/ice_grid.F90
@@ -104,10 +104,10 @@ subroutine set_ice_grid(IG, US, param_file, NCat_dflt, ocean_part_min_dflt)
   IG%H_subroundoff = 1.0e-30*US%kg_m3_to_R*US%m_to_Z
 
   call get_param(param_file, mod_nm, "MIN_OCEAN_PARTSIZE", IG%ocean_part_min, &
-                 "The minimum value for the fractional open-ocean area. \n"//&
-                 "This can be 0, but for some purposes it may be useful \n"//&
-                 "to set this to a miniscule value (like 1e-40) that will \n"//&
-                 "be lost to roundoff during any sums so that the open \n"//&
+                 "The minimum value for the fractional open-ocean area. "//&
+                 "This can be 0, but for some purposes it may be useful "//&
+                 "to set this to a miniscule value (like 1e-40) that will "//&
+                 "be lost to roundoff during any sums so that the open "//&
                  "ocean fluxes can be used in with new categories.", &
                  units="nondim", default=opm_dflt)
   if ((IG%ocean_part_min < 0.0) .or. (IG%ocean_part_min > 1.0e-20)) &

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1778,27 +1778,27 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "If true, the ice is specified and there is no dynamics.", &
                  default=.false.)
   call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", Cgrid_dyn, &
-                 "If true, use a C-grid discretization of the sea-ice \n"//&
+                 "If true, use a C-grid discretization of the sea-ice "//&
                  "dynamics; if false use a B-grid discretization.", &
                  default=.false.)
   if (specified_ice) then
     slab_ice = .true.
     call log_param(param_file, mdl, "USE_SLAB_ICE", slab_ice, &
-                 "Use the very old slab-style ice.  With SPECIFIED_ICE, \n"//&
+                 "Use the very old slab-style ice.  With SPECIFIED_ICE, "//&
                  "USE_SLAB_ICE is always true.")
   else
     call get_param(param_file, mdl, "USE_SLAB_ICE", slab_ice, &
                  "If true, use the very old slab-style ice.", default=.false.)
   endif
   call get_param(param_file, mdl, "SINGLE_ICE_STATE_TYPE", single_IST, &
-                 "If true, the fast and slow portions of the ice use a \n"//&
-                 "single common ice_state_type.  Otherwise they point to \n"//&
-                 "different ice_state_types that need to be explicitly \n"//&
+                 "If true, the fast and slow portions of the ice use a "//&
+                 "single common ice_state_type.  Otherwise they point to "//&
+                 "different ice_state_types that need to be explicitly "//&
                  "copied back and forth.", default=.true.)
   call get_param(param_file, mdl, "EULERIAN_TSURF", Eulerian_tsurf, &
-                 "If true, use previous calculations of the ice-top surface \n"//&
-                 "skin temperature for tsurf at the start of atmospheric \n"//&
-                 "time stepping, including interpolating between tsurf \n"//&
+                 "If true, use previous calculations of the ice-top surface "//&
+                 "skin temperature for tsurf at the start of atmospheric "//&
+                 "time stepping, including interpolating between tsurf "//&
                  "values from other categories in the same location.", default=.true.)
 
   call obsolete_logical(param_file, "SIS1_5L_THERMODYNAMICS", warning_val=.false.)
@@ -1807,10 +1807,10 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
   dflt_stagger = "B" ; if (Cgrid_dyn) dflt_stagger = "C"
   call get_param(param_file, mdl, "ICE_OCEAN_STRESS_STAGGER", stagger, &
-                 "A case-insensitive character string to indicate the \n"//&
-                 "staggering of the stress field on the ocean that is \n"//&
-                 "returned to the coupler.  Valid values include \n"//&
-                 "'A', 'B', or 'C', with a default that follows the \n"//&
+                 "A case-insensitive character string to indicate the "//&
+                 "staggering of the stress field on the ocean that is "//&
+                 "returned to the coupler.  Valid values include "//&
+                 "'A', 'B', or 'C', with a default that follows the "//&
                  "value of CGRID_ICE_DYNAMICS.", default=dflt_stagger)
 
   ! Rho_ocean is not actually used here, but it used from later get_param
@@ -1834,24 +1834,24 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "The default momentum roughness length scale for the ocean.", &
                  units="m", default=1.0e-4)
   call get_param(param_file, mdl, "HEAT_ROUGH_ICE", heat_rough_ice, &
-                 "The default roughness length scale for the turbulent \n"//&
+                 "The default roughness length scale for the turbulent "//&
                  "transfer of heat into the ocean.", units="m", default=1.0e-4)
 
   call get_param(param_file, mdl, "CONSTANT_COSZEN_IC", coszen_IC, &
-                 "A constant value to use to initialize the cosine of \n"//&
-                 "the solar zenith angle for the first radiation step, \n"//&
+                 "A constant value to use to initialize the cosine of "//&
+                 "the solar zenith angle for the first radiation step, "//&
                  "or a negative number to use the current time and astronomy.", &
                  units="nondim", default=-1.0)
   call get_param(param_file, mdl, "DT_RADIATION", dt_Rad_real, &
-                 "The time step with which the shortwave radiation and \n"//&
-                 "fields like albedos are updated.  Currently this is only \n"//&
+                 "The time step with which the shortwave radiation and "//&
+                 "fields like albedos are updated.  Currently this is only "//&
                  "used to initialize albedos when there is no restart file.", &
                  units="s", default=time_type_to_real(Time_step_slow))
   dt_Rad = real_to_time(dt_Rad_real)
   call get_param(param_file, mdl, "ICE_KMELT", kmelt, &
-                 "A constant giving the proportionality of the ocean/ice \n"//&
-                 "base heat flux to the tempature difference, given by \n"//&
-                 "the product of the heat capacity per unit volume of sea \n"//&
+                 "A constant giving the proportionality of the ocean/ice "//&
+                 "base heat flux to the tempature difference, given by "//&
+                 "the product of the heat capacity per unit volume of sea "//&
                  "water times a molecular diffusive piston velocity.", &
                  units="W m-2 K-1", scale=US%W_m2_to_QRZ_T, default=6e-5*4e6)
   !### This parameter appears to be unused and should be obsoleted.
@@ -1859,17 +1859,17 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "The conductivity of heat in snow.", units="W m-1 K-1", &
                  default=0.31)
   call get_param(param_file, mdl, "COLUMN_CHECK", column_check, &
-                 "If true, add code to allow debugging of conservation \n"//&
-                 "column-by-column.  This does not change answers, but \n"//&
+                 "If true, add code to allow debugging of conservation "//&
+                 "column-by-column.  This does not change answers, but "//&
                  "can increase model run time.", default=.false., &
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "IMBALANCE_TOLERANCE", imb_tol, &
                  "The tolerance for imbalances to be flagged by COLUMN_CHECK.", &
                  units="nondim", default=1.0e-9, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, &
@@ -1882,8 +1882,8 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "If true, write out verbose debugging data on the fast ice PEs.", &
                  default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "GLOBAL_INDEXING", global_indexing, &
-                 "If true, use a global lateral indexing convention, so \n"//&
-                 "that corresponding points on different processors have \n"//&
+                 "If true, use a global lateral indexing convention, so "//&
+                 "that corresponding points on different processors have "//&
                  "the same index. This does not work with static memory.", &
                  default=.false., layoutParam=.true.)
 #ifdef STATIC_MEMORY_
@@ -1891,34 +1891,34 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
        "GLOBAL_INDEXING can not be true with STATIC_MEMORY.")
 #endif
   call get_param(param_file, mdl, "FIRST_DIRECTION", first_direction, &
-                 "An integer that indicates which direction goes first \n"//&
-                 "in parts of the code that use directionally split \n"//&
-                 "updates, with even numbers (or 0) used for x- first \n"//&
+                 "An integer that indicates which direction goes first "//&
+                 "in parts of the code that use directionally split "//&
+                 "updates, with even numbers (or 0) used for x- first "//&
                  "and odd numbers used for y-first.", default=0)
 
   call get_param(param_file, mdl, "ICE_SEES_ATMOS_WINDS", atmos_winds, &
-                 "If true, the sea ice is being given wind stresses with \n"//&
-                 "the atmospheric sign convention, and need to have their \n"//&
-                 "sign changed.", default=.true.)
+                 "If true, the sea ice is being given wind stresses with "//&
+                 "the atmospheric sign convention, and need to have their sign changed.", &
+                 default=.true.)
   call get_param(param_file, mdl, "ICE_BULK_SALINITY", ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", units = "g/kg", &
                  default=4.0, do_not_log=.true.)
   call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
-                 "The initial salinity of sea ice as a fraction of the \n"//&
+                 "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
                  units = "nondim", default=0.0, do_not_log=.true.)
   if ((ice_bulk_salin < 0.0) .or. (ice_rel_salin > 0.0)) ice_bulk_salin = 0.0
 
   call get_param(param_file, mdl, "APPLY_SLP_TO_OCEAN", slp2ocean, &
-                 "If true, apply the atmospheric sea level pressure to \n"//&
-                 "the ocean.", default=.false.)
+                 "If true, apply the atmospheric sea level pressure to the ocean.", &
+                 default=.false.)
   call get_param(param_file, mdl, "PASS_STRESS_MAG_TO_OCEAN", pass_stress_mag, &
-                 "If true, provide the time and area weighted mean magnitude \n"//&
+                 "If true, provide the time and area weighted mean magnitude "//&
                  "of the stresses on the ocean to the ocean.", default=.false.)
   !### This parameter is not used here, although a similar parameter is used elsewhere.
   call get_param(param_file, mdl, "MIN_H_FOR_TEMP_CALC", h_lo_lim, &
-                 "The minimum ice thickness at which to do temperature \n"//&
-                 "calculations.", units="m", default=0.0)
+                 "The minimum ice thickness at which to do temperature calculations.", &
+                 units="m", default=0.0)
   call get_param(param_file, mdl, "DO_ICEBERGS", do_icebergs, &
                  "If true, call the iceberg module.", default=.false.)
   if (do_icebergs) then
@@ -1927,10 +1927,10 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   else ; pass_iceberg_area_to_ocean = .false. ; endif
 
   call get_param(param_file, mdl, "ADD_DIURNAL_SW", add_diurnal_sw, &
-                 "If true, add a synthetic diurnal cycle to the shortwave \n"//&
-                 "radiation.", default=.false.)
+                 "If true, add a synthetic diurnal cycle to the shortwave radiation.", &
+                 default=.false.)
   call get_param(param_file, mdl, "DO_SUN_ANGLE_FOR_ALB", do_sun_angle_for_alb, &
-                 "If true, find the sun angle for calculating the ocean \n"//&
+                 "If true, find the sun angle for calculating the ocean "//&
                  "albedo within the sea ice model.", default=.false.)
   call get_param(param_file, mdl, "DO_RIDGING", do_ridging, &
                  "If true, call the ridging routines.", default=.false.)
@@ -1939,17 +1939,16 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "The name of the restart file.", default="ice_model.res.nc")
   if (fast_ice_PE.eqv.slow_ice_PE) then
     call get_param(param_file, mdl, "FAST_ICE_RESTARTFILE", fast_rest_file, &
-                   "The name of the restart file for those elements of the \n"//&
-                   "the sea ice that are handled by the fast ice PEs.", &
-                   default=restart_file)
+                   "The name of the restart file for those elements of the "//&
+                   "the sea ice that are handled by the fast ice PEs.", default=restart_file)
   else
     call get_param(param_file, mdl, "FAST_ICE_RESTARTFILE", fast_rest_file, &
-                   "The name of the restart file for those elements of the \n"//&
+                   "The name of the restart file for those elements of the "//&
                    "the sea ice that are handled by the fast ice PEs.", &
                    default="ice_model_fast.res.nc")
   endif
   call get_param(param_file, mdl, "APPLY_MASKS_AFTER_RESTART", do_mask_restart, &
-                 "If true, applies masks to mH_ice,mH_snow and part_size after a restart.",&
+                 "If true, applies masks to mH_ice,mH_snow and part_size after a restart.", &
                   default=.true.)
 
   call get_param(param_file, mdl, "MASSLESS_ICE_ENTH", massless_ice_enth, &
@@ -1962,16 +1961,16 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "The ice salinity fill value for massless categories.", &
                  units="g kg-1", default=0.0, do_not_log=.true.)
   call get_param(param_file, "MOM", "WRITE_GEOM", write_geom, &
-                 "If =0, never write the geometry and vertical grid files.\n"//&
-                 "If =1, write the geometry and vertical grid files only for\n"//&
-                 "a new simulation. If =2, always write the geometry and\n"//&
+                 "If =0, never write the geometry and vertical grid files. "//&
+                 "If =1, write the geometry and vertical grid files only for "//&
+                 "a new simulation. If =2, always write the geometry and "//&
                  "vertical grid files. Other values are invalid.", default=1)
   call get_param(param_file, "MOM", "INTERPOLATE_FLUXES", interp_fluxes, &
-                 "If true, interpolate a linearized version of the fast \n"//&
+                 "If true, interpolate a linearized version of the fast "//&
                  "fluxes into arealess categories.", default=.true.)
   call get_param(param_file, "MOM", "REDO_FAST_ICE_UPDATE", redo_fast_update, &
-                 "If true, recalculate the thermal updates from the fast \n"//&
-                 "dynamics on the slowly evolving ice state, rather than \n"//&
+                 "If true, recalculate the thermal updates from the fast "//&
+                 "dynamics on the slowly evolving ice state, rather than "//&
                  "copying over the slow ice state to the fast ice state.", default=Concurrent)
   if (write_geom<0 .or. write_geom>2) call SIS_error(FATAL,"SIS2: "//&
          "WRITE_GEOM must be equal to 0, 1 or 2.")
@@ -2627,9 +2626,9 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   ! Initialize icebergs
     if (Ice%sCS%do_icebergs) then
       call get_param(param_file, mdl, "ICEBERG_WINDSTRESS_BUG", Ice%sCS%berg_windstress_bug, &
-                 "If true, use older code that applied an old ice-ocean \n"//&
-                 "stress to the icebergs in place of the current air-ocean \n"//&
-                 "stress.  This option is here for backward compatibility, \n"//&
+                 "If true, use older code that applied an old ice-ocean "//&
+                 "stress to the icebergs in place of the current air-ocean "//&
+                 "stress.  This option is here for backward compatibility, "//&
                  "but should be avoided.", default=.false.)
 
       isc = sG%isc ; iec = sG%iec ; jsc = sG%jsc ; jec = sG%jec

--- a/src/specified_ice.F90
+++ b/src/specified_ice.F90
@@ -262,7 +262,7 @@ subroutine specified_ice_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
                  "The time unit for ICE_STATS_INTERVAL.", &
                  units="s", default=86400.0)
   call get_param(param_file, mdl, "ICE_STATS_INTERVAL", CS%ice_stats_interval, &
-                 "The interval in units of TIMEUNIT between writes of the \n"//&
+                 "The interval in units of TIMEUNIT between writes of the "//&
                  "globally summed ice statistics and conservation checks.", &
                  default=real_to_time(86400.0), timeunit=Time_unit)
 
@@ -273,9 +273,9 @@ subroutine specified_ice_init(Time, G, IG, param_file, diag, CS, output_dir, Tim
                  "If true, write out verbose debugging data on the slow ice PEs.", &
                  default=debug, debuggingParam=.true.)
   call get_param(param_file, mdl, "ICE_BOUNDS_CHECK", CS%bounds_check, &
-                 "If true, periodically check the values of ice and snow \n"//&
-                 "temperatures and thicknesses to ensure that they are \n"//&
-                 "sensible, and issue warnings if they are not.  This \n"//&
+                 "If true, periodically check the values of ice and snow "//&
+                 "temperatures and thicknesses to ensure that they are "//&
+                 "sensible, and issue warnings if they are not.  This "//&
                  "does not change answers, but can increase model run time.", &
                  default=.true.)
 


### PR DESCRIPTION
  Removed hard-coded newline symbols from most SIS2 parameter descriptions in
calls to get_param or log_param, instead allowing these routines to format the
output automatically.  All answers are bitwise identical, but there are changes
in many of the variable descriptions in the SIS_parameter_doc files.