### PR TITLE
SIS2: +Add options to restrict tiny ice transports

### DIFF
--- a/src/SIS_continuity.F90
+++ b/src/SIS_continuity.F90
@@ -40,17 +40,19 @@ type, public :: SIS_continuity_CS ; private
                              !! timing of diagnostic output.
   logical :: use_upwind2d    !< If true, use the non-split upwind scheme that was
                              !! used in older versions of SIS.
-  logical :: upwind_1st      !< If true, use a directionally-split first-order
-                             !! upwind scheme.
-  logical :: monotonic       !< If true, use the Colella & Woodward monotonic
-                             !! limiter; otherwise use a simple positive
-                             !! definite limiter.
-  logical :: simple_2nd      !< If true, use a simple second order (arithmetic
-                             !! mean) interpolation of the edge values instead
-                             !! of the higher order interpolation.
-  logical :: vol_CFL         !< If true, use the ratio of the open face lengths
-                             !! to the tracer cell areas when estimating CFL
-                             !! numbers.
+  logical :: upwind_1st      !< If true, use a directionally-split first-order upwind scheme.
+  logical :: monotonic       !< If true, use the Colella & Woodward monotonic limiter;
+                             !! otherwise use a simple positive definite limiter.
+  logical :: simple_2nd      !< If true, use a simple second order (arithmetic mean) interpolation
+                             !! of the edge values instead of the higher order interpolation.
+  logical :: vol_CFL         !< If true, use the ratio of the open face lengths to the tracer
+                             !! cell areas when estimating CFL numbers.
+  real :: h_neglect_cont     !< The category ice mass per ocean cell area below which the
+                             !! transport within this thickness category of out of a cell is
+                             !! set to zero [R Z ~> kg m-2]
+  real :: frac_neglect       !< When the total fluxes are distributed between categories, any
+                             !! category whose ice is less than this fraction of the total mass
+                             !! contributes no flux [nondim]
 end type SIS_continuity_CS
 
 !> This type is used to specify the active loop bounds
@@ -64,7 +66,7 @@ contains
 
 !> ice_continuity time steps the category thickness changes due to advection,
 !! using a monotonically limited, directionally split PPM scheme.
-subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
+subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS, use_h_neg, masking_uh, masking_vh)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZIB_(G),SZJ_(G)), &
@@ -85,13 +87,23 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
   type(unit_scale_type),   intent(in)    :: US  !< A structure with unit conversion factors
   type(SIS_continuity_CS), pointer       :: CS  !< The control structure returned by a
                                                 !! previous call to SIS_continuity_init.
+  logical,       optional, intent(in)    :: use_h_neg !< If true, only move mass out of a cell if it
+                                                !! is thicker than CS%h_neglect_cont.
+  real, dimension(SZIB_(G),SZJ_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_uh  !< If this is 0, uh = 0.  Often this is another
+                                                !! zonal mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
+                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+
 !    This subroutine time steps the category thicknesses, using a monotonically
 !  limit, directionally split PPM scheme, based on Lin (1994).  In the following
 !  documentation, H is used for the units of thickness (usually m or kg m-2.)
 
   ! Local variables
   type(loop_bounds_type) :: LB  ! A structure with the active loop bounds.
-  real    :: h_up
+  real    :: h_up ! The upwind thickness [R Z ~> kg m-2]
+  logical :: apply_h_neg
   integer :: is, ie, js, je, nCat, stensil
   integer :: i, j, k
 
@@ -101,6 +113,11 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
   if (.not.associated(CS)) call SIS_error(FATAL, &
          "SIS_continuity: Module must be initialized before it is used.")
   x_first = (MOD(G%first_direction,2) == 0)
+
+  apply_h_neg = .false.
+  if (present(use_h_neg)) then
+    apply_h_neg = ((use_h_neg) .and. (CS%h_neglect_cont > 0.0))
+  endif
 
   stensil = 3 ; if (CS%simple_2nd) stensil = 2 ; if (CS%upwind_1st) stensil = 1
 
@@ -115,13 +132,19 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
     do j=js,je ; do k=1,nCat ; do I=is-1,ie
       if (u(I,j) >= 0.0) then ; h_up = hin(i,j,k)
       else ; h_up = hin(i+1,j,k) ; endif
+      if (apply_h_neg .and. (h_up < CS%h_neglect_cont)) h_up = 0.0
+
       uh(I,j,k) = G%dy_Cu(I,j) * u(I,j) * h_up
+      if (present(masking_uh)) then ; if (masking_uh(I,j,k) == 0.0) uh(I,j,k) = 0.0 ; endif
     enddo ; enddo ; enddo
     !$OMP do
     do J=js-1,je ; do k=1,nCat ; do i=is,ie
       if (v(i,J) >= 0.0) then ; h_up = hin(i,j,k)
       else ; h_up = hin(i,j+1,k) ; endif
+      if (apply_h_neg .and. (h_up < CS%h_neglect_cont)) h_up = 0.0
+
       vh(i,J,k) = G%dx_Cv(i,J) * v(i,J) * h_up
+      if (present(masking_vh)) then ; if (masking_vh(i,J,k) == 0.0) vh(i,J,k) = 0.0 ; endif
     enddo ; enddo ; enddo
     !$OMP do
     do j=js,je ; do k=1,nCat ; do i=is,ie
@@ -137,7 +160,12 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
   !    First, advect zonally.
     LB%ish = G%isc ; LB%ieh = G%iec
     LB%jsh = G%jsc-stensil ; LB%jeh = G%jec+stensil
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, hin, uh)
+    if (apply_h_neg) then
+      call zonal_mass_flux(u, dt, G, US, IG, CS, LB, hin, uh, &
+                           h_mobilize=CS%h_neglect_cont, masking_uh=masking_uh)
+    else
+      call zonal_mass_flux(u, dt, G, US, IG, CS, LB, hin, uh, masking_uh=masking_uh)
+    endif
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -154,7 +182,12 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
 
   !    Now advect meridionally, using the updated thicknesses to determine
   !  the fluxes.
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, h, vh)
+    if (apply_h_neg) then
+      call meridional_mass_flux(v, dt, G, US, IG, CS, LB, h, vh, &
+                                h_mobilize=CS%h_neglect_cont, masking_vh=masking_vh)
+    else
+      call meridional_mass_flux(v, dt, G, US, IG, CS, LB, h, vh, masking_vh=masking_vh)
+    endif
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -172,7 +205,12 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
     LB%ish = G%isc-stensil ; LB%ieh = G%iec+stensil
     LB%jsh = G%jsc ; LB%jeh = G%jec
 
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, hin, vh)
+    if (apply_h_neg) then
+      call meridional_mass_flux(v, dt, G, US, IG, CS, LB, hin, vh, &
+                                h_mobilize=CS%h_neglect_cont, masking_vh=masking_vh)
+    else
+      call meridional_mass_flux(v, dt, G, US, IG, CS, LB, hin, vh, masking_vh=masking_vh)
+    endif
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -188,7 +226,12 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS)
   !    Now advect zonally, using the updated thicknesses to determine
   !  the fluxes.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, h, uh)
