### PR TITLE
SIS2: +Encapsulate SIS2 infrastructure calls

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -2,36 +2,30 @@
 !! types, including allocation, deallocation, registration for restarts, and checksums.
 module SIS_ctrl_types
 
-! use mpp_mod,          only: mpp_sum, stdout, input_nml_file, PE_here => mpp_pe
-! use mpp_domains_mod,  only: domain2D, mpp_get_compute_domain, CORNER, EAST, NORTH
-use mpp_domains_mod,   only : domain2D, CORNER, EAST, NORTH
-! use mpp_parameter_mod, only : CGRID_NE, BGRID_NE, AGRID
 use coupler_types_mod, only : coupler_2d_bc_type, coupler_3d_bc_type
 use coupler_types_mod, only : coupler_type_initialized, coupler_type_set_diags
 
-use SIS_dyn_trans,   only : dyn_trans_CS
-use SIS_fast_thermo, only : fast_thermo_CS
-use SIS_slow_thermo, only : slow_thermo_CS
-use specified_ice,   only : specified_ice_CS
-
-use SIS_hor_grid, only : SIS_hor_grid_type
-use ice_grid, only : ice_grid_type
-use SIS_types, only : ice_state_type, ice_ocean_flux_type, ocean_sfc_state_type
-use SIS_types, only : fast_ice_avg_type, ice_rad_type, simple_OSS_type
-use SIS_types, only : total_sfc_flux_type
-use SIS_optics, only : SIS_optics_CS
-
-use MOM_coms,          only : PE_here
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg, is_root_pe
+use ice_grid,          only : ice_grid_type
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_file_parser,   only : param_file_type
 use MOM_hor_index,     only : hor_index_type
 use MOM_time_manager,  only : time_type, time_type_to_real
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
-use SIS_sum_output, only : SIS_sum_out_CS
+use SIS_dyn_trans,     only : dyn_trans_CS
+use SIS_fast_thermo,   only : fast_thermo_CS
+use SIS_framework,     only : domain2D, CORNER, EAST, NORTH
+use SIS_hor_grid,      only : SIS_hor_grid_type
+use SIS_optics,        only : SIS_optics_CS
+use SIS_slow_thermo,   only : slow_thermo_CS
+use SIS_sum_output,    only : SIS_sum_out_CS
 ! use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS_tracer_flow_control, only : SIS_tracer_flow_control_CS
+use SIS_types,         only : ice_state_type, ice_ocean_flux_type, ocean_sfc_state_type
+use SIS_types,         only : fast_ice_avg_type, ice_rad_type, simple_OSS_type
+use SIS_types,         only : total_sfc_flux_type
+use specified_ice,     only : specified_ice_CS
 
 implicit none ; private
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -10,19 +10,19 @@ module SIS_dyn_bgrid
 ! Recoded for consistency with MOM6 and symmetry by R. Hallberg, 7/2013.       !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
+use MOM_domains,       only : pass_var, pass_vector, BGRID_NE
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
+use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
+use MOM_hor_index,     only : hor_index_type
+use MOM_unit_scaling,  only : unit_scale_type
 use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
 use SIS_debugging,     only : chksum, Bchksum, hchksum, check_redundant_B
 use SIS_debugging,     only : Bchksum_pair
-use MOM_domains,      only : pass_var, pass_vector, BGRID_NE
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
-use MOM_file_parser,  only : get_param, log_param, read_param, log_version, param_file_type
-use MOM_hor_index,    only : hor_index_type
-use MOM_unit_scaling, only : unit_scale_type
-use SIS_hor_grid,     only : SIS_hor_grid_type
-use fms_io_mod,       only : register_restart_field, restart_file_type
-use mpp_domains_mod,  only : domain2D
-use ice_ridging_mod,  only : ridge_rate
+use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : domain2D
+use SIS_hor_grid,      only : SIS_hor_grid_type
+use ice_ridging_mod,   only : ridge_rate
 
 implicit none ; private
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -14,24 +14,25 @@ module SIS_dyn_cgrid
 !                                                                              !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, NOTE, SIS_mesg=>MOM_mesg
+use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
+use MOM_domains,       only : pass_var, pass_vector, CGRID_NE, CORNER, pe_here
+use MOM_domains,       only : MOM_domain_type, clone_MOM_domain
+use MOM_hor_index,     only : hor_index_type
+use MOM_io,            only : open_file, APPEND_FILE, ASCII_FILE, MULTIPLE, SINGLE_FILE
+use MOM_time_manager,  only : time_type, real_to_time, operator(+), operator(-)
+use MOM_time_manager,  only : set_date, get_time, get_date
+use MOM_unit_scaling,  only : unit_scale_type
+
 use SIS_diag_mediator, only : post_SIS_data, SIS_diag_ctrl
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, enable_SIS_averaging
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
 use SIS_debugging,     only : chksum, Bchksum, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, NOTE, SIS_mesg=>MOM_mesg
-use MOM_file_parser,  only : get_param, log_param, read_param, log_version, param_file_type
-use MOM_domains,      only : pass_var, pass_vector, CGRID_NE, CORNER, pe_here
-use MOM_domains,      only : MOM_domain_type, clone_MOM_domain
-use MOM_hor_index,    only : hor_index_type
-use MOM_io,           only : open_file, APPEND_FILE, ASCII_FILE, MULTIPLE, SINGLE_FILE
-use MOM_time_manager, only : time_type, real_to_time, operator(+), operator(-)
-use MOM_time_manager, only : set_date, get_time, get_date
-use MOM_unit_scaling, only : unit_scale_type
-use SIS_hor_grid,     only : SIS_hor_grid_type
-use fms_io_mod,       only : register_restart_field, restart_file_type
-use fms_io_mod,       only : restore_state, query_initialized
-use mpp_domains_mod,  only : domain2D
+use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : restore_state, query_initialized
+use SIS_framework,     only : domain2D
+use SIS_hor_grid,      only : SIS_hor_grid_type
 
 implicit none ; private
 

--- a/src/SIS_framework.F90
+++ b/src/SIS_framework.F90
@@ -1,0 +1,50 @@
+!> Provides wrapped interfaces for infrastructure calls used by SIS2 that can not be
+!! found in the MOM6 framework directory.
+module SIS_framework
+
+! This file is part of SIS2. See LICENSE.md for the license.
+
+use fms_io_mod,        only : set_domain, nullify_domain
+use fms_io_mod,        only : restart_file_type, register_restart_field
+use fms_io_mod,        only : save_restart, restore_state, query_initialized
+use mpp_mod,           only : SIS_chksum=>mpp_chksum
+use mpp_domains_mod,   only : domain2D, CORNER, EAST, NORTH
+use mpp_domains_mod,   only : get_layout=>mpp_get_layout, get_compute_domain=>mpp_get_compute_domain
+use mpp_domains_mod,   only : redistribute_data=>mpp_redistribute
+use mpp_domains_mod,   only : broadcast_domain=>mpp_broadcast_domain
+
+use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
+use MOM_file_parser,   only : get_param, read_param, log_param, log_version, param_file_type
+
+implicit none ; private
+
+public :: SIS_chksum, redistribute_data, domain2D, CORNER, EAST, NORTH
+public :: set_domain, nullify_domain, get_layout, get_compute_domain, broadcast_domain
+public :: restart_file_type, register_restart_field, save_restart, restore_state, query_initialized
+public :: SIS_initialize_framework
+
+contains
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+!> SIS_initialize_framework is a template that might be used later to initialize structrures
+!! and types that are used for the SIS2 infrastructure.
+subroutine SIS_initialize_framework(PF)
+  type(param_file_type),   intent(in)    :: PF  !< A structure indicating the open file
+                                                !! to parse for model parameter values.
+
+  character(len=200) :: inputdir   ! The directory where NetCDF input files are.
+  character(len=200) :: config
+  character(len=40)  :: mdl = "SIS_framework" ! This module's name.
+  logical :: debug
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
+
+  call callTree_enter("SIS_initialize_framework(), SIS_framework.F90")
+  call log_version(PF, mdl, version, "")
+  call get_param(PF, mdl, "DEBUG", debug, default=.false.)
+
+  call callTree_leave('SIS_initialize_framework()')
+
+end subroutine SIS_initialize_framework
+
+end module SIS_framework

--- a/src/SIS_hor_grid.F90
+++ b/src/SIS_hor_grid.F90
@@ -8,9 +8,6 @@ module SIS_hor_grid
 !   metric terms in a way that is very similar to MOM6. - Robert Hallberg      !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
-use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain
-use mpp_domains_mod, only : mpp_get_global_domain
-
 use MOM_hor_index, only : hor_index_type, hor_index_init
 use MOM_domains, only : MOM_domain_type, get_domain_extent, compute_block_extent
 use MOM_domains, only : MOM_domains_init, clone_MOM_domain

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -9,26 +9,24 @@ module SIS_state_initialization
 ! routines have options that just read and log their input parameters.         !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
