### PR TITLE
Fix data_override crash in interspersed ice mode

### DIFF
--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -150,6 +150,7 @@ subroutine ice_state_mass_init(IST, Ice, G, IG, US, PF, init_Time, just_read_par
   endif
 
   if (any_data_override) then
+    call data_override_init()      
     call data_override_unset_domains(unset_Ice=.true., must_be_set=.false.)
     call data_override_init(Ice_domain_in=Ice%slow_domain_NH)
   endif
@@ -311,6 +312,7 @@ subroutine ice_state_thermo_init(IST, Ice, G, IG, US, PF, init_Time, just_read_p
                         (trim(enth_snow_config)=="data_override")) .and. .not.just_read)
 
   if (any_data_override) then
+    call data_override_init()      
     call data_override_unset_domains(unset_Ice=.true., must_be_set=.false.)
     call data_override_init(Ice_domain_in=Ice%slow_domain_NH)
   endif


### PR DESCRIPTION
 CM4 highres in Interspersed Ice mode crashes when there is no ice_model.res.nc 
The crash happens on the two  calls to data_override_unset_domains on lines 155 and 315 because
  data_override is not initialized yet **on the fast ICE cores** that these ice calls run on.

I verified that this update fixes the issue.