+    if (apply_h_neg) then
+      call zonal_mass_flux(u, dt, G, US, IG, CS, LB, h, uh, &
+                           h_mobilize=CS%h_neglect_cont, masking_uh=masking_uh)
+    else
+      call zonal_mass_flux(u, dt, G, US, IG, CS, LB, h, uh, masking_uh=masking_uh)
+    endif
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -207,7 +250,7 @@ end subroutine ice_continuity
 
 
 !> ice_cover_transport advects the total fractional ice cover and limits them not to exceed 1.
-subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
+subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS, masking_uhtot, masking_vhtot)
   type(SIS_hor_grid_type),           intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),               intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZIB_(G),SZJ_(G)), intent(in)    :: u   !< Zonal ice velocity [L T-1 ~> m s-1].
@@ -217,6 +260,12 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
   type(unit_scale_type),             intent(in)    :: US  !< A structure with unit conversion factors
   type(SIS_continuity_CS),           pointer       :: CS  !< The control structure returned by a
                                                           !! previous call to SIS_continuity_init.
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           optional, intent(in)    :: masking_uhtot !< If this zonal mass flux is 0, the
+                                                          !! ice-cover u-transport is 0 [R Z L2 T-1 ~> kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), &
+                           optional, intent(in)    :: masking_vhtot !< If this meridional mass flux is 0, the
+                                                          !! ice-cover v-transport is 0 [R Z L2 T-1 ~> kg s-1].
 
   ! Local variables
   type(loop_bounds_type) :: LB  ! A structure with the active loop bounds.
@@ -247,12 +296,14 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
       if (u(I,j) >= 0.0) then ; cvr_up = cvr(i,j)
       else ; cvr_up = cvr(i+1,j) ; endif
       ucvr(I,j) = G%dy_Cu(I,j) * u(I,j) * cvr_up
+      if (present(masking_uhtot)) then ; if (masking_uhtot(I,j) == 0.0) ucvr(I,j) = 0.0 ; endif
     enddo ; enddo
     !$OMP do
     do J=js-1,je ; do i=is,ie
       if (v(i,J) >= 0.0) then ; cvr_up = cvr(i,j)
       else ; cvr_up = cvr(i,j+1) ; endif
       vcvr(i,J) = G%dx_Cv(i,J) * v(i,J) * cvr_up
+      if (present(masking_vhtot)) then ; if (masking_vhtot(i,J) == 0.0) vcvr(i,J) = 0.0 ; endif
     enddo ; enddo
     !$OMP do
     do j=js,je ; do i=is,ie
@@ -265,7 +316,7 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
   elseif (x_first) then
     ! First, advect zonally.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc-stensil ; LB%jeh = G%jec+stensil
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=cvr, uh_tot=ucvr)
+    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=cvr, uh_tot=ucvr, masking_uhtot=masking_uhtot)
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -278,7 +329,7 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
 
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
     ! Now advect meridionally, using the updated ice covers to determine the fluxes.
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=cvr, vh_tot=vcvr)
+    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=cvr, vh_tot=vcvr, masking_vhtot=masking_vhtot)
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -292,7 +343,7 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
   else  ! .not. x_first
     !  First, advect meridionally, so set the loop bounds accordingly.
     LB%ish = G%isc-stensil ; LB%ieh = G%iec+stensil ; LB%jsh = G%jsc ; LB%jeh = G%jec
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=cvr, vh_tot=vcvr)
+    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=cvr, vh_tot=vcvr, masking_vhtot=masking_vhtot)
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -305,7 +356,7 @@ subroutine ice_cover_transport(u, v, cvr, dt, G, US, IG, CS)
 
     ! Now advect zonally, using the updated ice covers to determine the fluxes.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=cvr, uh_tot=ucvr)
+    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=cvr, uh_tot=ucvr, masking_uhtot=masking_uhtot)
 
     call cpu_clock_begin(id_clock_update)
     !$OMP parallel do default(shared)
@@ -345,7 +396,6 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(inout) :: h_ice  !< Total ice mass per unit cell
                                                          !! area [R Z ~> kg m-2].  h_ice must not exceed h.
 
-
   ! Local variables
   type(loop_bounds_type) :: LB  ! A structure with the active loop bounds.
   real, dimension(SZIB_(G),SZJ_(G)) :: uh_ice ! Ice mass flux through zonal faces = u*h*dy
@@ -380,12 +430,14 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
     do j=js,je ; do I=is-1,ie
       if (u(I,j) >= 0.0) then ; h_up = h_in(i,j)
       else ; h_up = h_in(i+1,j) ; endif
