### PR TITLE
Use init_call argument to ice_data_type_chksum

### DIFF
--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -637,6 +637,7 @@ subroutine ice_data_type_chksum(mesg, timestep, Ice, init_call)
   integer :: outunit ! The output unit to write to.
 
   outunit = stdout()
+  init = .false. ; if (present(init_call)) init = init_call
   write(outunit,*) "BEGIN CHECKSUM(ice_data_type):: ", mesg, timestep
 
   if (Ice%fast_ice_PE) then


### PR DESCRIPTION
  Added code to use the optional init_call argument to ice_data_type_chksum,
which was recently omitted when this optional argument was added in an attempt
to partially address SIS2 issue #102.  Without this change, the logical variable
init was being used but not set, so it would have been random whether some of
the chksums were being written.  All solutions are bitwise identical.