### PR TITLE
(*)Updated SIS2 parameter defaults

### DIFF
--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -2122,7 +2122,7 @@ subroutine SIS_dyn_trans_register_restarts(mpp_domain, HI, IG, param_file, CS, &
   endif
   allocate(CS)
 
-  CS%Cgrid_dyn = .false. ; call read_param(param_file, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn)
+  CS%Cgrid_dyn = .true. ; call read_param(param_file, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn)
 
   if (CS%Cgrid_dyn) then
     call SIS_C_dyn_register_restarts(mpp_domain, HI, param_file, &
@@ -2203,7 +2203,7 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
   call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn, &
                  "If true, use a C-grid discretization of the sea-ice "//&
                  "dynamics; if false use a B-grid discretization.", &
-                 default=.false.)
+                 default=.true.)
   call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt_ice_dyn, &
                  "The time step used for the slow ice dynamics, including "//&
                  "stepping the continuity equation and interactions "//&

--- a/src/SIS_optics.F90
+++ b/src/SIS_optics.F90
@@ -101,10 +101,10 @@ subroutine SIS_optics_init(param_file, US, CS, slab_optics)
                  "shortwave radiation calculation.", default=.false.)
   call get_param(param_file, mdl, "MIN_POND_FRAC", CS%min_pond_frac, &
                  "Minimum melt pond cover (by ponds at sea level) "//&
-                 "pond drains to this when ice is porous.", default=0.2)
+                 "pond drains to this when ice is porous.", default=0.2, units="nondim")
   call get_param(param_file, mdl, "MAX_POND_FRAC", CS%max_pond_frac, &
                  "Maximum melt pond cover - associated with pond volume "//&
-                 "that suppresses ice top to waterline", default=0.5)
+                 "that suppresses ice top to waterline", default=0.5, units="nondim")
 
   call get_param(param_file, mdl, "ICE_DELTA_EDD_R_ICE", deltaEdd_R_ice, &
                  "A dreadfully documented tuning parameter for the radiative "//&

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -1845,7 +1845,7 @@ subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
                  "If true use a globally constant negligible volume in the denominator of the "//&
                  "tracer advection CFL calculation, reproducing an older incorrect expression, "//&
                  "rather than using a proper scaling of this negligible mass with cell area.", &
-                 default=.true.)
+                 default=.false.)
 
   if (first_call) then
     id_clock_advect = cpu_clock_id('(Ocean advect tracer)', grain=CLOCK_MODULE)

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1186,7 +1186,7 @@ subroutine SIS_transport_init(Time, G, US, param_file, diag, CS, continuity_CSp,
   call get_param(param_file, mdl, "INCONSISTENT_COVER_BUG", CS%inconsistent_cover_bug, &
                  "If true, omit a recalculation of the fractional ice-free "//&
                  "areal coverage after the adjustment of the ice categories.", &
-                 default=.true., do_not_log=merged_cont)
+                 default=.false., do_not_log=merged_cont)
   if (merged_cont) CS%inconsistent_cover_bug = .false.
   call obsolete_logical(param_file, "ADVECT_TSURF", warning_val=.false.)
   call obsolete_real(param_file, "ICE_CHANNEL_VISCOSITY", warning_val=0.0)

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -125,7 +125,7 @@ subroutine ice_ocean_driver_init(CS, Time_init, Time_in)
 !  call get_param(param_file, mdl, "TIMEUNIT", Time_unit, &
 !                 "The time unit for ENERGYSAVEDAYS.", units="s", default=86400.0)
 
-  call close_param_file(param_file)
+  call close_param_file(param_file, component="CIOD")
   CS%CS_is_initialized = .true.
 
   call callTree_leave("ice_ocean_driver_init(")

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1769,7 +1769,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   call get_param(param_file, mdl, "CGRID_ICE_DYNAMICS", Cgrid_dyn, &
                  "If true, use a C-grid discretization of the sea-ice "//&
                  "dynamics; if false use a B-grid discretization.", &
-                 default=.false.)
+                 default=.true.)
   if (specified_ice) then
     slab_ice = .true.
     call log_param(param_file, mdl, "USE_SLAB_ICE", slab_ice, &
@@ -2580,7 +2580,12 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   !but it should be called after restore_state() otherwise it causes a restart mismatch
   call nullify_domain()
 
-  call close_param_file(param_file)
+  ! Close the parameter file, supplying information for logging the default values.
+  if (slow_ice_PE) then
+    call close_param_file(param_file, component='SIS')
+  else
+    call close_param_file(param_file, component='SIS_fast')
+  endif
 
   ! Ice%xtype can be REDIST or DIRECT, depending on the relationship between
   ! the fast and slow ice PEs.  REDIST should always work but may be slower.


### PR DESCRIPTION
  Updated the default values for CGRID_ICE_DYNAMICS (to "C") and
INCONSISTENT_COVER_BUGS and CFL_MASS_NEGLECT_BUG to false, and made the
documented units of MIN_POND_FRAC and MAX_POND_FRAC consistent across the SIS2
code.  In addition, component arguments were added to the close_param_file calls
so that the parameter file defaults are properly documented.  By design, all
solutions in the MOM6-examples test suite are bitwise identical, but answers can
change for other cases, and there are changes in the SIS_parameter_doc files.