+      if (h_up < IG%CatIce*CS%h_neglect_cont) h_up = 0.0
       uh(I,j) = G%dy_Cu(I,j) * u(I,j) * h_up
     enddo ; enddo
     !$OMP do
     do J=js-1,je ; do i=is,ie
       if (v(i,J) >= 0.0) then ; h_up = h_in(i,j)
       else ; h_up = h_in(i,j+1) ; endif
+      if (h_up < IG%CatIce*CS%h_neglect_cont) h_up = 0.0
       vh(i,J) = G%dx_Cv(i,J) * v(i,J) * h_up
     enddo ; enddo
     if (present(h_ice)) then
@@ -421,7 +473,7 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
   elseif (x_first) then
     ! First, advect zonally.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc-stensil ; LB%jeh = G%jec+stensil
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=h_in, uh_tot=uh)
+    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=h_in, uh_tot=uh, h_mobilize=CS%h_neglect_cont)
 
     call cpu_clock_begin(id_clock_update)
 
@@ -452,7 +504,7 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
 
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
     ! Now advect meridionally, using the updated thicknesses to determine the fluxes.
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=h, vh_tot=vh)
+    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=h, vh_tot=vh, h_mobilize=CS%h_neglect_cont)
 
     call cpu_clock_begin(id_clock_update)
     if (present(h_ice)) then
@@ -482,7 +534,7 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
   else  ! .not. x_first
     !  First, advect meridionally, so set the loop bounds accordingly.
     LB%ish = G%isc-stensil ; LB%ieh = G%iec+stensil ; LB%jsh = G%jsc ; LB%jeh = G%jec
-    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=h_in, vh_tot=vh)
+    call meridional_mass_flux(v, dt, G, US, IG, CS, LB, htot_in=h_in, vh_tot=vh, h_mobilize=CS%h_neglect_cont)
 
     call cpu_clock_begin(id_clock_update)
     if (present(h_ice)) then
@@ -511,7 +563,7 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
 
     !  Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
-    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=h, uh_tot=uh)
+    call zonal_mass_flux(u, dt, G, US, IG, CS, LB, htot_in=h, uh_tot=uh, h_mobilize=CS%h_neglect_cont)
 
     call cpu_clock_begin(id_clock_update)
 
@@ -593,7 +645,7 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
   real, dimension(SZI_(G),SZJ_(G)) :: h_tot  ! Total thicknesses [R Z ~> kg m-2].
   real, dimension(SZI_(G),SZJ_(G)) :: I_htot ! The Adcroft reciprocal of the total thicknesses [R-1 Z-1 ~> m2 kg-1].
   type(loop_bounds_type) :: LB  ! A structure with the active loop bounds.
-  real    :: h_up
+  logical :: do_mask  ! If true, mask very small fluxes.
   integer :: is, ie, js, je, nCat, stensil
   integer :: i, j, k
 
@@ -603,6 +655,8 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
   if (.not.associated(CS)) call SIS_error(FATAL, &
          "SIS_continuity: Module must be initialized before it is used.")
   x_first = (MOD(G%first_direction,2) == 0)
+
+  do_mask = ((CS%h_neglect_cont > 0.0) .or. (CS%frac_neglect > 0.0))
 
   do j=js,je ; do i=is,ie ; if (h_tot_in(i,j) < 0.0) then
     call SIS_error(FATAL, 'Negative thickness input to proportionate_continuity().')