+use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
+use ice_grid,          only : ice_grid_type
+use ice_type_mod,      only : ice_data_type, dealloc_ice_arrays
+use ice_type_mod,      only : ice_type_slow_reg_restarts
 use MOM_domains,       only : MOM_domain_type
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser, only : get_param, log_param, log_version, read_param, param_file_type
-use MOM_hor_index, only : hor_index_type, hor_index_init
-use MOM_io, only : file_exists, MOM_read_data, slasher
-use MOM_time_manager, only : time_type, time_type_to_real, real_to_time
-use MOM_unit_scaling, only : unit_scale_type
-
-use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
-use fms_io_mod, only : restore_state, query_initialized
-use fms_io_mod, only : register_restart_field, restart_file_type
-
-use ice_grid, only : ice_grid_type
-use ice_type_mod, only : ice_data_type, dealloc_ice_arrays
-use ice_type_mod, only : ice_type_slow_reg_restarts
-use SIS_get_input, only : directories
-use SIS_types, only : ice_state_type
-use SIS_hor_grid, only : SIS_hor_grid_type, set_hor_grid, SIS_hor_grid_end
-use SIS2_ice_thm, only : get_SIS2_thermo_coefs, enth_from_TS, Temp_from_En_S, T_freeze, ice_thermo_type
+use MOM_file_parser,   only : get_param, log_param, log_version, read_param, param_file_type
+use MOM_hor_index,     only : hor_index_type, hor_index_init
+use MOM_io,            only : file_exists, MOM_read_data, slasher
+use MOM_time_manager,  only : time_type, time_type_to_real, real_to_time
+use MOM_unit_scaling,  only : unit_scale_type
+use SIS_framework,     only : restore_state, query_initialized
+use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_get_input,     only : directories
+use SIS_types,         only : ice_state_type
+use SIS_hor_grid,      only : SIS_hor_grid_type, set_hor_grid, SIS_hor_grid_end
+use SIS2_ice_thm,      only : get_SIS2_thermo_coefs, enth_from_TS, Temp_from_En_S, T_freeze, ice_thermo_type
 
 implicit none ; private
 

--- a/src/SIS_tracer_flow_control.F90
+++ b/src/SIS_tracer_flow_control.F90
@@ -45,16 +45,14 @@ module SIS_tracer_flow_control
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use SIS_diag_mediator, only : time_type, SIS_diag_ctrl
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
-use MOM_coms, only : sum_across_PEs
-use ice_grid, only : ice_grid_type
+use ice_grid,            only : ice_grid_type
+use MOM_error_handler,   only : SIS_error=>MOM_error, FATAL, WARNING
+use MOM_file_parser,     only : get_param, log_version, param_file_type
+use SIS_diag_mediator,   only : time_type, SIS_diag_ctrl
+use SIS_framework,       only : restart_file_type
+use SIS_hor_grid,        only : SIS_hor_grid_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS_tracer_registry, only : register_SIS_tracer, register_SIS_tracer_pair
-use SIS_hor_grid, only : SIS_hor_grid_type
-
-use fms_io_mod,      only : restart_file_type
-use MOM_file_parser, only : get_param, log_version, param_file_type
 
 #include <SIS2_memory.h>
 

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -7,9 +7,6 @@ use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d
 use coupler_types_mod, only : coupler_type_spawn, coupler_type_initialized
 use coupler_types_mod, only : coupler_type_redistribute_data, coupler_type_copy_data
 use coupler_types_mod, only : coupler_type_register_restarts
-use fms_io_mod,        only : register_restart_field, restart_file_type
-use fms_io_mod,        only : restore_state, query_initialized
-use mpp_domains_mod,   only : domain2D, CORNER, EAST, NORTH, mpp_redistribute
 
 use ice_grid,          only : ice_grid_type
 use MOM_coms,          only : PE_here
@@ -23,6 +20,9 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_debugging,     only : chksum, Bchksum, Bchksum_pair, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
+use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, redistribute_data
+use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : restore_state, query_initialized
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS2_ice_thm,      only : ice_thermo_type, SIS2_ice_thm_CS, get_SIS2_thermo_coefs
@@ -1272,70 +1272,70 @@ subroutine redistribute_IST_to_IST(IST_in, IST_out, domain_in, domain_out)
 
   ! The velocity components, rdg_mice, TrReg, and ITV are deliberately not being copied.
   if (associated(IST_out) .and. associated(IST_in)) then
-    call mpp_redistribute(domain_in, IST_in%part_size, domain_out, &
-                          IST_out%part_size, complete=.true.)
+    call redistribute_data(domain_in, IST_in%part_size, domain_out, &
+                           IST_out%part_size, complete=.true.)
 
     if (allocated(IST_out%t_surf) .or. allocated(IST_in%t_surf)) then
-      call mpp_redistribute(domain_in, IST_in%t_surf, domain_out, &
-                            IST_out%t_surf, complete=.false.)
+      call redistribute_data(domain_in, IST_in%t_surf, domain_out, &
+                             IST_out%t_surf, complete=.false.)
     endif
-    call mpp_redistribute(domain_in, IST_in%mH_pond, domain_out, &
-                          IST_out%mH_pond, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%mH_snow, domain_out, &
-                          IST_out%mH_snow, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%mH_ice, domain_out, &
-                          IST_out%mH_ice, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%enth_snow, domain_out, &
-                          IST_out%enth_snow, complete=.true.)
+    call redistribute_data(domain_in, IST_in%mH_pond, domain_out, &
+                           IST_out%mH_pond, complete=.false.)
+    call redistribute_data(domain_in, IST_in%mH_snow, domain_out, &
+                           IST_out%mH_snow, complete=.false.)
+    call redistribute_data(domain_in, IST_in%mH_ice, domain_out, &
+                           IST_out%mH_ice, complete=.false.)
+    call redistribute_data(domain_in, IST_in%enth_snow, domain_out, &
+                           IST_out%enth_snow, complete=.true.)
 
-    call mpp_redistribute(domain_in, IST_in%enth_ice, domain_out, &
-                          IST_out%enth_ice, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%sal_ice, domain_out, &
-                          IST_out%sal_ice, complete=.true.)
+    call redistribute_data(domain_in, IST_in%enth_ice, domain_out, &
+                           IST_out%enth_ice, complete=.false.)
+    call redistribute_data(domain_in, IST_in%sal_ice, domain_out, &
+                           IST_out%sal_ice, complete=.true.)
   elseif (associated(IST_out)) then
     ! Use the null pointers in place of the unneeded input arrays.
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          IST_out%part_size, complete=.true.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           IST_out%part_size, complete=.true.)
 
     if (allocated(IST_out%t_surf)) then
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            IST_out%t_surf, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             IST_out%t_surf, complete=.false.)
     endif
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          IST_out%mH_pond, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          IST_out%mH_snow, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          IST_out%mH_ice, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr4D, domain_out, &
-                          IST_out%enth_snow, complete=.true.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           IST_out%mH_pond, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           IST_out%mH_snow, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           IST_out%mH_ice, complete=.false.)
+    call redistribute_data(domain_in, null_ptr4D, domain_out, &
+                           IST_out%enth_snow, complete=.true.)
 
-    call mpp_redistribute(domain_in, null_ptr4D, domain_out, &
-                          IST_out%enth_ice, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr4D, domain_out, &
-                          IST_out%sal_ice, complete=.true.)
+    call redistribute_data(domain_in, null_ptr4D, domain_out, &
+                           IST_out%enth_ice, complete=.false.)
+    call redistribute_data(domain_in, null_ptr4D, domain_out, &
+                           IST_out%sal_ice, complete=.true.)
   elseif (associated(IST_in)) then
     ! Use the null pointers in place of the unneeded output arrays.
-    call mpp_redistribute(domain_in, IST_in%part_size, domain_out, &
-                          null_ptr3D, complete=.true.)
+    call redistribute_data(domain_in, IST_in%part_size, domain_out, &
+                           null_ptr3D, complete=.true.)
 
     if (allocated(IST_in%t_surf)) then
-      call mpp_redistribute(domain_in, IST_in%t_surf, domain_out, &
-                            null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, IST_in%t_surf, domain_out, &
+                             null_ptr3D, complete=.false.)
     endif
-    call mpp_redistribute(domain_in, IST_in%mH_pond, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%mH_snow, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%mH_ice, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%enth_snow, domain_out, &
-                          null_ptr4D, complete=.true.)
+    call redistribute_data(domain_in, IST_in%mH_pond, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, IST_in%mH_snow, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, IST_in%mH_ice, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, IST_in%enth_snow, domain_out, &
+                           null_ptr4D, complete=.true.)
 