@@ -618,8 +672,13 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
 
     if (present(h1)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
-      call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h1(i,j,k) = h1(i,j,k) - G%IareaT(i,j) * (dt * &
@@ -627,8 +686,13 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
       enddo ; enddo ; enddo
     endif
     if (present(h2)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
-      call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB, masking_uh=uh1)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB, masking_vh=vh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h2(i,j,k) = h2(i,j,k) - G%IareaT(i,j) * (dt * &
@@ -636,8 +700,13 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
       enddo ; enddo ; enddo
     endif
     if (present(h3)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
-      call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB, masking_uh=uh1)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB, masking_vh=vh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h3(i,j,k) = h3(i,j,k) - G%IareaT(i,j) * (dt * &
@@ -649,21 +718,33 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
     ! First, advect zonally.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc-1 ; LB%jeh = G%jec+1
     if (present(h1)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h1(i,j,k) = h1(i,j,k) - G%IareaT(i,j) * (dt * (uh1(I,j,k) - uh1(I-1,j,k)))
       enddo ; enddo ; enddo
     endif
     if (present(h2)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB, masking_uh=uh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h2(i,j,k) = h2(i,j,k) - G%IareaT(i,j) * (dt * (uh2(I,j,k) - uh2(I-1,j,k)))
       enddo ; enddo ; enddo
     endif
     if (present(h3)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB, masking_uh=uh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h3(i,j,k) = h3(i,j,k) - G%IareaT(i,j) * (dt * (uh3(I,j,k) - uh3(I-1,j,k)))
@@ -681,21 +762,33 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
     !  Now advect meridionally, using the updated thicknesses to determine the fluxes.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
     if (present(h1)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      endif
      !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h1(i,j,k) = h1(i,j,k) - G%IareaT(i,j) * (dt * (vh1(i,J,k) - vh1(i,J-1,k)) )
       enddo ; enddo ; enddo
     endif
     if (present(h2)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB, masking_vh=vh1)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h2(i,j,k) = h2(i,j,k) - G%IareaT(i,j) * (dt * (vh2(i,J,k) - vh2(i,J-1,k)) )
       enddo ; enddo ; enddo
     endif
     if (present(h3)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB, masking_vh=vh1)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h3(i,j,k) = h3(i,j,k) - G%IareaT(i,j) * (dt * (vh3(i,J,k) - vh3(i,J-1,k)) )
@@ -715,22 +808,34 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
     LB%ish = G%isc-1 ; LB%ieh = G%iec+1 ; LB%jsh = G%jsc ; LB%jeh = G%jec
 
     if (present(h1)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h1, vh1, G, IG, LB)
+      endif
      !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h1(i,j,k) = h1(i,j,k) - G%IareaT(i,j) * (dt * (vh1(i,J,k) - vh1(i,J-1,k)) )
       enddo ; enddo ; enddo
     endif
     if (present(h2)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
-     !$OMP parallel do default(shared)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB, masking_vh=vh1)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h2, vh2, G, IG, LB)
+      endif
+      !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h2(i,j,k) = h2(i,j,k) - G%IareaT(i,j) * (dt * (vh2(i,J,k) - vh2(i,J-1,k)) )
       enddo ; enddo ; enddo
     endif
     if (present(h3)) then
-      call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
-     !$OMP parallel do default(shared)
+      if (do_mask) then
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call merid_proportionate_fluxes(vh_tot, I_htot, h3, vh3, G, IG, LB)
+      endif
+      !$OMP parallel do default(shared)
       do j=js,je ; do k=1,nCat ; do i=is,ie
         h3(i,j,k) = h3(i,j,k) - G%IareaT(i,j) * (dt * (vh3(i,J,k) - vh3(i,J-1,k)) )
       enddo ; enddo ; enddo
@@ -744,25 +849,36 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
       I_htot(i,j) = 0.0 ; if (h_tot(i,j) > 0.0) I_htot(i,j) = 1.0 / h_tot(i,j)
     enddo ; enddo
 
-
     ! Now advect zonally, using the updated thicknesses to determine the fluxes.
     LB%ish = G%isc ; LB%ieh = G%iec ; LB%jsh = G%jsc ; LB%jeh = G%jec
     if (present(h1)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB, frac_neglect=CS%frac_neglect)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h1, uh1, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h1(i,j,k) = h1(i,j,k) - G%IareaT(i,j) * (dt * (uh1(I,j,k) - uh1(I-1,j,k)))
       enddo ; enddo ; enddo
     endif
     if (present(h2)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB, masking_uh=uh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h2, uh2, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h2(i,j,k) = h2(i,j,k) - G%IareaT(i,j) * (dt * (uh2(I,j,k) - uh2(I-1,j,k)))
       enddo ; enddo ; enddo
     endif
     if (present(h3)) then
-      call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
+      if (do_mask) then
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB, masking_uh=uh1)
+      else
+        call zonal_proportionate_fluxes(uh_tot, I_htot, h3, uh3, G, IG, LB)
+      endif
       !$OMP parallel do default(shared)
       do j=LB%jsh,LB%jeh ; do k=1,nCat ; do i=LB%ish,LB%ieh
         h3(i,j,k) = h3(i,j,k) - G%IareaT(i,j) * (dt * (uh3(I,j,k) - uh3(I-1,j,k)))
@@ -782,7 +898,7 @@ subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS,
 end subroutine proportionate_continuity
 
 !> Calculate zonal fluxes by category that are proportionate to the relative masses in the upwind cell.
-subroutine zonal_proportionate_fluxes(uh_tot, I_htot, h, uh, G, IG, LB)
+subroutine zonal_proportionate_fluxes(uh_tot, I_htot, h, uh, G, IG, LB, masking_uh, frac_neglect)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: uh_tot !< Total mass flux through zonal faces
@@ -795,22 +911,32 @@ subroutine zonal_proportionate_fluxes(uh_tot, I_htot, h, uh, G, IG, LB)
                            intent(out)   :: uh  !< Category mass flux through zonal faces = u*h*dy.
                                                 !! [R Z L2 T-1 ~> kg s-1].
   type(loop_bounds_type),  intent(in)    :: LB  !< A structure with the active loop bounds.
+  real, dimension(SZIB_(G),SZJ_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_uh  !< If this is 0, uh = 0.  Often this is another
+                                                !! zonal mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+  real,          optional, intent(in)    :: frac_neglect  !< Any category with less than this fraction
+                                                !! of the total transport has no transport [nondim].
 
   ! Local variables
+  real :: frac ! The fraction of the total transport in a category [nondim].
   integer :: i, j, k, ish, ieh, jsh, jeh, nCat
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nCat = IG%CatIce
   !$OMP parallel do default(shared)
   do j=jsh,jeh ; do k=1,nCat ; do I=ish-1,ieh
-    if (uh_tot(I,j) < 0.0) then ; uh(I,j,k) = (h(i+1,j,k) * I_htot(i+1,j)) * uh_tot(I,j)
-    elseif (uh_tot(I,j) > 0.0) then ; uh(I,j,k) = (h(i,j,k) * I_htot(i,j)) * uh_tot(I,j)
-    else ; uh(i,j,k) = 0.0 ; endif
+    frac = 0.0
+    if (uh_tot(I,j) < 0.0) then ; frac = (h(i+1,j,k) * I_htot(i+1,j))
+    elseif (uh_tot(I,j) > 0.0) then ; frac = (h(i,j,k) * I_htot(i,j)) ; endif
+    if (present(masking_uh)) then ; if (masking_uh(I,j,k) == 0.0) frac = 0.0 ; endif
+    if (present(frac_neglect)) then ; if (frac < frac_neglect) frac = 0.0 ; endif
+
+    uh(I,j,k) = frac * uh_tot(I,j)
   enddo ; enddo ; enddo
 
 end subroutine zonal_proportionate_fluxes
 
 !> Calculate meridional mass fluxes by category that are proportionate to the relative masses in the upwind cell.
-subroutine merid_proportionate_fluxes(vh_tot, I_htot, h, vh, G, IG, LB)
+subroutine merid_proportionate_fluxes(vh_tot, I_htot, h, vh, G, IG, LB, masking_vh, frac_neglect)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZI_(G),SZJB_(G)), intent(in) :: vh_tot !< Total mass flux through meridional faces
@@ -823,23 +949,34 @@ subroutine merid_proportionate_fluxes(vh_tot, I_htot, h, vh, G, IG, LB)
                            intent(out)   :: vh  !< Category mass flux through meridional faces = v*h*dx
                                                 !! [R Z L2 T-1 ~> kg s-1].
   type(loop_bounds_type),  intent(in)    :: LB  !< A structure with the active loop bounds.
+  real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
+                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+  real,          optional, intent(in)    :: frac_neglect  !< Any category with less than this fraction
+                                                !! of the total transport has no transport [nondim].
 
   ! Local variables
+  real :: frac ! The fraction of the total transport in a category [nondim].
   integer :: i, j, k, ish, ieh, jsh, jeh, nCat
 
   ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nCat = IG%CatIce
   !$OMP parallel do default(shared)
   do J=jsh-1,jeh ; do k=1,nCat ; do i=ish,ieh
-    if (vh_tot(i,J) < 0.0) then ; vh(i,J,k) = (h(i,J+1,k) * I_htot(i,J+1)) * vh_tot(i,J)
-    elseif (vh_tot(i,J) > 0.0) then ; vh(i,J,k) = (h(i,j,k) * I_htot(i,j)) * vh_tot(i,J)
-    else ; vh(i,j,k) = 0.0 ; endif
+    frac = 0.0
+    if (vh_tot(i,J) < 0.0) then ; frac = (h(i,j+1,k) * I_htot(i,j+1))
+    elseif (vh_tot(i,J) > 0.0) then ; frac = (h(i,j,k) * I_htot(i,j)) ; endif
+    if (present(masking_vh)) then ; if (masking_vh(i,J,k) == 0.0) frac = 0.0 ; endif
+    if (present(frac_neglect)) then ; if (frac < frac_neglect) frac = 0.0 ; endif
+
+    vh(i,J,k) = frac * vh_tot(i,J)
   enddo ; enddo ; enddo
 
 end subroutine merid_proportionate_fluxes
 
 !> Calculates the mass or volume fluxes through the zonal
 !! faces, and other related quantities.
-subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot)
+subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot, h_mobilize, &
+                           masking_uh, masking_uhtot)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZIB_(G),SZJ_(G)), &
@@ -849,7 +986,6 @@ subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot)
   type(SIS_continuity_CS), pointer       :: CS  !< The control structure returned by a
                                                 !! previous call to SIS_continuity_init.
   type(loop_bounds_type),  intent(in)    :: LB  !< A structure with the active loop bounds.
-
   real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)), &
                  optional, intent(in)    :: h_in !< Category thickness used to calculate the fluxes [R Z ~> kg m-2].
   real, dimension(SZIB_(G),SZJ_(G),SZCAT_(IG)), &
@@ -860,6 +996,14 @@ subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot)
   real, dimension(SZIB_(G),SZJ_(G)), &
                  optional, intent(out)   :: uh_tot !< Total mass flux through zonal faces = u*htot*dy
                                                 !! [R Z L2 T-1 ~> kg s-1].
+  real,          optional, intent(in)    :: h_mobilize !< The minimum ice thickness per category that
+                                                !! is able to move out of a cell [R Z ~> kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_uh  !< If this is 0, uh = 0.  Often this is another
+                                                !! zonal mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                 optional, intent(in)    :: masking_uhtot !< If this is 0, uh_tot = 0.  Often this is another
+                                                !! total zonal mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
 !   This subroutine calculates the mass or volume fluxes through the zonal
 ! faces, and other related quantities.
 
@@ -877,23 +1021,37 @@ subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot)
                  ! with the same units as h_in.
 !  real :: h_marg ! The marginal thickness of a flux [R Z ~> kg m-2].
 !  real :: dx_E, dx_W ! Effective x-grid spacings to the east and west [L ~> m].
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nCat
 
-  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = IG%CatIce
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nCat = IG%CatIce
 
   call cpu_clock_begin(id_clock_update)
 
   htot(:,:) = 0.0
   if (present(htot_in)) then
-    !$OMP parallel do default(shared)
-    do j=jsh,jeh ; do i=G%isd,G%ied
-      htot(i,j) = htot(i,j) + htot_in(i,j)
-    enddo ; enddo
+    if (present(h_mobilize)) then
+      !$OMP parallel do default(shared)
+      do j=jsh,jeh ; do i=G%isd,G%ied
+        if (htot_in(i,j) >= nCat*h_mobilize) htot(i,j) = htot(i,j) + htot_in(i,j)
+      enddo ; enddo
+    else
+      !$OMP parallel do default(shared)
+      do j=jsh,jeh ; do i=G%isd,G%ied
+        htot(i,j) = htot(i,j) + htot_in(i,j)
+      enddo ; enddo
+    endif
   elseif (present(h_in)) then
-    !$OMP parallel do default(shared)
-    do j=jsh,jeh ; do k=1,nz ; do i=G%isd,G%ied
-      htot(i,j) = htot(i,j) + h_in(i,j,k)
-    enddo ; enddo ; enddo
+    if (present(h_mobilize)) then
+      !$OMP parallel do default(shared)
+      do j=jsh,jeh ; do k=1,nCat ; do i=G%isd,G%ied
+        if (h_in(i,j,k) >= h_mobilize) htot(i,j) = htot(i,j) + h_in(i,j,k)
+      enddo ; enddo ; enddo
+    else
+      !$OMP parallel do default(shared)
+      do j=jsh,jeh ; do k=1,nCat ; do i=G%isd,G%ied
+        htot(i,j) = htot(i,j) + h_in(i,j,k)
+      enddo ; enddo ; enddo
+    endif
   else
     call SIS_error(FATAL, "Either h_in or htot_in must be present in call to zonal_mass_flux.")
   endif
@@ -942,18 +1100,43 @@ subroutine zonal_mass_flux(u, dt, G, US, IG, CS, LB, h_in, uh, htot_in, uh_tot)
       do i=ish-1,ieh+1
         I_htot(i,j) = 0.0 ; if (htot(i,j) > 0.0) I_htot(i,j) = 1.0 / htot(i,j)
       enddo