-    call mpp_redistribute(domain_in, IST_in%enth_ice, domain_out, &
-                          null_ptr4D, complete=.false.)
-    call mpp_redistribute(domain_in, IST_in%sal_ice, domain_out, &
-                          null_ptr4D, complete=.true.)
+    call redistribute_data(domain_in, IST_in%enth_ice, domain_out, &
+                           null_ptr4D, complete=.false.)
+    call redistribute_data(domain_in, IST_in%sal_ice, domain_out, &
+                           null_ptr4D, complete=.true.)
 
   else
     call SIS_error(FATAL, "redistribute_IST_to_IST called with "//&
@@ -1463,63 +1463,63 @@ subroutine redistribute_sOSS_to_sOSS(OSS_in, OSS_out, domain_in, domain_out, HI_
     ! This could have complete set to .false. if the halo sizes matched.
     call coupler_type_redistribute_data(OSS_in%tr_fields, domain_in, &
                           OSS_out%tr_fields, domain_out, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%SST_C, domain_out, &
-                          OSS_out%SST_C, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%s_surf, domain_out, &
-                          OSS_out%s_surf, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%T_fr_ocn, domain_out, &
-                          OSS_out%T_fr_ocn, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%bheat, domain_out, &
-                          OSS_out%bheat, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%u_ocn_A, domain_out, &
-                          OSS_out%u_ocn_A, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%v_ocn_A, domain_out, &
-                          OSS_out%v_ocn_A, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%u_ice_A, domain_out, &
-                          OSS_out%u_ice_A, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%v_ice_A, domain_out, &
-                          OSS_out%v_ice_A, complete=.true.)
+    call redistribute_data(domain_in, OSS_in%SST_C, domain_out, &
+                           OSS_out%SST_C, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%s_surf, domain_out, &
+                           OSS_out%s_surf, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%T_fr_ocn, domain_out, &
+                           OSS_out%T_fr_ocn, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%bheat, domain_out, &
+                           OSS_out%bheat, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%u_ocn_A, domain_out, &
+                           OSS_out%u_ocn_A, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%v_ocn_A, domain_out, &
+                           OSS_out%v_ocn_A, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%u_ice_A, domain_out, &
+                           OSS_out%u_ice_A, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%v_ice_A, domain_out, &
+                           OSS_out%v_ice_A, complete=.true.)
   elseif (associated(OSS_out)) then
     ! Use the null pointer in place of the unneeded input arrays.
 
     call coupler_type_redistribute_data(null_bc, domain_in, &
                           OSS_out%tr_fields, domain_out, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%SST_C, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%s_surf, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%T_fr_ocn, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%bheat, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%u_ocn_A, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%v_ocn_A, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%u_ice_A, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr, domain_out, &
-                          OSS_out%v_ice_A, complete=.true.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%SST_C, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%s_surf, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%T_fr_ocn, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%bheat, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%u_ocn_A, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%v_ocn_A, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%u_ice_A, complete=.false.)
+    call redistribute_data(domain_in, null_ptr, domain_out, &
+                           OSS_out%v_ice_A, complete=.true.)
   elseif (associated(OSS_in)) then
     ! Use the null pointer in place of the unneeded output arrays.
     call coupler_type_redistribute_data(OSS_in%tr_fields, domain_in, &
                           null_bc, domain_out, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%SST_C, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%s_surf, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%T_fr_ocn, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%bheat, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%u_ocn_A, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%v_ocn_A, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%u_ice_A, domain_out, &
-                          null_ptr, complete=.false.)
-    call mpp_redistribute(domain_in, OSS_in%v_ice_A, domain_out, &
-                          null_ptr, complete=.true.)
+    call redistribute_data(domain_in, OSS_in%SST_C, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%s_surf, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%T_fr_ocn, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%bheat, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%u_ocn_A, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%v_ocn_A, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%u_ice_A, domain_out, &
+                           null_ptr, complete=.false.)
+    call redistribute_data(domain_in, OSS_in%v_ice_A, domain_out, &
+                           null_ptr, complete=.true.)
   else
     call SIS_error(FATAL, "redistribute_sOSS_to_sOSS called with "//&
                           "neither OSS_in nor OSS_out associated.")
@@ -1656,73 +1656,73 @@ subroutine redistribute_FIA_to_FIA(FIA_in, FIA_out, domain_in, domain_out, G_out
     call coupler_type_redistribute_data(FIA_in%tr_flux, domain_in, &
                           FIA_out%tr_flux, domain_out, complete=.false.)
     do b=1,size(FIA_in%flux_sw_top,4)
-      call mpp_redistribute(domain_in, FIA_in%flux_sw_top(:,:,:,b), domain_out, &
-                            FIA_out%flux_sw_top(:,:,:,b), complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_sw_top(:,:,:,b), domain_out, &
+                             FIA_out%flux_sw_top(:,:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, FIA_in%flux_sh_top, domain_out, &
+    call  redistribute_data(domain_in, FIA_in%flux_sh_top, domain_out, &
                           FIA_out%flux_sh_top, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%evap_top, domain_out, &
-                          FIA_out%evap_top, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%flux_lw_top, domain_out, &
-                          FIA_out%flux_lw_top, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%flux_lh_top, domain_out, &
-                          FIA_out%flux_lh_top, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%lprec_top, domain_out, &
-                          FIA_out%lprec_top, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%fprec_top, domain_out, &
-                          FIA_out%fprec_top, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%evap_top, domain_out, &
+                           FIA_out%evap_top, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%flux_lw_top, domain_out, &
+                           FIA_out%flux_lw_top, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%flux_lh_top, domain_out, &
+                           FIA_out%flux_lh_top, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%lprec_top, domain_out, &
+                           FIA_out%lprec_top, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%fprec_top, domain_out, &
+                           FIA_out%fprec_top, complete=.true.)
 
-    call mpp_redistribute(domain_in, FIA_in%tmelt, domain_out, &
-                          FIA_out%tmelt, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%bmelt, domain_out, &
-                          FIA_out%bmelt, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%sw_abs_ocn, domain_out, &
-                          FIA_out%sw_abs_ocn, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%tmelt, domain_out, &
+                           FIA_out%tmelt, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%bmelt, domain_out, &
+                           FIA_out%bmelt, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%sw_abs_ocn, domain_out, &
+                           FIA_out%sw_abs_ocn, complete=.true.)
 
-    call mpp_redistribute(domain_in, FIA_in%WindStr_x, domain_out, &
-                          FIA_out%WindStr_x, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_y, domain_out, &
-                          FIA_out%WindStr_y, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_ocn_x, domain_out, &
-                          FIA_out%WindStr_ocn_x, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_ocn_y, domain_out, &
-                          FIA_out%WindStr_ocn_y, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%p_atm_surf, domain_out, &
-                          FIA_out%p_atm_surf, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%runoff, domain_out, &
-                          FIA_out%runoff, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%calving, domain_out, &
-                          FIA_out%calving, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%runoff_hflx, domain_out, &
-                          FIA_out%runoff_hflx, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%calving_hflx, domain_out, &
-                          FIA_out%calving_hflx, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%Tskin_avg, domain_out, &
-                          FIA_out%Tskin_avg, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_x, domain_out, &
+                           FIA_out%WindStr_x, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_y, domain_out, &
+                           FIA_out%WindStr_y, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_ocn_x, domain_out, &
+                           FIA_out%WindStr_ocn_x, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_ocn_y, domain_out, &
+                           FIA_out%WindStr_ocn_y, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%p_atm_surf, domain_out, &
+                           FIA_out%p_atm_surf, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%runoff, domain_out, &
+                           FIA_out%runoff, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%calving, domain_out, &
+                           FIA_out%calving, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%runoff_hflx, domain_out, &
+                           FIA_out%runoff_hflx, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%calving_hflx, domain_out, &
+                           FIA_out%calving_hflx, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%Tskin_avg, domain_out, &
+                           FIA_out%Tskin_avg, complete=.false.)
     do b=1,size(FIA_in%flux_sw_dn,3)
-      call mpp_redistribute(domain_in, FIA_in%flux_sw_dn(:,:,b), domain_out, &
-                            FIA_out%flux_sw_dn(:,:,b), complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_sw_dn(:,:,b), domain_out, &
+                             FIA_out%flux_sw_dn(:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, FIA_in%ice_free, domain_out, &
-                          FIA_out%ice_free, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%ice_cover, domain_out, &
-                          FIA_out%ice_cover, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%ice_free, domain_out, &
+                           FIA_out%ice_free, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%ice_cover, domain_out, &
+                           FIA_out%ice_cover, complete=.true.)
 
     if (allocated(FIA_in%flux_sh0)) then
-      call mpp_redistribute(domain_in, FIA_in%flux_sh0, domain_out, &
-                            FIA_out%flux_sh0, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%evap0, domain_out, &
-                            FIA_out%evap0, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%flux_lw0, domain_out, &
-                            FIA_out%flux_lw0, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%dshdt, domain_out, &
-                            FIA_out%dshdt, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%devapdt, domain_out, &
-                            FIA_out%devapdt, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%dlwdt, domain_out, &
-                            FIA_out%dlwdt, complete=.true.)
-      call mpp_redistribute(domain_in, FIA_in%Tskin_cat, domain_out, &
-                            FIA_out%Tskin_cat, complete=.true.)
+      call redistribute_data(domain_in, FIA_in%flux_sh0, domain_out, &
+                             FIA_out%flux_sh0, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%evap0, domain_out, &
+                             FIA_out%evap0, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_lw0, domain_out, &
+                             FIA_out%flux_lw0, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%dshdt, domain_out, &
+                             FIA_out%dshdt, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%devapdt, domain_out, &
+                             FIA_out%devapdt, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%dlwdt, domain_out, &
+                             FIA_out%dlwdt, complete=.true.)
+      call redistribute_data(domain_in, FIA_in%Tskin_cat, domain_out, &
+                             FIA_out%Tskin_cat, complete=.true.)
     endif
 
   elseif (associated(FIA_out)) then
@@ -1730,73 +1730,73 @@ subroutine redistribute_FIA_to_FIA(FIA_in, FIA_out, domain_in, domain_out, G_out
     call coupler_type_redistribute_data(null_bc, domain_in, &
                           FIA_out%tr_flux, domain_out, complete=.false.)
     do b=1,size(FIA_out%flux_sw_top,4)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%flux_sw_top(:,:,:,b), complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%flux_sw_top(:,:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%flux_sh_top, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%evap_top, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%flux_lw_top, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%flux_lh_top, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%lprec_top, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%fprec_top, complete=.true.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%flux_sh_top, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%evap_top, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%flux_lw_top, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%flux_lh_top, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%lprec_top, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%fprec_top, complete=.true.)
 
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%tmelt, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%bmelt, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          FIA_out%sw_abs_ocn, complete=.true.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%tmelt, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%bmelt, complete=.false.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           FIA_out%sw_abs_ocn, complete=.true.)
 
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%WindStr_x, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%WindStr_y, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%WindStr_ocn_x, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%WindStr_ocn_y, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%p_atm_surf, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%runoff, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%calving, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%runoff_hflx, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%calving_hflx, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%Tskin_avg, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%WindStr_x, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%WindStr_y, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%WindStr_ocn_x, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%WindStr_ocn_y, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%p_atm_surf, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%runoff, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%calving, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%runoff_hflx, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%calving_hflx, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%Tskin_avg, complete=.false.)
     do b=1,size(FIA_out%flux_sw_dn,3)
-      call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                            FIA_out%flux_sw_dn(:,:,b), complete=.false.)
+      call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                             FIA_out%flux_sw_dn(:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%ice_free, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          FIA_out%ice_cover, complete=.true.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%ice_free, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           FIA_out%ice_cover, complete=.true.)
 
     if (allocated(FIA_out%flux_sh0)) then
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%flux_sh0, complete=.false.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%evap0, complete=.false.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%flux_lw0, complete=.false.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%dshdt, complete=.false.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%devapdt, complete=.false.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%dlwdt, complete=.true.)
-      call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                            FIA_out%Tskin_cat, complete=.true.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%flux_sh0, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%evap0, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%flux_lw0, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%dshdt, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%devapdt, complete=.false.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%dlwdt, complete=.true.)
+      call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                             FIA_out%Tskin_cat, complete=.true.)
     endif
 
 
@@ -1805,73 +1805,73 @@ subroutine redistribute_FIA_to_FIA(FIA_in, FIA_out, domain_in, domain_out, G_out
     call coupler_type_redistribute_data(FIA_in%tr_flux, domain_in, &
                           null_bc, domain_out, complete=.false.)
     do b=1,size(FIA_in%flux_sw_top,4)
-      call mpp_redistribute(domain_in, FIA_in%flux_sw_top(:,:,:,b), domain_out, &
-                            null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_sw_top(:,:,:,b), domain_out, &
+                             null_ptr3D, complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, FIA_in%flux_sh_top, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%evap_top, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%flux_lw_top, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%flux_lh_top, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%lprec_top, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%fprec_top, domain_out, &
-                          null_ptr3D, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%flux_sh_top, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%evap_top, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%flux_lw_top, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%flux_lh_top, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%lprec_top, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%fprec_top, domain_out, &
+                           null_ptr3D, complete=.true.)
 
-    call mpp_redistribute(domain_in, FIA_in%tmelt, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%bmelt, domain_out, &
-                          null_ptr3D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%sw_abs_ocn, domain_out, &
-                          null_ptr3D, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%tmelt, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%bmelt, domain_out, &
+                           null_ptr3D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%sw_abs_ocn, domain_out, &
+                           null_ptr3D, complete=.true.)
 
-    call mpp_redistribute(domain_in, FIA_in%WindStr_x, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_y, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_ocn_x, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%WindStr_ocn_y, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%p_atm_surf, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%runoff, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%calving, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%runoff_hflx, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%calving_hflx, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%Tskin_avg, domain_out, &
-                          null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_x, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_y, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_ocn_x, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%WindStr_ocn_y, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%p_atm_surf, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%runoff, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%calving, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%runoff_hflx, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%calving_hflx, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%Tskin_avg, domain_out, &
+                           null_ptr2D, complete=.false.)
     do b=1,size(FIA_in%flux_sw_dn,3)
-      call mpp_redistribute(domain_in, FIA_in%flux_sw_dn(:,:,b), domain_out, &
-                            null_ptr2D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_sw_dn(:,:,b), domain_out, &
+                             null_ptr2D, complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, FIA_in%ice_free, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, FIA_in%ice_cover, domain_out, &
-                          null_ptr2D, complete=.true.)
+    call redistribute_data(domain_in, FIA_in%ice_free, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, FIA_in%ice_cover, domain_out, &
+                           null_ptr2D, complete=.true.)
 
     if (allocated(FIA_in%flux_sh0)) then
-      call mpp_redistribute(domain_in, FIA_in%flux_sh0, domain_out, &
-                            null_ptr3D, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%evap0, domain_out, &
-                            null_ptr3D, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%flux_lw0, domain_out, &
-                            null_ptr3D, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%dshdt, domain_out, &
-                            null_ptr3D, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%devapdt, domain_out, &
-                            null_ptr3D, complete=.false.)
-      call mpp_redistribute(domain_in, FIA_in%dlwdt, domain_out, &
-                            null_ptr3D, complete=.true.)
-      call mpp_redistribute(domain_in, FIA_in%Tskin_cat, domain_out, &
-                            null_ptr3D, complete=.true.)
+      call redistribute_data(domain_in, FIA_in%flux_sh0, domain_out, &
+                             null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%evap0, domain_out, &
+                             null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%flux_lw0, domain_out, &
+                             null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%dshdt, domain_out, &
+                             null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%devapdt, domain_out, &
+                             null_ptr3D, complete=.false.)
+      call redistribute_data(domain_in, FIA_in%dlwdt, domain_out, &
+                             null_ptr3D, complete=.true.)
+      call redistribute_data(domain_in, FIA_in%Tskin_cat, domain_out, &
+                             null_ptr3D, complete=.true.)
     endif
 
   else
@@ -1960,61 +1960,61 @@ subroutine redistribute_TSF_to_TSF(TSF_in, TSF_out, domain_in, domain_out, HI_ou
     call coupler_type_redistribute_data(TSF_in%tr_flux, domain_in, &
                           TSF_out%tr_flux, domain_out, complete=.false.)
     do b=1,size(TSF_in%flux_sw,3)
-      call mpp_redistribute(domain_in, TSF_in%flux_sw(:,:,b), domain_out, &
-                          TSF_out%flux_sw(:,:,b), complete=.false.)
+      call redistribute_data(domain_in, TSF_in%flux_sw(:,:,b), domain_out, &
+                             TSF_out%flux_sw(:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, TSF_in%flux_sh, domain_out, &
-                          TSF_out%flux_sh, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%flux_lw, domain_out, &
-                          TSF_out%flux_lw, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%flux_lh, domain_out, &
-                          TSF_out%flux_lh, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%evap, domain_out, &
-                          TSF_out%evap, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%lprec, domain_out, &
-                          TSF_out%lprec, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%fprec, domain_out, &
-                          TSF_out%fprec, complete=.true.)
+    call redistribute_data(domain_in, TSF_in%flux_sh, domain_out, &
+                           TSF_out%flux_sh, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%flux_lw, domain_out, &
+                           TSF_out%flux_lw, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%flux_lh, domain_out, &
+                           TSF_out%flux_lh, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%evap, domain_out, &
+                           TSF_out%evap, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%lprec, domain_out, &
+                           TSF_out%lprec, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%fprec, domain_out, &
+                           TSF_out%fprec, complete=.true.)
   elseif (associated(TSF_out)) then
     ! Use the null pointer in place of the unneeded input arrays.
     call coupler_type_redistribute_data(null_bc, domain_in, &
                           TSF_out%tr_flux, domain_out, complete=.false.)
     do b=1,size(TSF_out%flux_sw,3)
-      call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%flux_sw(:,:,b), complete=.false.)
+      call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                             TSF_out%flux_sw(:,:,b), complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%flux_sh, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%flux_lw, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%flux_lh, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%evap, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%lprec, complete=.false.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          TSF_out%fprec, complete=.true.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%flux_sh, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%flux_lw, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%flux_lh, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%evap, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%lprec, complete=.false.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           TSF_out%fprec, complete=.true.)
   elseif (associated(TSF_in)) then
     ! Use the null pointer in place of the unneeded output arrays.
     call coupler_type_redistribute_data(TSF_in%tr_flux, domain_in, &
                           null_bc, domain_out, complete=.false.)
     do b=1,size(TSF_in%flux_sw,3)
-      call mpp_redistribute(domain_in, TSF_in%flux_sw(:,:,b), domain_out, &
-                            null_ptr2D, complete=.false.)
+      call redistribute_data(domain_in, TSF_in%flux_sw(:,:,b), domain_out, &
+                             null_ptr2D, complete=.false.)
     enddo
-    call mpp_redistribute(domain_in, TSF_in%flux_sh, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%flux_lw, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%flux_lh, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%evap, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%lprec, domain_out, &
-                          null_ptr2D, complete=.false.)
-    call mpp_redistribute(domain_in, TSF_in%fprec, domain_out, &
-                          null_ptr2D, complete=.true.)
+    call redistribute_data(domain_in, TSF_in%flux_sh, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%flux_lw, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%flux_lh, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%evap, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%lprec, domain_out, &
+                           null_ptr2D, complete=.false.)
+    call redistribute_data(domain_in, TSF_in%fprec, domain_out, &
+                           null_ptr2D, complete=.true.)
   else
     call SIS_error(FATAL, "redistribute_TSF_to_TSF called with "//&
                           "neither TSF_in nor TSF_out associated.")
@@ -2077,22 +2077,22 @@ subroutine redistribute_Rad_to_Rad(Rad_in, Rad_out, domain_in, domain_out)
   integer :: m
 
   if (associated(Rad_out) .and. associated(Rad_in)) then
-    call mpp_redistribute(domain_in, Rad_in%tskin_rad, domain_out, &
-                          Rad_out%tskin_rad, complete=.true.)
-    call mpp_redistribute(domain_in, Rad_in%coszen_lastrad, domain_out, &
-                          Rad_out%coszen_lastrad, complete=.true.)
+    call redistribute_data(domain_in, Rad_in%tskin_rad, domain_out, &
+                           Rad_out%tskin_rad, complete=.true.)
+    call redistribute_data(domain_in, Rad_in%coszen_lastrad, domain_out, &
+                           Rad_out%coszen_lastrad, complete=.true.)
   elseif (associated(Rad_out)) then
     ! Use the null pointers in place of the unneeded input arrays.
-    call mpp_redistribute(domain_in, null_ptr3D, domain_out, &
-                          Rad_out%tskin_rad, complete=.true.)
-    call mpp_redistribute(domain_in, null_ptr2D, domain_out, &
-                          Rad_out%coszen_lastrad, complete=.true.)
+    call redistribute_data(domain_in, null_ptr3D, domain_out, &
+                           Rad_out%tskin_rad, complete=.true.)
+    call redistribute_data(domain_in, null_ptr2D, domain_out, &
+                           Rad_out%coszen_lastrad, complete=.true.)
   elseif (associated(Rad_in)) then
     ! Use the null pointers in place of the unneeded output arrays.
-    call mpp_redistribute(domain_in, Rad_in%tskin_rad, domain_out, &
-                          null_ptr3D, complete=.true.)
-    call mpp_redistribute(domain_in, Rad_in%coszen_lastrad, domain_out, &
-                          null_ptr2D, complete=.true.)
+    call redistribute_data(domain_in, Rad_in%tskin_rad, domain_out, &
+                           null_ptr3D, complete=.true.)
+    call redistribute_data(domain_in, Rad_in%coszen_lastrad, domain_out, &
+                           null_ptr2D, complete=.true.)
   else
     call SIS_error(FATAL, "redistribute_Rad_to_Rad called with "//&
                           "neither Rad_in nor Rad_out associated.")

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -17,6 +17,7 @@ use MOM_io,            only : file_exists, close_file, slasher, ensembler
 use MOM_io,            only : open_namelist_file, check_nml_error
 use MOM_time_manager,  only : time_type, time_type_to_real, real_to_time_type
 use MOM_time_manager,  only : operator(+), operator(-), operator(>)
+use SIS_framework,     only : domain2D, get_layout, get_compute_domain
 
 use ice_model_mod,     only : ice_data_type, ice_model_end
 use ice_model_mod,     only : update_ice_slow_thermo, update_ice_dynamics_trans
@@ -26,7 +27,6 @@ use ocean_model_mod,   only : ocean_public_type, ocean_state_type, ice_ocean_bou
 use coupler_types_mod, only : coupler_type_send_data, coupler_type_data_override
 use coupler_types_mod, only : coupler_type_copy_data
 use data_override_mod, only : data_override
-use mpp_domains_mod,   only : domain2D, mpp_get_layout, mpp_get_compute_domain
 
 implicit none ; private
 
@@ -253,12 +253,12 @@ function same_domain(a, b)
 
   ! This does a limited number of checks for consistent domain sizes.
 
-  call mpp_get_layout(a, layout_a)
-  call mpp_get_layout(b, layout_b)
+  call get_layout(a, layout_a)
+  call get_layout(b, layout_b)
   same_domain = ((layout_a(1) == layout_b(1)) .and. (layout_a(2) == layout_b(2)))
 
-  call mpp_get_compute_domain(a, xsize=isize_a, ysize=jsize_a)
-  call mpp_get_compute_domain(b, xsize=isize_b, ysize=jsize_b)
+  call get_compute_domain(a, xsize=isize_a, ysize=jsize_a)
+  call get_compute_domain(b, xsize=isize_b, ysize=jsize_b)
 
   same_domain = same_domain .and. ((layout_a(1) == layout_b(1)) .and. &
                                    (layout_a(2) == layout_b(2)))

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -6,13 +6,6 @@ module ice_age_tracer
 ! ashao: Get all the dependencies from other modules (check against
 !   ideal_age_example.F90)
 
-use SIS_diag_mediator, only     : register_SIS_diag_field, &
-                                  safe_alloc_ptr
-use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
-use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type
-use SIS_hor_grid, only          : sis_hor_grid_type
-use SIS_utils, only             : post_avg
-
 use MOM_file_parser, only       : get_param, log_param, log_version, param_file_type
 use MOM_restart, only           : query_initialized, MOM_restart_CS
 use MOM_io, only                : vardesc, var_desc, query_vardesc, file_exists
@@ -22,11 +15,13 @@ use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING
 use MOM_error_handler, only     : SIS_mesg=>MOM_mesg
 use MOM_string_functions, only  : slasher
 use MOM_unit_scaling, only      : unit_scale_type
-
-use fms_mod, only               : read_data
-use fms_io_mod, only            : register_restart_field, restore_state
-use fms_io_mod, only            : restart_file_type
-
+use SIS_diag_mediator, only     : register_SIS_diag_field, safe_alloc_ptr
+use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
+use SIS_framework, only         : register_restart_field, restore_state
+use SIS_framework, only         : restart_file_type
+use SIS_hor_grid, only          : SIS_hor_grid_type
+use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type
+use SIS_utils, only             : post_avg
 use ice_grid, only              : ice_grid_type
 
 implicit none ; private

--- a/src/ice_boundary_types.F90
+++ b/src/ice_boundary_types.F90
@@ -10,9 +10,9 @@ module ice_boundary_types
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
 use coupler_types_mod, only : coupler_2d_bc_type, coupler_3d_bc_type, coupler_type_write_chksums
-use fms_mod,           only : stdout
-use mpp_mod,           only : mpp_chksum
-use mpp_parameter_mod, only : CGRID_NE, BGRID_NE, AGRID
+use MOM_error_handler, only : stdout
+use MOM_domains,       only : CGRID_NE, BGRID_NE, AGRID
+use SIS_framework,     only : SIS_chksum
 
 implicit none ; private
 
@@ -125,13 +125,13 @@ subroutine ocn_ice_bnd_type_chksum(id, timestep, bnd_type)
 
   outunit = stdout()
   write(outunit,*) 'BEGIN CHECKSUM(ocean_ice_boundary_type):: ', id, timestep
-  write(outunit,100) 'ocn_ice_bnd_type%u        ',mpp_chksum(bnd_type%u        )
-  write(outunit,100) 'ocn_ice_bnd_type%v        ',mpp_chksum(bnd_type%v        )
-  write(outunit,100) 'ocn_ice_bnd_type%t        ',mpp_chksum(bnd_type%t        )
-  write(outunit,100) 'ocn_ice_bnd_type%s        ',mpp_chksum(bnd_type%s        )
-  write(outunit,100) 'ocn_ice_bnd_type%frazil   ',mpp_chksum(bnd_type%frazil   )
-  write(outunit,100) 'ocn_ice_bnd_type%sea_level',mpp_chksum(bnd_type%sea_level)
-  !    write(outunit,100) 'ocn_ice_bnd_type%data     ',mpp_chksum(bnd_type%data     )
+  write(outunit,100) 'ocn_ice_bnd_type%u        ', SIS_chksum(bnd_type%u        )
+  write(outunit,100) 'ocn_ice_bnd_type%v        ', SIS_chksum(bnd_type%v        )
+  write(outunit,100) 'ocn_ice_bnd_type%t        ', SIS_chksum(bnd_type%t        )
+  write(outunit,100) 'ocn_ice_bnd_type%s        ', SIS_chksum(bnd_type%s        )
+  write(outunit,100) 'ocn_ice_bnd_type%frazil   ', SIS_chksum(bnd_type%frazil   )
+  write(outunit,100) 'ocn_ice_bnd_type%sea_level', SIS_chksum(bnd_type%sea_level)
+  !    write(outunit,100) 'ocn_ice_bnd_type%data     ', SIS_chksum(bnd_type%data     )
   100 FORMAT("CHECKSUM::",A32," = ",Z20)
 
   call coupler_type_write_chksums(bnd_type%fields, outunit, 'oibt%')
@@ -147,32 +147,32 @@ subroutine atm_ice_bnd_type_chksum(id, timestep, bnd_type)
 
   outunit = stdout()
   write(outunit,*) 'BEGIN CHECKSUM(atmos_ice_boundary_type):: ', id, timestep
-  write(outunit,100) 'atm_ice_bnd_type%u_flux          ',mpp_chksum(bnd_type%u_flux)
-  write(outunit,100) 'atm_ice_bnd_type%v_flux          ',mpp_chksum(bnd_type%v_flux)
-  write(outunit,100) 'atm_ice_bnd_type%u_star          ',mpp_chksum(bnd_type%u_star)
-  write(outunit,100) 'atm_ice_bnd_type%t_flux          ',mpp_chksum(bnd_type%t_flux)
-  write(outunit,100) 'atm_ice_bnd_type%q_flux          ',mpp_chksum(bnd_type%q_flux)
-  write(outunit,100) 'atm_ice_bnd_type%lw_flux         ',mpp_chksum(bnd_type%lw_flux)
-  write(outunit,100) 'atm_ice_bnd_type%sw_flux_vis_dir ',mpp_chksum(bnd_type%sw_flux_vis_dir)
-  write(outunit,100) 'atm_ice_bnd_type%sw_flux_vis_dif ',mpp_chksum(bnd_type%sw_flux_vis_dif)
-  write(outunit,100) 'atm_ice_bnd_type%sw_flux_nir_dir ',mpp_chksum(bnd_type%sw_flux_nir_dir)
-  write(outunit,100) 'atm_ice_bnd_type%sw_flux_nir_dif ',mpp_chksum(bnd_type%sw_flux_nir_dif)
+  write(outunit,100) 'atm_ice_bnd_type%u_flux          ', SIS_chksum(bnd_type%u_flux)
+  write(outunit,100) 'atm_ice_bnd_type%v_flux          ', SIS_chksum(bnd_type%v_flux)
+  write(outunit,100) 'atm_ice_bnd_type%u_star          ', SIS_chksum(bnd_type%u_star)
+  write(outunit,100) 'atm_ice_bnd_type%t_flux          ', SIS_chksum(bnd_type%t_flux)
+  write(outunit,100) 'atm_ice_bnd_type%q_flux          ', SIS_chksum(bnd_type%q_flux)
+  write(outunit,100) 'atm_ice_bnd_type%lw_flux         ', SIS_chksum(bnd_type%lw_flux)
+  write(outunit,100) 'atm_ice_bnd_type%sw_flux_vis_dir ', SIS_chksum(bnd_type%sw_flux_vis_dir)
+  write(outunit,100) 'atm_ice_bnd_type%sw_flux_vis_dif ', SIS_chksum(bnd_type%sw_flux_vis_dif)
+  write(outunit,100) 'atm_ice_bnd_type%sw_flux_nir_dir ', SIS_chksum(bnd_type%sw_flux_nir_dir)
+  write(outunit,100) 'atm_ice_bnd_type%sw_flux_nir_dif ', SIS_chksum(bnd_type%sw_flux_nir_dif)
   if (associated(bnd_type%sw_down_vis_dir)) &
-    write(outunit,100) 'atm_ice_bnd_type%sw_down_vis_dir ',mpp_chksum(bnd_type%sw_down_vis_dir)
+    write(outunit,100) 'atm_ice_bnd_type%sw_down_vis_dir ', SIS_chksum(bnd_type%sw_down_vis_dir)
   if (associated(bnd_type%sw_down_vis_dif)) &
-    write(outunit,100) 'atm_ice_bnd_type%sw_down_vis_dif ',mpp_chksum(bnd_type%sw_down_vis_dif)
+    write(outunit,100) 'atm_ice_bnd_type%sw_down_vis_dif ', SIS_chksum(bnd_type%sw_down_vis_dif)
   if (associated(bnd_type%sw_down_nir_dir)) &
-    write(outunit,100) 'atm_ice_bnd_type%sw_down_nir_dir ',mpp_chksum(bnd_type%sw_down_nir_dir)
+    write(outunit,100) 'atm_ice_bnd_type%sw_down_nir_dir ', SIS_chksum(bnd_type%sw_down_nir_dir)
   if (associated(bnd_type%sw_down_nir_dif)) &
-    write(outunit,100) 'atm_ice_bnd_type%sw_down_nir_dif ',mpp_chksum(bnd_type%sw_down_nir_dif)
-  write(outunit,100) 'atm_ice_bnd_type%lprec           ',mpp_chksum(bnd_type%lprec)
-  write(outunit,100) 'atm_ice_bnd_type%fprec           ',mpp_chksum(bnd_type%fprec)
-  write(outunit,100) 'atm_ice_bnd_type%dhdt            ',mpp_chksum(bnd_type%dhdt)
-  write(outunit,100) 'atm_ice_bnd_type%dedt            ',mpp_chksum(bnd_type%dedt)
-  write(outunit,100) 'atm_ice_bnd_type%drdt            ',mpp_chksum(bnd_type%drdt)
-  write(outunit,100) 'atm_ice_bnd_type%coszen          ',mpp_chksum(bnd_type%coszen)
-  write(outunit,100) 'atm_ice_bnd_type%p               ',mpp_chksum(bnd_type%p)
-!    write(outunit,100) 'atm_ice_bnd_type%data            ',mpp_chksum(bnd_type%data)
+    write(outunit,100) 'atm_ice_bnd_type%sw_down_nir_dif ', SIS_chksum(bnd_type%sw_down_nir_dif)
+  write(outunit,100) 'atm_ice_bnd_type%lprec           ', SIS_chksum(bnd_type%lprec)
+  write(outunit,100) 'atm_ice_bnd_type%fprec           ', SIS_chksum(bnd_type%fprec)
+  write(outunit,100) 'atm_ice_bnd_type%dhdt            ', SIS_chksum(bnd_type%dhdt)
+  write(outunit,100) 'atm_ice_bnd_type%dedt            ', SIS_chksum(bnd_type%dedt)
+  write(outunit,100) 'atm_ice_bnd_type%drdt            ', SIS_chksum(bnd_type%drdt)
+  write(outunit,100) 'atm_ice_bnd_type%coszen          ', SIS_chksum(bnd_type%coszen)
+  write(outunit,100) 'atm_ice_bnd_type%p               ', SIS_chksum(bnd_type%p)
+!    write(outunit,100) 'atm_ice_bnd_type%data            ', SIS_chksum(bnd_type%data)
 100 FORMAT("CHECKSUM::",A32," = ",Z20)
 
 end subroutine atm_ice_bnd_type_chksum
@@ -186,11 +186,11 @@ subroutine lnd_ice_bnd_type_chksum(id, timestep, bnd_type)
 
   outunit = stdout()
   write(outunit,*) 'BEGIN CHECKSUM(land_ice_boundary_type):: ', id, timestep
-  write(outunit,100) 'lnd_ice_bnd_type%runoff  ',mpp_chksum(bnd_type%runoff)
-  write(outunit,100) 'lnd_ice_bnd_type%calving ',mpp_chksum(bnd_type%calving)
-  write(outunit,100) 'lnd_ice_bnd_type%runoff_hflx ',mpp_chksum(bnd_type%runoff_hflx)
-  write(outunit,100) 'lnd_ice_bnd_type%calving_hflx',mpp_chksum(bnd_type%calving_hflx)
-  !    write(outunit,100) 'lnd_ice_bnd_type%data    ',mpp_chksum(bnd_type%data)
+  write(outunit,100) 'lnd_ice_bnd_type%runoff  ', SIS_chksum(bnd_type%runoff)
+  write(outunit,100) 'lnd_ice_bnd_type%calving ', SIS_chksum(bnd_type%calving)
+  write(outunit,100) 'lnd_ice_bnd_type%runoff_hflx ', SIS_chksum(bnd_type%runoff_hflx)
+  write(outunit,100) 'lnd_ice_bnd_type%calving_hflx', SIS_chksum(bnd_type%calving_hflx)
+  !    write(outunit,100) 'lnd_ice_bnd_type%data    ', SIS_chksum(bnd_type%data)
   100 FORMAT("CHECKSUM::",A32," = ",Z20)
 end subroutine lnd_ice_bnd_type_chksum
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -45,9 +45,6 @@ use MOM_unit_scaling,  only : unit_scaling_end, fix_restart_unit_scaling
 use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
 use coupler_types_mod, only : coupler_type_spawn, coupler_type_initialized
 use coupler_types_mod, only : coupler_type_rescale_data, coupler_type_copy_data
-use fms_io_mod, only : set_domain, nullify_domain, restore_state, query_initialized
-use fms_io_mod, only : register_restart_field, restart_file_type
-use mpp_domains_mod, only : mpp_broadcast_domain
 
 use astronomy_mod, only : astronomy_init, astronomy_end
 use astronomy_mod, only : universal_time, orbital_time, diurnal_solar, daily_mean_solar
@@ -80,6 +77,8 @@ use SIS_fast_thermo,   only : accumulate_deposition_fluxes, convert_frost_to_sno
 use SIS_fast_thermo,   only : do_update_ice_model_fast, avg_top_quantities, total_top_quantities
 use SIS_fast_thermo,   only : redo_update_ice_model_fast, find_excess_fluxes
 use SIS_fast_thermo,   only : infill_array, SIS_fast_thermo_init, SIS_fast_thermo_end
+use SIS_framework,     only : set_domain, nullify_domain, broadcast_domain
+use SIS_framework,     only : restart_file_type, restore_state, query_initialized, register_restart_field
 use SIS_fixed_initialization, only : SIS_initialize_fixed
 use SIS_get_input,     only : Get_SIS_input, directories
 use SIS_hor_grid,      only : SIS_hor_grid_type, set_hor_grid, SIS_hor_grid_end, set_first_direction
@@ -2665,10 +2664,10 @@ subroutine share_ice_domains(Ice)
   else
     allocate(Ice%fast_domain)
   endif
-  call mpp_broadcast_domain(Ice%Domain)
-  call mpp_broadcast_domain(Ice%slow_domain_NH)
-  call mpp_broadcast_domain(Ice%slow_domain)
-  call mpp_broadcast_domain(Ice%fast_domain)
+  call broadcast_domain(Ice%Domain)
+  call broadcast_domain(Ice%slow_domain_NH)
+  call broadcast_domain(Ice%slow_domain)
+  call broadcast_domain(Ice%fast_domain)
 
   if (Ice%shared_slow_fast_PEs) then
     ice_clock_exchange = cpu_clock_id('Ice Fast/Slow Exchange', grain=CLOCK_SUBCOMPONENT )

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -11,7 +11,7 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MO
 use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_hor_grid,      only : SIS_hor_grid_type
-use fms_io_mod,        only : register_restart_field, restart_file_type
+use SIS_framework,     only : register_restart_field, restart_file_type
 
 implicit none ; private
 

--- a/src/ice_spec.F90
+++ b/src/ice_spec.F90
@@ -1,14 +1,15 @@
 !> sea ice and SST specified from data as per GFDL climate group
 module ice_spec_mod
 
-use fms_mod, only: open_namelist_file, check_nml_error, close_file, &
-                   stdlog, stdout, mpp_pe, mpp_root_pe, write_version_number
-use mpp_mod, only: input_nml_file
-use mpp_domains_mod, only : domain2d
-use MOM_hor_index,   only : hor_index_type
-
-use time_manager_mod, only: time_type, get_date, set_date
 use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
+use fms_mod, only : write_version_number
+use mpp_mod, only : input_nml_file
+
+use MOM_error_handler, only : stdlog, stdout
+use MOM_hor_index,     only : hor_index_type
+use MOM_io,            only : open_namelist_file, check_nml_error, close_file
+use MOM_time_manager,  only : time_type, get_date, set_date
+use SIS_framework,     only : domain2d
 
 implicit none ;  private
 

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -1,33 +1,28 @@
 !> maintains the sea ice data, reads/writes restarts, reads the namelist and initializes diagnostics.
 module ice_type_mod
 
-use mpp_mod,          only: mpp_sum, stdout, input_nml_file, PE_here => mpp_pe, mpp_chksum
-use mpp_domains_mod,  only: domain2D, mpp_get_compute_domain, CORNER, EAST, NORTH
-use mpp_parameter_mod, only: CGRID_NE, BGRID_NE, AGRID
-use fms_mod,          only: open_namelist_file, check_nml_error, close_file, stdout
-use fms_io_mod,       only: save_restart, restore_state, query_initialized
-use fms_io_mod,       only: register_restart_field, restart_file_type
-use coupler_types_mod,only: coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
-use coupler_types_mod,only: coupler_type_spawn, coupler_type_write_chksums
-
-use SIS_hor_grid, only : SIS_hor_grid_type
-use ice_grid, only : ice_grid_type
-
-use SIS2_ice_thm, only : ice_thermo_type, enth_from_TS, energy_melt_EnthS
-use SIS2_ice_thm, only : get_SIS2_thermo_coefs, temp_from_En_S
-use ice_bergs, only : icebergs, icebergs_stock_pe, icebergs_save_restart
-
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg, is_root_pe
+use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
+use coupler_types_mod, only : coupler_type_spawn, coupler_type_write_chksums
+use ice_bergs,         only : icebergs, icebergs_stock_pe, icebergs_save_restart
+use ice_grid,          only : ice_grid_type
+use MOM_coms,          only : PE_here
+use MOM_domains,       only : CGRID_NE, BGRID_NE, AGRID
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg, stdout
 use MOM_file_parser,   only : param_file_type
 use MOM_hor_index,     only : hor_index_type
 use MOM_time_manager,  only : time_type, time_type_to_real
 use MOM_unit_scaling,  only : unit_scale_type
+use SIS_ctrl_types,    only : SIS_fast_CS, SIS_slow_CS
 use SIS_debugging,     only : chksum
 use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field
-
-use SIS_types, only : ice_state_type, fast_ice_avg_type
-use SIS_ctrl_types, only : SIS_fast_CS, SIS_slow_CS
+use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, SIS_chksum, get_compute_domain
+use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : save_restart, restore_state, query_initialized
+use SIS_hor_grid,      only : SIS_hor_grid_type
+use SIS_types,         only : ice_state_type, fast_ice_avg_type
+use SIS2_ice_thm,      only : ice_thermo_type, enth_from_TS, energy_melt_EnthS
+use SIS2_ice_thm,      only : get_SIS2_thermo_coefs, temp_from_En_S
 
 implicit none ; private
 
@@ -183,7 +178,7 @@ subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call mpp_get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_compute_domain(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   ! The fields t_surf, s_surf, and part_size are only available on fast PEs.
@@ -286,7 +281,7 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call mpp_get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_compute_domain(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   allocate(Ice%t_surf(isc:iec, jsc:jec, km)) ; Ice%t_surf(:,:,:) = 0.0
@@ -629,61 +624,68 @@ end subroutine ice_stock_pe
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> Write chksums of fields in the ice data type, using interfaces that shared
 !! with older sea ice models
-subroutine ice_data_type_chksum(mesg, timestep, Ice)
-  character(len=*), intent(in) :: mesg  !< An identifying message
-  integer         , intent(in) :: timestep !< The timestep number
-  type(ice_data_type), intent(in) :: Ice !< The publicly visible ice data type.
+subroutine ice_data_type_chksum(mesg, timestep, Ice, init_call)
+  character(len=*),    intent(in) :: mesg      !< An identifying message
+  integer         ,    intent(in) :: timestep  !< The timestep number
+  type(ice_data_type), intent(in) :: Ice       !< The publicly visible ice data type.
+  logical, optional,   intent(in) :: init_call !< If true omit checksums that do not make sense
+                                               !! to output during initialization.
 
   ! Local variables
-  integer ::   n, m, outunit
+  logical :: init    ! If true, omit checksums that do not make sense to output
+                     ! during initialization.
+  integer :: outunit ! The output unit to write to.
 
   outunit = stdout()
   write(outunit,*) "BEGIN CHECKSUM(ice_data_type):: ", mesg, timestep
 
-
   if (Ice%fast_ice_PE) then
     ! These fields are only valid on fast ice PEs.
-    write(outunit,100) 'ice_data_type%part_size          ',mpp_chksum(Ice%part_size       )
-    write(outunit,100) 'ice_data_type%t_surf             ',mpp_chksum(Ice%t_surf          )
-    write(outunit,100) 'ice_data_type%s_surf             ',mpp_chksum(Ice%s_surf          )
-    write(outunit,100) 'ice_data_type%albedo             ',mpp_chksum(Ice%albedo          )
-    write(outunit,100) 'ice_data_type%albedo_vis_dir     ',mpp_chksum(Ice%albedo_vis_dir  )
-    write(outunit,100) 'ice_data_type%albedo_nir_dir     ',mpp_chksum(Ice%albedo_nir_dir  )
-    write(outunit,100) 'ice_data_type%albedo_vis_dif     ',mpp_chksum(Ice%albedo_vis_dif  )
-    write(outunit,100) 'ice_data_type%albedo_nir_dif     ',mpp_chksum(Ice%albedo_nir_dif  )
-    write(outunit,100) 'ice_data_type%rough_mom          ',mpp_chksum(Ice%rough_mom       )
-    write(outunit,100) 'ice_data_type%rough_heat         ',mpp_chksum(Ice%rough_heat      )
-    write(outunit,100) 'ice_data_type%rough_moist        ',mpp_chksum(Ice%rough_moist     )
+    if (.not.init) then
+      write(outunit,100) 'ice_data_type%part_size          ', SIS_chksum(Ice%part_size       )
+      write(outunit,100) 'ice_data_type%t_surf             ', SIS_chksum(Ice%t_surf          )
+      write(outunit,100) 'ice_data_type%s_surf             ', SIS_chksum(Ice%s_surf          )
+      write(outunit,100) 'ice_data_type%albedo             ', SIS_chksum(Ice%albedo          )
+      write(outunit,100) 'ice_data_type%albedo_vis_dir     ', SIS_chksum(Ice%albedo_vis_dir  )
+      write(outunit,100) 'ice_data_type%albedo_nir_dir     ', SIS_chksum(Ice%albedo_nir_dir  )
+      write(outunit,100) 'ice_data_type%albedo_vis_dif     ', SIS_chksum(Ice%albedo_vis_dif  )
+      write(outunit,100) 'ice_data_type%albedo_nir_dif     ', SIS_chksum(Ice%albedo_nir_dif  )
+    endif
+    write(outunit,100)   'ice_data_type%rough_mom          ', SIS_chksum(Ice%rough_mom       )
+    write(outunit,100)   'ice_data_type%rough_heat         ', SIS_chksum(Ice%rough_heat      )
+    write(outunit,100)   'ice_data_type%rough_moist        ', SIS_chksum(Ice%rough_moist     )
 
-    write(outunit,100) 'ice_data_type%u_surf             ',mpp_chksum(Ice%u_surf          )
-    write(outunit,100) 'ice_data_type%v_surf             ',mpp_chksum(Ice%v_surf          )
+    if (.not.init) then
+      write(outunit,100) 'ice_data_type%u_surf             ', SIS_chksum(Ice%u_surf          )
+      write(outunit,100) 'ice_data_type%v_surf             ', SIS_chksum(Ice%v_surf          )
+    endif
 
     call coupler_type_write_chksums(Ice%ocean_fields, outunit, 'ice%')
   endif
 
   if (Ice%slow_ice_PE) then
     ! These fields are only valid on slow ice PEs.
-    write(outunit,100) 'ice_data_type%flux_u             ',mpp_chksum(Ice%flux_u          )
-    write(outunit,100) 'ice_data_type%flux_v             ',mpp_chksum(Ice%flux_v          )
-    write(outunit,100) 'ice_data_type%flux_t             ',mpp_chksum(Ice%flux_t          )
-    write(outunit,100) 'ice_data_type%flux_q             ',mpp_chksum(Ice%flux_q          )
-    write(outunit,100) 'ice_data_type%flux_lw            ',mpp_chksum(Ice%flux_lw         )
-    write(outunit,100) 'ice_data_type%flux_sw_vis_dir    ',mpp_chksum(Ice%flux_sw_vis_dir )
-    write(outunit,100) 'ice_data_type%flux_sw_vis_dif    ',mpp_chksum(Ice%flux_sw_vis_dif )
-    write(outunit,100) 'ice_data_type%flux_sw_nir_dir    ',mpp_chksum(Ice%flux_sw_nir_dir )
-    write(outunit,100) 'ice_data_type%flux_sw_nir_dif    ',mpp_chksum(Ice%flux_sw_nir_dif )
-    write(outunit,100) 'ice_data_type%flux_lh            ',mpp_chksum(Ice%flux_lh         )
-    write(outunit,100) 'ice_data_type%lprec              ',mpp_chksum(Ice%lprec           )
-    write(outunit,100) 'ice_data_type%fprec              ',mpp_chksum(Ice%fprec           )
-    write(outunit,100) 'ice_data_type%p_surf             ',mpp_chksum(Ice%p_surf          )
-    write(outunit,100) 'ice_data_type%runoff             ',mpp_chksum(Ice%runoff          )
-    write(outunit,100) 'ice_data_type%calving            ',mpp_chksum(Ice%calving         )
-    write(outunit,100) 'ice_data_type%flux_salt          ',mpp_chksum(Ice%flux_salt       )
+    write(outunit,100) 'ice_data_type%flux_u             ', SIS_chksum(Ice%flux_u          )
+    write(outunit,100) 'ice_data_type%flux_v             ', SIS_chksum(Ice%flux_v          )
+    write(outunit,100) 'ice_data_type%flux_t             ', SIS_chksum(Ice%flux_t          )
+    write(outunit,100) 'ice_data_type%flux_q             ', SIS_chksum(Ice%flux_q          )
+    write(outunit,100) 'ice_data_type%flux_lw            ', SIS_chksum(Ice%flux_lw         )
+    write(outunit,100) 'ice_data_type%flux_sw_vis_dir    ', SIS_chksum(Ice%flux_sw_vis_dir )
+    write(outunit,100) 'ice_data_type%flux_sw_vis_dif    ', SIS_chksum(Ice%flux_sw_vis_dif )
+    write(outunit,100) 'ice_data_type%flux_sw_nir_dir    ', SIS_chksum(Ice%flux_sw_nir_dir )
+    write(outunit,100) 'ice_data_type%flux_sw_nir_dif    ', SIS_chksum(Ice%flux_sw_nir_dif )
+    write(outunit,100) 'ice_data_type%flux_lh            ', SIS_chksum(Ice%flux_lh         )
+    write(outunit,100) 'ice_data_type%lprec              ', SIS_chksum(Ice%lprec           )
+    write(outunit,100) 'ice_data_type%fprec              ', SIS_chksum(Ice%fprec           )
+    write(outunit,100) 'ice_data_type%p_surf             ', SIS_chksum(Ice%p_surf          )
+    write(outunit,100) 'ice_data_type%runoff             ', SIS_chksum(Ice%runoff          )
+    write(outunit,100) 'ice_data_type%calving            ', SIS_chksum(Ice%calving         )
+    write(outunit,100) 'ice_data_type%flux_salt          ', SIS_chksum(Ice%flux_salt       )
 
     if (associated(Ice%sCS)) then ; if (Ice%sCS%pass_iceberg_area_to_ocean) then
-      write(outunit,100) 'ice_data_type%ustar_berg         ',mpp_chksum(Ice%ustar_berg    )
-      write(outunit,100) 'ice_data_type%area_berg          ',mpp_chksum(Ice%area_berg     )
-      write(outunit,100) 'ice_data_type%mass_berg          ',mpp_chksum(Ice%mass_berg     )
+      write(outunit,100) 'ice_data_type%ustar_berg         ', SIS_chksum(Ice%ustar_berg    )
+      write(outunit,100) 'ice_data_type%area_berg          ', SIS_chksum(Ice%area_berg     )
+      write(outunit,100) 'ice_data_type%mass_berg          ', SIS_chksum(Ice%mass_berg     )
     endif ; endif
 
   endif


### PR DESCRIPTION
  Added the new module SIS_framework with interfaces to some FMS infrastructure
routines and direct infrastructure calls from throughout the SIS2 code either
through this new module or the MOM6 framework directory.  All calls ultimately
lead to the same code as before, but this should help to prevent ongoing changes
to FMS from requiring widespread changes in the SIS2 code and should in ensuring
continuity of answers as FMS evolves.  All answers and output files are bitwise
identical, but there are some new interface names and one new optional argument.
The commits in this PR include:

- NOAA-GFDL/SIS2@6b1f497 Access infrastructure routines via SIS_framework
- NOAA-GFDL/SIS2@9b73944 Use broadcast_domain in share_ice_domains
- NOAA-GFDL/SIS2@4de49b9 Use SIS_framework in combined_ice_ocean_driver.F90
- NOAA-GFDL/SIS2@1341f59 +Add init_call argument to ice_data_type_chksum
- NOAA-GFDL/SIS2@85946e0 Call SIS_chksum instead of mpp_chksum
- NOAA-GFDL/SIS2@86511f0 Call redistribute_data in SIS_types routines
- NOAA-GFDL/SIS2@ae5b3f1 +Add the new module SIS_framework