-      do k=1,nz ; do I=ish-1,ieh
-        if (u(I,j) >= 0.0) then
-          uh(I,j,k) = uhtot(I) * (h_in(i,j,k) * I_htot(i,j))
-        else
-          uh(I,j,k) = uhtot(I) * (h_in(i+1,j,k) * I_htot(i+1,j))
-        endif
+      if (present(h_mobilize)) then
+        do k=1,nCat ; do I=ish-1,ieh
+          uh(I,j,k) = 0.0
+          if (u(I,j) >= 0.0) then
+            if (h_in(i,j,k) >= h_mobilize) uh(I,j,k) = uhtot(I) * (h_in(i,j,k) * I_htot(i,j))
+          else
+            if (h_in(i+1,j,k) >= h_mobilize) uh(I,j,k) = uhtot(I) * (h_in(i+1,j,k) * I_htot(i+1,j))
+          endif
+        enddo ; enddo
+      else
+        do k=1,nCat ; do I=ish-1,ieh
+          if (u(I,j) >= 0.0) then
+            uh(I,j,k) = uhtot(I) * (h_in(i,j,k) * I_htot(i,j))
+          else
+            uh(I,j,k) = uhtot(I) * (h_in(i+1,j,k) * I_htot(i+1,j))
+          endif
+        enddo ; enddo
+      endif
+    endif
+
+    ! Block mass fluxes in categories where a related flux (e.g. of ice) is zero.
+    if (present(masking_uh) .and. present(uh)) then
+      do k=1,nCat ; do I=ish-1,ieh
+        if (masking_uh(I,j,k) == 0.0) uh(I,j,k) = 0.0
       enddo ; enddo
     endif
 
-    if (present(uh_tot)) then ; do I=ish-1,ieh
-      uh_tot(I,j) = uhtot(I)
-    enddo ; endif
+    if (present(uh_tot) .and. present(masking_uhtot)) then
+      do I=ish-1,ieh
+        uh_tot(I,j) = uhtot(I)
+        if (masking_uhtot(I,j) == 0.0) uh_tot(I,j) = 0.0
+      enddo
+    elseif (present(uh_tot)) then
+      do I=ish-1,ieh
+        uh_tot(I,j) = uhtot(I)
+      enddo
+    endif
 
   enddo ! j-loop
   call cpu_clock_end(id_clock_correct)
@@ -962,7 +1145,8 @@ end subroutine zonal_mass_flux
 
 !> Calculates the mass or volume fluxes through the meridional
 !! faces, and other related quantities.
-subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_tot)
+subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_tot, &
+                                h_mobilize, masking_vh, masking_vhtot)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZI_(G),SZJB_(G)), &
@@ -982,6 +1166,14 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
   real, dimension(SZI_(G),SZJB_(G)), &
                  optional, intent(out)   :: vh_tot !< Total mass flux through meridional faces = v*htot*dx
                                                 !! [R Z L2 T-1 ~> kg s-1].
+  real,          optional, intent(in)    :: h_mobilize !< The minimum ice thickness per category that
+                                                !! is able to move out of a cell [R Z ~> kg m-2].
+  real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
+                 optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
+                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), &
+                 optional, intent(in)    :: masking_vhtot !< If this is 0, vh_tot = 0.  Often this is another
+                                                !! total meridional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
 
 !   This subroutine calculates the mass or volume fluxes through the meridional
 ! faces, and other related quantities.
@@ -1000,24 +1192,38 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
                  ! with the same units as h_in.
   real :: h_marg ! The marginal thickness of a flux [R Z ~> kg m-2].
 !  real :: dy_N, dy_S ! Effective y-grid spacings to the north and south [L ~> m].
-  integer :: i, j, k, ish, ieh, jsh, jeh, nz
+  integer :: i, j, k, ish, ieh, jsh, jeh, nCat
 
-  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nz = IG%CatIce
+  ish = LB%ish ; ieh = LB%ieh ; jsh = LB%jsh ; jeh = LB%jeh ; nCat = IG%CatIce
 
   call cpu_clock_begin(id_clock_update)
 
   htot(:,:) = 0.0
 
   if (present(htot_in)) then
-    !$OMP parallel do default(shared)
-    do j=G%jsd,G%jed ; do i=ish,ieh
-      htot(i,j) = htot(i,j) + htot_in(i,j)
-    enddo ; enddo
+    if (present(h_mobilize)) then
+      !$OMP parallel do default(shared)
+      do j=G%jsd,G%jed ; do i=ish,ieh
+        if (htot_in(i,j) >= nCat*h_mobilize) htot(i,j) = htot(i,j) + htot_in(i,j)
+      enddo ; enddo
+    else
+      !$OMP parallel do default(shared)
+      do j=G%jsd,G%jed ; do i=ish,ieh
+        htot(i,j) = htot(i,j) + htot_in(i,j)
+      enddo ; enddo
+    endif
   elseif (present(h_in)) then
-    !$OMP parallel do default(shared)
-    do j=G%jsd,G%jed ; do k=1,nz ; do i=ish,ieh
-      htot(i,j) = htot(i,j) + h_in(i,j,k)
-    enddo ; enddo ; enddo
+    if (present(h_mobilize)) then
+      !$OMP parallel do default(shared)
+      do j=G%jsd,G%jed ; do k=1,nCat ; do i=ish,ieh
+        if (h_in(i,j,k) >= h_mobilize) htot(i,j) = htot(i,j) + h_in(i,j,k)
+      enddo ; enddo ; enddo
+    else
+      !$OMP parallel do default(shared)
+      do j=G%jsd,G%jed ; do k=1,nCat ; do i=ish,ieh
+        htot(i,j) = htot(i,j) + h_in(i,j,k)
+      enddo ; enddo ; enddo
+    endif
   else
     call SIS_error(FATAL, "Either h_in or htot_in must be present in call to meridional_mass_flux.")
   endif
@@ -1063,17 +1269,44 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
     enddo
 
     ! Partition the transports by category in proportion to their relative masses.
-    if (present(vh)) then ; do k=1,nz ; do i=ish,ieh
-      if (v(i,J) >= 0.0) then
-        vh(i,J,k) = vhtot(i) * (h_in(i,j,k) * I_htot(i,j))
+    if (present(vh)) then
+      if (present(h_mobilize)) then
+        do k=1,nCat ; do i=ish,ieh
+          vh(i,J,k) = 0.0
+          if (v(i,J) >= 0.0) then
+            if (h_in(i,j,k) >= h_mobilize) vh(i,J,k) = vhtot(i) * (h_in(i,j,k) * I_htot(i,j))
+          else
+            if (h_in(i,j+1,k) >= h_mobilize) vh(i,J,k) = vhtot(i) * (h_in(i,j+1,k) * I_htot(i,j+1))
+          endif
+        enddo ; enddo
       else
-        vh(i,J,k) = vhtot(i) * (h_in(i,j+1,k) * I_htot(i,j+1))
+        do k=1,nCat ; do i=ish,ieh
+          if (v(i,J) >= 0.0) then
+            vh(i,J,k) = vhtot(i) * (h_in(i,j,k) * I_htot(i,j))
+          else
+            vh(i,J,k) = vhtot(i) * (h_in(i,j+1,k) * I_htot(i,j+1))
+          endif
+        enddo ; enddo
       endif
-    enddo ; enddo ; endif
+    endif
 
-    if (present(vh_tot)) then ; do i=ish,ieh
-      vh_tot(i,J) = vhtot(i)
-    enddo ; endif
+    ! Block mass fluxes in categories where a related flux (e.g. of ice) is zero.
+    if (present(masking_vh) .and. present(vh)) then
+      do k=1,nCat ; do i=ish,ieh
+        if (masking_vh(i,J,k) == 0.0) vh(i,J,k) = 0.0
+      enddo ; enddo
+    endif
+
+    if (present(vh_tot) .and. present(masking_vhtot)) then
+      do i=ish,ieh
+        vh_tot(i,J) = vhtot(I)
+        if (masking_vhtot(i,J) == 0.0) vh_tot(i,J) = 0.0
+      enddo
+    elseif (present(vh_tot)) then
+      do i=ish,ieh
+        vh_tot(i,J) = vhtot(I)
+      enddo
+    endif
 
   enddo ! j-loop
   call cpu_clock_end(id_clock_correct)
@@ -1343,17 +1576,18 @@ subroutine PPM_limit_CW84(h_in, h_l, h_r, G, iis, iie, jis, jie)
 end subroutine PPM_limit_CW84
 
 !> Initializes the sea ice continuity module
-subroutine SIS_continuity_init(Time, G, param_file, diag, CS, CS_cvr)
+subroutine SIS_continuity_init(Time, G, US, param_file, diag, CS, CS_cvr)
   type(time_type),     target, intent(in)    :: Time !< The sea-ice model's clock,
-                                                    !! set with the current model time.
-  type(SIS_hor_grid_type),     intent(in)    :: G   !< The horizontal grid type
+                                                     !! set with the current model time.
+  type(SIS_hor_grid_type),     intent(in)    :: G    !< The horizontal grid type
+  type(unit_scale_type),       intent(in)    :: US   !< A structure with unit conversion factors
   type(param_file_type),       intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(SIS_diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic output
-  type(SIS_continuity_CS),     pointer       :: CS  !< The control structure for mass transport that
-                                                    !! is carried out by this module; it is allocated
-                                                    !! and populated here.
+  type(SIS_continuity_CS),     pointer       :: CS   !< The control structure for mass transport that
+                                                     !! is carried out by this module; it is allocated
+                                                     !! and populated here.
   type(SIS_continuity_CS),     optional, pointer :: CS_cvr !< A secondary control structure for the
-                                                    !! transport of ice cover.
+                                                     !! transport of ice cover.
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -1398,6 +1632,17 @@ subroutine SIS_continuity_init(Time, G, param_file, diag, CS, CS_cvr)
                  "If true, use the ratio of the open face lengths to the "//&
                  "tracer cell areas when estimating CFL numbers.", &
                  default=.false.)
+  call get_param(param_file, mdl, "CONTINUITY_H_NEGLECT", CS%h_neglect_cont, &
+                 "The category ice mass per ocean cell area below which the transport "//&
+                 "within this thickness category of out of a cell is set to zero.  A suggested "//&
+                 "non-default value might be of order 3e-32 kg m-2, which is one molecule of "//&
+                 "ice per square kilometer.", &
+                 default=0.0, units="kg m-2", scale=US%kg_m3_to_R*US%m_to_Z)
+  call get_param(param_file, mdl, "CONTINUITY_FRAC_NEGLECT", CS%frac_neglect, &
+                 "When the total fluxes are distributed between categories with "//&
+                 "MERGED_CONTINUITY, any category whose ice is less than this fraction of the "//&
+                 "total mass contributes no flux.  A suggested non-default value might be of "//&
+                 "order 1e-20.", default=0.0, units="nondim")
 
   CS%diag => diag
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1109,7 +1109,8 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, dt_cycle, Time_start, G, US,
         call summed_continuity(DS2d%u_ice_C, DS2d%v_ice_C, DS2d%mca_step(:,:,n-1), DS2d%mca_step(:,:,n), &
                                DS2d%uh_step(:,:,n), DS2d%vh_step(:,:,n), dt_adv, G, US, IG, &
                                CS%continuity_CSp, h_ice=DS2d%mi_sum)
-        call ice_cover_transport(DS2d%u_ice_C, DS2d%v_ice_C, DS2d%ice_cover, dt_adv, G, US, IG, CS%cover_trans_CSp)
+        call ice_cover_transport(DS2d%u_ice_C, DS2d%v_ice_C, DS2d%ice_cover, dt_adv, G, US, IG, CS%cover_trans_CSp, &
+                                 masking_uhtot=DS2d%uh_step(:,:,n), masking_vhtot=DS2d%vh_step(:,:,n))
         call pass_var(DS2d%mi_sum, G%Domain, complete=.false.)
         call pass_var(DS2d%ice_cover, G%Domain, complete=.false.)
         call pass_var(DS2d%mca_step(:,:,n), G%Domain, complete=.true.)

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -16,13 +16,10 @@ module SIS_ice_diags
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, read_param, log_param, log_version, param_file_type
-use MOM_time_manager, only : time_type, time_type_to_real, real_to_time
-! use MOM_time_manager, only : operator(+), operator(-)
-! use MOM_time_manager, only : operator(>), operator(*), operator(/), operator(/=)
+use MOM_time_manager, only : time_type
 use MOM_unit_scaling, only : unit_scale_type
 use coupler_types_mod, only: coupler_type_initialized, coupler_type_send_data
 
-use SIS_continuity,    only : SIS_continuity_CS, summed_continuity, ice_cover_transport
 use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
 use SIS_diag_mediator, only : post_SIS_data, post_data=>post_SIS_data
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, SIS_diag_ctrl, safe_alloc_alloc

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -158,7 +158,8 @@ subroutine ice_state_mass_init(IST, Ice, G, IG, US, PF, init_Time, just_read_par
 
   select case (trim(conc_config))
     case ("data_override")
-      call data_override('ICE', 'sic_obs', IST%part_size(isc:iec,jsc:jec,1), init_Time)
+      if (.not.just_read) &
+        call data_override('ICE', 'sic_obs', IST%part_size(isc:iec,jsc:jec,1), init_Time)
     case ("file")
       call initialize_concentration_from_file(IST%part_size, G, IG, US, PF, just_read_params=just_read)
     case ("zero")

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -187,12 +187,12 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
                                     h2=CAS%m_snow, uh2=uh_snow, vh2=vh_snow, &
                                     h3=CAS%m_pond, uh3=uh_pond, vh3=vh_pond)
     else
-      call continuity(uc, vc, mca0_ice, CAS%m_ice, uh_ice, vh_ice, &
-                      dt_adv, G, US, IG, CS%continuity_CSp)
-      call continuity(uc, vc, mca0_snow, CAS%m_snow, uh_snow, vh_snow, &
-                      dt_adv, G, US, IG, CS%continuity_CSp)
-      call continuity(uc, vc, mca0_pond, CAS%m_pond, uh_pond, vh_pond, &
-                      dt_adv, G, US, IG, CS%continuity_CSp)
+      call continuity(uc, vc, mca0_ice, CAS%m_ice, uh_ice, vh_ice, dt_adv, &
+                      G, US, IG, CS%continuity_CSp, use_h_neg=.true.)
+      call continuity(uc, vc, mca0_snow, CAS%m_snow, uh_snow, vh_snow, dt_adv, &
+                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice)
+      call continuity(uc, vc, mca0_pond, CAS%m_pond, uh_pond, vh_pond, dt_adv, &
+                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice)
     endif
 
     call advect_scalar(CAS%mH_ice, mca0_ice, CAS%m_ice, uh_ice, vh_ice, &
@@ -1194,7 +1194,7 @@ subroutine SIS_transport_init(Time, G, US, param_file, diag, CS, continuity_CSp,
   call obsolete_logical(param_file, "USE_SIS_CONTINUITY", .true.)
   call obsolete_logical(param_file, "USE_SIS_THICKNESS_ADVECTION", .true.)
 
-  call SIS_continuity_init(Time, G, param_file, diag, CS%continuity_CSp, &
+  call SIS_continuity_init(Time, G, US, param_file, diag, CS%continuity_CSp, &
                            CS_cvr=cover_trans_CSp)
   call SIS_tracer_advect_init(Time, G, param_file, diag, CS%SIS_tr_adv_CSp)
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2352,17 +2352,20 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       endif
 
       call callTree_leave("ice_model_init():restore_from_restart_files")
-    else ! no restart file implies initialization with no ice
-      call ice_state_mass_init(sIST, Ice, sG, sIG, US, param_file, Ice%sCS%Time, just_read_params=is_restart)
+    endif ! file_exists(restart_path)
 
-      call ice_state_thermo_init(sIST, Ice, sG, sIG, US, param_file, Ice%sCS%Time, &
-                                just_read_params=is_restart)
+    ! If there is not a restart file, initialize the ice another way, perhaps with no ice.
+    ! If there is a restart file, the following two calls are just here to read and log parameters.
+    call ice_state_mass_init(sIST, Ice, sG, sIG, US, param_file, Ice%sCS%Time, just_read_params=is_restart)
 
+    call ice_state_thermo_init(sIST, Ice, sG, sIG, US, param_file, Ice%sCS%Time, &
+                               just_read_params=is_restart)
+
+    if (.not.is_restart) then
       ! Record the need to transfer ice to the correct thickness category.
       recategorize_ice = .true.
       init_coszen = .true. ; init_Tskin = .true. ; init_rough = .true.
-
-    endif ! file_exists(restart_path)
+    endif
 
     ! The restart files have now been read or the variables that would have been in the restart
     ! files have been initialized, although some corrections and halo updates still need to be done.


### PR DESCRIPTION
  This PR adds new runtime parameters to restrict the transport out of cells
with miniscule ice masses and to prevent the formation of very small fractional
ice coverage in some categories. These options should help avoid some problems
that had been arising with tracer transport in and around categories with tiny
masses.  There were also some minor changes to help detect unused parameters. 
By default there are no changes to answers, but there are new entries in
SIS_parameter_doc files.  The commits in this PR include:

- NOAA-GFDL/SIS2@9adb8fe Always call ice_state_mass_init
- NOAA-GFDL/SIS2@e431d16 +Added new runtime parameter ICE_COVER_DISCARD
- NOAA-GFDL/SIS2@c44f798 +Added CONTINUITY_H_NEGLECT to mask tiny fluxes
