### PR TITLE
+SIS2: Restructure SIS2 to use the framework module

### DIFF
--- a/src/SIS_continuity.F90
+++ b/src/SIS_continuity.F90
@@ -13,16 +13,14 @@ module SIS_continuity
 !*                                                                     *
 !********+*********+*********+*********+*********+*********+*********+**
 
-use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
+use ice_grid,          only : ice_grid_type
+use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_ROUTINE
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
+use MOM_file_parser,   only : get_param, log_version, param_file_type
 use MOM_obsolete_params, only : obsolete_logical
+use MOM_unit_scaling,  only : unit_scale_type
 use SIS_diag_mediator, only : time_type, SIS_diag_ctrl
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, is_root_pe
-use MOM_file_parser, only : get_param, log_version, param_file_type
-use MOM_unit_scaling,   only : unit_scale_type
-use SIS_hor_grid, only : SIS_hor_grid_type
-use ice_grid, only : ice_grid_type
-! use MOM_variables, only : ocean_OBC_type, OBC_SIMPLE
-! use MOM_variables, only : OBC_FLATHER_E, OBC_FLATHER_W, OBC_FLATHER_N, OBC_FLATHER_S
+use SIS_hor_grid,      only : SIS_hor_grid_type
 
 implicit none ; private
 
@@ -94,7 +92,7 @@ subroutine ice_continuity(u, v, hin, h, uh, vh, dt, G, US, IG, CS, use_h_neg, ma
                                                 !! zonal mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
   real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
                  optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
-                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+                                                !! meridional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
 
 !    This subroutine time steps the category thicknesses, using a monotonically
 !  limit, directionally split PPM scheme, based on Lin (1994).  In the following
@@ -603,7 +601,7 @@ subroutine summed_continuity(u, v, h_in, h, uh, vh, dt, G, US, IG, CS, h_ice)
 end subroutine summed_continuity
 
 !> proportionate_continuity time steps the category thickness changes due to advection,
-!! using input total mass fluxes with the fluxes proprotionate to the relative upwind
+!! using input total mass fluxes with the fluxes proportionate to the relative upwind
 !! thicknesses.
 subroutine proportionate_continuity(h_tot_in, uh_tot, vh_tot, dt, G, US, IG, CS, &
                                     h1, uh1, vh1, h2, uh2, vh2, h3, uh3, vh3)
@@ -957,7 +955,7 @@ subroutine merid_proportionate_fluxes(vh_tot, I_htot, h, vh, G, IG, LB, masking_
   type(loop_bounds_type),  intent(in)    :: LB  !< A structure with the active loop bounds.
   real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
                  optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
-                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+                                                !! meridional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
   real,          optional, intent(in)    :: frac_neglect  !< Any category with less than this fraction
                                                 !! of the total transport has no transport [nondim].
 
@@ -1177,7 +1175,7 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
                                                 !! is able to move out of a cell [R Z ~> kg m-2].
   real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
                  optional, intent(in)    :: masking_vh  !< If this is 0, vh = 0.  Often this is another
-                                                !! merional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
+                                                !! meridional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
   real, dimension(SZI_(G),SZJB_(G)), &
                  optional, intent(in)    :: masking_vhtot !< If this is 0, vh_tot = 0.  Often this is another
                                                 !! total meridional mass flux, e.g. of ice [R Z L2 T-1 ~> kg s-1].
@@ -1334,7 +1332,7 @@ subroutine PPM_reconstruction_x(h_in, h_l, h_r, G, LB, h_min, monotonic, simple_
                                                        !! Otherwise use a simple positive-definite limiter.
   logical, optional,                intent(in)  :: simple_2nd !< If true, use the arithmetic mean thicknesses as the
                                                        !! default edge values for a simple 2nd order scheme.
-! This subroutine calculates left/right edge valus for PPM reconstruction.
+! This subroutine calculates left/right edge values for PPM reconstruction.
 
   ! Local variables with useful mnemonic names.
   real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.
@@ -1426,7 +1424,7 @@ subroutine PPM_reconstruction_y(h_in, h_l, h_r, G, LB, h_min, monotonic, simple_
                                                        !! Otherwise use a simple positive-definite limiter.
   logical, optional,                intent(in)  :: simple_2nd !< If true, use the arithmetic mean thicknesses as the
                                                        !! default edge values for a simple 2nd order scheme.
-! This subroutine calculates left/right edge valus for PPM reconstruction.
+! This subroutine calculates left/right edge values for PPM reconstruction.
 
 ! Local variables with useful mnemonic names.
   real, dimension(SZI_(G),SZJ_(G))  :: slp ! The slopes.

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -2,9 +2,6 @@
 !! types, including allocation, deallocation, registration for restarts, and checksums.
 module SIS_ctrl_types
 
-use coupler_types_mod, only : coupler_2d_bc_type, coupler_3d_bc_type
-use coupler_types_mod, only : coupler_type_initialized, coupler_type_set_diags
-
 use ice_grid,          only : ice_grid_type
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_file_parser,   only : param_file_type
@@ -16,6 +13,8 @@ use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_dyn_trans,     only : dyn_trans_CS
 use SIS_fast_thermo,   only : fast_thermo_CS
 use SIS_framework,     only : domain2D, CORNER, EAST, NORTH
+use SIS_framework,     only : coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : coupler_type_initialized, coupler_type_set_diags
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_optics,        only : SIS_optics_CS
 use SIS_slow_thermo,   only : slow_thermo_CS

--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -13,10 +13,10 @@ use MOM_safe_alloc, only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_string_functions, only : lowercase, uppercase, slasher
 use MOM_time_manager, only : time_type
 
-use diag_manager_mod, only : diag_manager_init
-use diag_manager_mod, only : send_data, diag_axis_init,EAST,NORTH
+use diag_manager_mod, only : diag_manager_init, send_data, diag_axis_init
 use diag_manager_mod, only : register_diag_field_fms=>register_diag_field
 use diag_manager_mod, only : register_static_field_fms=>register_static_field
+use SIS_framework,    only : EAST, NORTH
 
 implicit none ; private
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -19,7 +19,7 @@ use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_di
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
 use SIS_debugging,     only : chksum, Bchksum, hchksum, check_redundant_B
 use SIS_debugging,     only : Bchksum_pair
-use SIS_framework,     only : register_restart_field, SIS_restart_CS
+use SIS_framework,     only : register_restart_field, SIS_restart_CS, safe_alloc_ptr
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use ice_ridging_mod,   only : ridge_rate
 
@@ -720,9 +720,10 @@ subroutine SIS_B_dyn_register_restarts(HI, param_file, CS, Ice_restart)
   endif
   allocate(CS)
 
-  allocate(CS%sig11(isd:ied, jsd:jed)) ; CS%sig11(:,:) = 0.0
-  allocate(CS%sig12(isd:ied, jsd:jed)) ; CS%sig12(:,:) = 0.0
-  allocate(CS%sig22(isd:ied, jsd:jed)) ; CS%sig22(:,:) = 0.0
+  call safe_alloc_ptr(CS%sig11, isd, ied, jsd, jed)
+  call safe_alloc_ptr(CS%sig12, isd, ied, jsd, jed)
+  call safe_alloc_ptr(CS%sig22, isd, ied, jsd, jed)
+
   if (associated(Ice_restart)) then
     call register_restart_field(Ice_restart, 'sig11', CS%sig11, mandatory=.false.)
     call register_restart_field(Ice_restart, 'sig22', CS%sig22, mandatory=.false.)

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -19,8 +19,7 @@ use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_di
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
 use SIS_debugging,     only : chksum, Bchksum, hchksum, check_redundant_B
 use SIS_debugging,     only : Bchksum_pair
-use SIS_framework,     only : register_restart_field, restart_file_type
-use SIS_framework,     only : domain2D
+use SIS_framework,     only : register_restart_field, SIS_restart_CS, domain2D
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use ice_ridging_mod,   only : ridge_rate
 
@@ -707,7 +706,7 @@ subroutine SIS_B_dyn_register_restarts(mpp_domain, HI, param_file, CS, Ice_resta
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(SIS_B_dyn_CS),      pointer    :: CS    !< The control structure for this module that
                                                !! will be allocated here
-  type(restart_file_type), pointer    :: Ice_restart !< The sea ice restart control structure
+  type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
   character(len=*),        intent(in) :: restart_file !< The ice restart file name
 
 !   This subroutine registers the restart variables associated with the
@@ -727,12 +726,9 @@ subroutine SIS_B_dyn_register_restarts(mpp_domain, HI, param_file, CS, Ice_resta
   allocate(CS%sig12(isd:ied, jsd:jed)) ; CS%sig12(:,:) = 0.0
   allocate(CS%sig22(isd:ied, jsd:jed)) ; CS%sig22(:,:) = 0.0
   if (associated(Ice_restart)) then
-    id = register_restart_field(Ice_restart, restart_file, 'sig11', CS%sig11, &
-                                domain=mpp_domain, mandatory=.false.)
-    id = register_restart_field(Ice_restart, restart_file, 'sig22', CS%sig22, &
-                                domain=mpp_domain, mandatory=.false.)
-    id = register_restart_field(Ice_restart, restart_file, 'sig12', CS%sig12, &
-                                domain=mpp_domain, mandatory=.false.)
+    call register_restart_field(Ice_restart, 'sig11', CS%sig11, mandatory=.false.)
+    call register_restart_field(Ice_restart, 'sig22', CS%sig22, mandatory=.false.)
+    call register_restart_field(Ice_restart, 'sig12', CS%sig12, mandatory=.false.)
   endif
 end subroutine SIS_B_dyn_register_restarts
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -19,7 +19,7 @@ use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_di
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
 use SIS_debugging,     only : chksum, Bchksum, hchksum, check_redundant_B
 use SIS_debugging,     only : Bchksum_pair
-use SIS_framework,     only : register_restart_field, SIS_restart_CS, domain2D
+use SIS_framework,     only : register_restart_field, SIS_restart_CS
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use ice_ridging_mod,   only : ridge_rate
 
@@ -700,14 +700,12 @@ end function sigII
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> SIS_B_dyn_register_restarts allocates and registers any variables for this
 !!      module that need to be included in the restart files.
-subroutine SIS_B_dyn_register_restarts(mpp_domain, HI, param_file, CS, Ice_restart, restart_file)
-  type(domain2d),          intent(in) :: mpp_domain !< The ice models' FMS domain type
+subroutine SIS_B_dyn_register_restarts(HI, param_file, CS, Ice_restart)
   type(hor_index_type),    intent(in) :: HI    !< The horizontal index type describing the domain
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(SIS_B_dyn_CS),      pointer    :: CS    !< The control structure for this module that
                                                !! will be allocated here
   type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in) :: restart_file !< The ice restart file name
 
 !   This subroutine registers the restart variables associated with the
 ! the ice dynamics.

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -29,8 +29,8 @@ use SIS_diag_mediator, only : query_SIS_averaging_enabled, enable_SIS_averaging
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
 use SIS_debugging,     only : chksum, Bchksum, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
-use SIS_framework,     only : restore_SIS_state, register_restart_field, SIS_restart_CS
-use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts, safe_alloc
+use SIS_framework,     only : register_restart_field, only_read_from_restarts, SIS_restart_CS
+use SIS_framework,     only : query_initialized=>query_inited, safe_alloc
 use SIS_hor_grid,      only : SIS_hor_grid_type
 
 implicit none ; private

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -29,7 +29,7 @@ use SIS_diag_mediator, only : query_SIS_averaging_enabled, enable_SIS_averaging
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
 use SIS_debugging,     only : chksum, Bchksum, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
-use SIS_framework,     only : domain2D, restore_SIS_state, register_restart_field, SIS_restart_CS
+use SIS_framework,     only : restore_SIS_state, register_restart_field, SIS_restart_CS
 use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts
 use SIS_hor_grid,      only : SIS_hor_grid_type
 
@@ -1577,14 +1577,11 @@ end subroutine find_sigII
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> SIS_C_dyn_register_restarts allocates and registers any variables for the
 !!   SIS C-grid dynamics module that need to be included in the restart files.
-subroutine SIS_C_dyn_register_restarts(mpp_domain, HI, param_file, CS, &
-                                       Ice_restart, restart_file)
-  type(domain2d),          intent(in) :: mpp_domain !< The ice models' FMS domain type
+subroutine SIS_C_dyn_register_restarts(HI, param_file, CS, Ice_restart)
   type(hor_index_type),    intent(in) :: HI    !< The horizontal index type describing the domain
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(SIS_C_dyn_CS),      pointer    :: CS    !< The control structure for this module
   type(SIS_restart_CS),    pointer    :: Ice_restart  !< The control structure for the ice restarts
-  character(len=*),        intent(in) :: restart_file !< The ice restart file name
 
 !   This subroutine registers the restart variables associated with the
 ! the ice dynamics.
@@ -1619,12 +1616,11 @@ end subroutine SIS_C_dyn_register_restarts
 !!   and non-symmetric memory restart files.  It also handles any changes in dimensional rescaling
 !!   of these variables between what is stored in the restart file and what is done for the current
 !!   run segment.
-subroutine SIS_C_dyn_read_alt_restarts(CS, G, US, Ice_restart, restart_file, restart_dir)
+subroutine SIS_C_dyn_read_alt_restarts(CS, G, US, Ice_restart, restart_dir)
   type(SIS_C_dyn_CS),      pointer    :: CS    !< The control structure for this module
   type(SIS_hor_grid_type), intent(in) :: G   !< The horizontal grid type
   type(unit_scale_type),   intent(in) :: US  !< A structure with unit conversion factors
   type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in) :: restart_file !< The ice restart file name
   character(len=*),        intent(in) :: restart_dir !< The directory in which to find the restart files
 
   ! These are temporary variables that will be used only here for reading and

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -30,7 +30,7 @@ use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
 use SIS_debugging,     only : chksum, Bchksum, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
 use SIS_framework,     only : restore_SIS_state, register_restart_field, SIS_restart_CS
-use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts
+use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts, safe_alloc
 use SIS_hor_grid,      only : SIS_hor_grid_type
 
 implicit none ; private
@@ -1596,9 +1596,10 @@ subroutine SIS_C_dyn_register_restarts(HI, param_file, CS, Ice_restart)
   endif
   allocate(CS)
 
-  allocate(CS%str_d(isd:ied, jsd:jed)) ; CS%str_d(:,:) = 0.0
-  allocate(CS%str_t(isd:ied, jsd:jed)) ; CS%str_t(:,:) = 0.0
-  allocate(CS%str_s(HI%IsdB:HI%IedB, HI%JsdB:HI%JedB)) ; CS%str_s(:,:) = 0.0
+  call safe_alloc(CS%str_d, isd, ied, jsd, jed)
+  call safe_alloc(CS%str_t, isd, ied, jsd, jed)
+  call safe_alloc(CS%str_s, HI%IsdB, HI%IedB, HI%JsdB, HI%JedB)
+
   if (associated(Ice_restart)) then
     call register_restart_field(Ice_restart, 'str_d', CS%str_d, mandatory=.false.)
     call register_restart_field(Ice_restart, 'str_t', CS%str_t, mandatory=.false.)

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -2119,8 +2119,7 @@ subroutine SIS_dyn_trans_register_restarts(HI, IG, param_file, CS, Ice_restart)
   else
     call SIS_B_dyn_register_restarts(HI, param_file, CS%SIS_B_dyn_CSp, Ice_restart)
   endif
-!  call SIS_transport_register_restarts(G, param_file, CS%SIS_transport_CSp, &
-!                                       Ice_restart, restart_file)
+!  call SIS_transport_register_restarts(G, param_file, CS%SIS_transport_CSp, Ice_restart)
 
 end subroutine SIS_dyn_trans_register_restarts
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -43,7 +43,7 @@ use SIS_dyn_bgrid,     only : SIS_B_dyn_register_restarts, SIS_B_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_CS, SIS_C_dynamics, SIS_C_dyn_init
 use SIS_dyn_cgrid,     only : SIS_C_dyn_register_restarts, SIS_C_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_read_alt_restarts
-use SIS_framework,     only : restart_file_type, domain2D, safe_alloc
+use SIS_framework,     only : SIS_restart_CS, domain2D, safe_alloc
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_ice_diags,     only : ice_state_diags_type, register_ice_state_diagnostics
 use SIS_ice_diags,     only : post_ocean_sfc_diagnostics, post_ice_state_diagnostics
@@ -2102,7 +2102,7 @@ subroutine SIS_dyn_trans_register_restarts(mpp_domain, HI, IG, param_file, CS, &
   type(ice_grid_type),     intent(in) :: IG     !< The sea-ice grid type
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(dyn_trans_CS),      pointer    :: CS     !< The control structure for the SIS_dyn_trans module
-  type(restart_file_type), pointer    :: Ice_restart !< The sea ice restart control structure
+  type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
   character(len=*),        intent(in) :: restart_file !< The ice restart file name
 
 !   This subroutine registers the restart variables associated with the
@@ -2137,7 +2137,7 @@ subroutine SIS_dyn_trans_read_alt_restarts(CS, G, US, Ice_restart, &
   type(dyn_trans_CS),      pointer    :: CS  !< The control structure for the SIS_dyn_trans module
   type(unit_scale_type),   intent(in) :: US  !< A structure with unit conversion factors
   type(SIS_hor_grid_type), intent(in) :: G   !< The horizontal grid type
-  type(restart_file_type), pointer    :: Ice_restart !< The sea ice restart control structure
+  type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
   character(len=*),        intent(in) :: restart_file !< The ice restart file name
   character(len=*),        intent(in) :: restart_dir !< The directory in which to find the restart files
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -29,7 +29,6 @@ use MOM_time_manager,  only : operator(>), operator(*), operator(/), operator(/=
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_EOS,           only : EOS_type, calculate_density_derivs
 
-use coupler_types_mod, only : coupler_type_initialized, coupler_type_send_data
 
 use SIS_continuity,    only : SIS_continuity_CS, summed_continuity, ice_cover_transport
 use SIS_debugging,     only : chksum, Bchksum, hchksum
@@ -44,6 +43,7 @@ use SIS_dyn_cgrid,     only : SIS_C_dyn_CS, SIS_C_dynamics, SIS_C_dyn_init
 use SIS_dyn_cgrid,     only : SIS_C_dyn_register_restarts, SIS_C_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_read_alt_restarts
 use SIS_framework,     only : SIS_restart_CS, safe_alloc
+use SIS_framework,     only : coupler_type_initialized, coupler_type_send_data
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_ice_diags,     only : ice_state_diags_type, register_ice_state_diagnostics
 use SIS_ice_diags,     only : post_ocean_sfc_diagnostics, post_ice_state_diagnostics

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -43,7 +43,7 @@ use SIS_dyn_bgrid,     only : SIS_B_dyn_register_restarts, SIS_B_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_CS, SIS_C_dynamics, SIS_C_dyn_init
 use SIS_dyn_cgrid,     only : SIS_C_dyn_register_restarts, SIS_C_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_read_alt_restarts
-use SIS_framework,     only : SIS_restart_CS, domain2D, safe_alloc
+use SIS_framework,     only : SIS_restart_CS, safe_alloc
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_ice_diags,     only : ice_state_diags_type, register_ice_state_diagnostics
 use SIS_ice_diags,     only : post_ocean_sfc_diagnostics, post_ice_state_diagnostics
@@ -2095,15 +2095,12 @@ end subroutine set_wind_stresses_B
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> SIS_dyn_trans_register_restarts allocates and registers any variables associated
 !!      slow ice dynamics and transport that need to be included in the restart files.
-subroutine SIS_dyn_trans_register_restarts(mpp_domain, HI, IG, param_file, CS, &
-                                      Ice_restart, restart_file)
-  type(domain2d),          intent(in) :: mpp_domain !< The ice models' FMS domain type
+subroutine SIS_dyn_trans_register_restarts(HI, IG, param_file, CS, Ice_restart)
   type(hor_index_type),    intent(in) :: HI     !< The horizontal index type describing the domain
   type(ice_grid_type),     intent(in) :: IG     !< The sea-ice grid type
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(dyn_trans_CS),      pointer    :: CS     !< The control structure for the SIS_dyn_trans module
   type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in) :: restart_file !< The ice restart file name
 
 !   This subroutine registers the restart variables associated with the
 ! the slow ice dynamics and thermodynamics.
@@ -2118,11 +2115,9 @@ subroutine SIS_dyn_trans_register_restarts(mpp_domain, HI, IG, param_file, CS, &
   CS%Cgrid_dyn = .true. ; call read_param(param_file, "CGRID_ICE_DYNAMICS", CS%Cgrid_dyn)
 
   if (CS%Cgrid_dyn) then
-    call SIS_C_dyn_register_restarts(mpp_domain, HI, param_file, &
-                 CS%SIS_C_dyn_CSp, Ice_restart, restart_file)
+    call SIS_C_dyn_register_restarts(HI, param_file, CS%SIS_C_dyn_CSp, Ice_restart)
   else
-    call SIS_B_dyn_register_restarts(mpp_domain, HI, param_file, &
-                 CS%SIS_B_dyn_CSp, Ice_restart, restart_file)
+    call SIS_B_dyn_register_restarts(HI, param_file, CS%SIS_B_dyn_CSp, Ice_restart)
   endif
 !  call SIS_transport_register_restarts(G, param_file, CS%SIS_transport_CSp, &
 !                                       Ice_restart, restart_file)
@@ -2132,18 +2127,15 @@ end subroutine SIS_dyn_trans_register_restarts
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> SIS_dyn_trans_register_restarts allocates and registers any variables associated
 !!      slow ice dynamics and transport that need to be included in the restart files.
-subroutine SIS_dyn_trans_read_alt_restarts(CS, G, US, Ice_restart, &
-                                           restart_file, restart_dir)
+subroutine SIS_dyn_trans_read_alt_restarts(CS, G, US, Ice_restart, restart_dir)
   type(dyn_trans_CS),      pointer    :: CS  !< The control structure for the SIS_dyn_trans module
   type(unit_scale_type),   intent(in) :: US  !< A structure with unit conversion factors
   type(SIS_hor_grid_type), intent(in) :: G   !< The horizontal grid type
   type(SIS_restart_CS),    pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in) :: restart_file !< The ice restart file name
   character(len=*),        intent(in) :: restart_dir !< The directory in which to find the restart files
 
   if (CS%Cgrid_dyn) then
-    call SIS_C_dyn_read_alt_restarts(CS%SIS_C_dyn_CSp, G, US, Ice_restart, &
-                                     restart_file, restart_dir)
+    call SIS_C_dyn_read_alt_restarts(CS%SIS_C_dyn_CSp, G, US, Ice_restart, restart_dir)
   endif
 
 end subroutine SIS_dyn_trans_read_alt_restarts

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -22,8 +22,6 @@ use MOM_shared_initialization, only : read_face_length_list, set_velocity_depth_
 use MOM_shared_initialization, only : compute_global_grid_integrals, write_ocean_geometry_file
 use MOM_unit_scaling, only : unit_scale_type
 
-use netcdf
-
 implicit none ; private
 
 public :: SIS_initialize_fixed

--- a/src/SIS_framework.F90
+++ b/src/SIS_framework.F90
@@ -5,8 +5,9 @@ module SIS_framework
 ! This file is part of SIS2. See LICENSE.md for the license.
 
 use fms_io_mod,        only : set_domain, nullify_domain
-use fms_io_mod,        only : restart_file_type, register_restart_field
-use fms_io_mod,        only : save_restart, restore_state, query_initialized
+use fms_io_mod,        only : restart_file_type, FMS1_register_restart=>register_restart_field
+use fms_io_mod,        only : save_restart_FMS1=>save_restart, FMS1_restore_state=>restore_state
+use fms_io_mod,        only : FMS1_query_initialized=>query_initialized
 ! use fms2_io_mod,       only : query_initialized=>is_registered_to_restart
 use mpp_mod,           only : SIS_chksum=>mpp_chksum
 use mpp_domains_mod,   only : domain2D, CORNER, EAST, NORTH
@@ -14,7 +15,9 @@ use mpp_domains_mod,   only : get_layout=>mpp_get_layout, get_compute_domain=>mp
 use mpp_domains_mod,   only : redistribute_data=>mpp_redistribute
 use mpp_domains_mod,   only : broadcast_domain=>mpp_broadcast_domain
 
+use MOM_domains,       only : MOM_domain_type
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, NOTE
 use MOM_safe_alloc,    only : safe_alloc=>safe_alloc_alloc, safe_alloc_ptr
 use MOM_file_parser,   only : get_param, read_param, log_param, log_version, param_file_type
 
@@ -22,8 +25,34 @@ implicit none ; private
 
 public :: SIS_chksum, redistribute_data, domain2D, CORNER, EAST, NORTH
 public :: set_domain, nullify_domain, get_layout, get_compute_domain, broadcast_domain
-public :: restart_file_type, register_restart_field, save_restart, restore_state, query_initialized
+public :: restart_file_type, restore_SIS_state, register_restart_field, save_restart, query_inited
+public :: query_initialized, SIS_restart_init, SIS_restart_end, only_read_from_restarts
 public :: SIS_initialize_framework, safe_alloc, safe_alloc_ptr
+
+!> A restart registry and the control structure for restarts
+type, public :: SIS_restart_CS ! ; private
+  type(restart_file_type), pointer :: fms_restart => NULL() !< The FMS restart file type to use
+  type(domain2d), pointer :: mpp_domain => NULL() !< The mpp domain to use for read of decomposed fields.
+  character(len=240) :: restart_file !< The name or name root for MOM restart files.
+end type SIS_restart_CS
+
+!> Register fields for restarts
+interface register_restart_field
+  module procedure register_restart_field_4d
+  module procedure register_restart_field_3d
+  module procedure register_restart_field_2d
+  module procedure register_restart_field_1d
+  module procedure register_restart_field_0d
+end interface
+
+!> Register fields for restarts
+interface only_read_from_restarts
+  module procedure only_read_restart_field_4d
+  module procedure only_read_restart_field_3d
+  module procedure only_read_restart_field_2d
+!  module procedure only_read_restart_field_1d
+!  module procedure only_read_restart_field_0d
+end interface
 
 contains
 
@@ -48,5 +77,321 @@ subroutine SIS_initialize_framework(PF)
   call callTree_leave('SIS_initialize_framework()')
 
 end subroutine SIS_initialize_framework
+
+
+!> Initialize and set up a restart control structure.
+subroutine SIS_restart_init(CS, filename, mpp_domain)
+  type(SIS_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object that is allocated here
+  character(len=*),      intent(in) :: filename !< The path to the restart file.
+  type(domain2d),        pointer    :: mpp_domain !< The mpp domain descriptor
+
+  if (associated(CS)) then
+    call SIS_error(WARNING, "SIS_restart_init called with an associated control structure.")
+    return
+  endif
+  allocate(CS)
+
+  allocate(CS%fms_restart)
+  CS%restart_file = trim(filename)
+  CS%mpp_domain => mpp_domain
+
+end subroutine SIS_restart_init
+
+!======================= register_restart_field variants =======================
+
+!> Register a 4-d field for restarts, providing the metadata as individual arguments
+subroutine register_restart_field_4d(CS, name, f_ptr, longname, units, position, dim_3, dim_4, &
+                                     mandatory, read_only, id)
+  type(SIS_restart_CS),       pointer    :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),           intent(in) :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:,:,:), &
+                      target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+  character(len=*), optional, intent(in) :: longname  !< variable long name
+  character(len=*), optional, intent(in) :: units     !< variable units
+  integer,          optional, intent(in) :: position  !< A coded integer indicating the horizontal
+                                                      !! position of this variable
+  character(len=*), optional, intent(in) :: dim_3     !< The name of the 3rd dimension axis
+  character(len=*), optional, intent(in) :: dim_4     !< The name of the 4th dimension axis
+  logical,          optional, intent(in) :: mandatory !< If true, the run will abort if this field is not
+                                                      !! successfully read from the restart file.
+  logical,          optional, intent(in) :: read_only !< If true, this variable is read but not written.
+  integer,         optional, intent(out) :: id        !< The restart ID foonly_read_from_restartsr this variable
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: register_restart_field_4d: "//&
+      "Restart_CS must be initialized before it is used to register "//trim(name))
+
+  idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, longname=longname, &
+                              units=units, mandatory=mandatory, read_only=read_only, &
+                              domain=CS%mpp_domain, position=position)
+  if (present(id)) id = idr
+
+end subroutine register_restart_field_4d
+
+!> Register a 3-d field for restarts, providing the metadata as individual arguments
+subroutine register_restart_field_3d(CS, name, f_ptr, longname, units, position, dim_3, &
+                                     mandatory, read_only, id)
+  type(SIS_restart_CS),       pointer    :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),           intent(in) :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:,:), &
+                      target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+  character(len=*), optional, intent(in) :: longname  !< variable long name
+  character(len=*), optional, intent(in) :: units     !< variable units
+  integer,          optional, intent(in) :: position  !< A coded integer indicating the horizontal
+                                                      !! position of this variable
+  character(len=*), optional, intent(in) :: dim_3     !< The name of the 3rd dimension axis
+  logical,          optional, intent(in) :: mandatory !< If true, the run will abort if this field is not
+                                                      !! successfully read from the restart file.
+  logical,          optional, intent(in) :: read_only !< If true, this variable is read but not written.
+  integer,         optional, intent(out) :: id        !< The restart ID for this variable
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: register_restart_field_3d: "//&
+      "Restart_CS must be initialized before it is used to register "//trim(name))
+
+  idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, longname=longname, &
+                              units=units, mandatory=mandatory, read_only=read_only, &
+                              domain=CS%mpp_domain, position=position)
+  if (present(id)) id = idr
+
+end subroutine register_restart_field_3d
+
+!> Register a 2-d field for restarts, providing the metadata as individual arguments
+subroutine register_restart_field_2d(CS, name, f_ptr, units, longname, position, &
+                                     mandatory, read_only, id)
+  type(SIS_restart_CS),       pointer    :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),           intent(in) :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:), &
+                      target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+  character(len=*), optional, intent(in) :: longname  !< variable long name
+  character(len=*), optional, intent(in) :: units     !< variable units
+  integer,          optional, intent(in) :: position  !< A coded integer indicating the horizontal
+                                                      !! position of this variable
+  logical,          optional, intent(in) :: mandatory !< If true, the run will abort if this field is not
+                                                      !! successfully read from the restart file.
+  logical,          optional, intent(in) :: read_only !< If true, this variable is read but not written.
+  integer,         optional, intent(out) :: id        !< The restart ID for this variable
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: register_restart_field_2d: "//&
+      "Restart_CS must be initialized before it is used to register "//trim(name))
+
+  idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, longname=longname, &
+                              units=units, mandatory=mandatory, read_only=read_only, &
+                              domain=CS%mpp_domain, position=position)
+  if (present(id)) id = idr
+
+end subroutine register_restart_field_2d
+
+!> Register a 1-d field for restarts, providing the metadata as individual arguments
+subroutine register_restart_field_1d(CS, name, f_ptr, longname, units, dim_3, &
+                                     mandatory, read_only, id)
+  type(SIS_restart_CS),       pointer    :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),           intent(in) :: name      !< The variable name to be used in the restart file
+  real, dimension(:), target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+  character(len=*), optional, intent(in) :: longname  !< variable long name
+  character(len=*), optional, intent(in) :: units     !< variable units
+  character(len=*), optional, intent(in) :: dim_3     !< The name of the axis
+  logical,          optional, intent(in) :: mandatory !< If true, the run will abort if this field is not
+                                                      !! successfully read from the restart file.
+  logical,          optional, intent(in) :: read_only !< If true, this variable is read but not written.
+  integer,         optional, intent(out) :: id        !< The restart ID for this variable
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: register_restart_field_1d: "//&
+      "Restart_CS must be initialized before it is used to register "//trim(name))
+
+  idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, longname=longname, &
+                              units=units, mandatory=mandatory, read_only=read_only, &
+                              no_domain=.true.)
+  if (present(id)) id = idr
+
+end subroutine register_restart_field_1d
+
+!> Register a 0-d field for restarts, providing the metadata as individual arguments
+subroutine register_restart_field_0d(CS, name, f_ptr, longname, units, mandatory, read_only, id)
+  type(SIS_restart_CS),       pointer    :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),           intent(in) :: name      !< The variable name to be used in the restart file
+  real,               target, intent(in) :: f_ptr     !< A pointer to the field to be read or written
+  character(len=*), optional, intent(in) :: longname  !< variable long name
+  character(len=*), optional, intent(in) :: units     !< variable units
+  logical,          optional, intent(in) :: mandatory !< If true, the run will abort if this field is not
+                                                      !! successfully read from the restart file.
+  logical,          optional, intent(in) :: read_only !< If true, this variable is read but not written.
+  integer,         optional, intent(out) :: id        !< The restart ID for this variable
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: register_restart_field_0d: "//&
+      "Restart_CS must be initialized before it is used to register "//trim(name))
+
+  idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, longname=longname, &
+                              units=units, mandatory=mandatory, read_only=read_only, &
+                              no_domain=.true.)
+  if (present(id)) id = idr
+
+end subroutine register_restart_field_0d
+
+!====================== only_read_from_restarts variants =======================
+
+!> Try to read a named 4-d field from the restart files
+subroutine only_read_restart_field_4d(CS, name, f_ptr, position, directory, domain, success)
+  type(SIS_restart_CS),            pointer     :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),                intent(in)  :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:,:,:),target, intent(in)  :: f_ptr     !< A pointer to the field to be read
+  integer,               optional, intent(in)  :: position  !< A coded integer indicating the horizontal
+                                                            !! position of this variable
+  character(len=*),      optional, intent(in)  :: directory !< The directory in which to seek restart files.
+  type(MOM_domain_type), optional, intent(in)  :: domain    !< The MOM domain descriptor being used
+  logical,               optional, intent(out) :: success   !< True if the field was read successfully
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: only_read_restart_field_4d: "//&
+      "Restart_CS must be initialized before it is used to read "//trim(name))
+
+  if (present(domain)) then
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=domain%mpp_domain, mandatory=.false., position=position)
+  else
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=CS%mpp_domain, mandatory=.false., position=position)
+  endif
+  call restore_SIS_state(CS, idr, directory=directory)
+
+  if (present(success)) success = query_initialized(CS, name)
+
+end subroutine only_read_restart_field_4d
+
+!> Try to read a named 3-d field from the restart files
+subroutine only_read_restart_field_3d(CS, name, f_ptr, position, directory, domain, success)
+  type(SIS_restart_CS),            pointer     :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),                intent(in)  :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:,:),  target, intent(in)  :: f_ptr     !< A pointer to the field to be read
+  integer,               optional, intent(in)  :: position  !< A coded integer indicating the horizontal
+                                                            !! position of this variable
+  character(len=*),      optional, intent(in)  :: directory !< The directory in which to seek restart files.
+  type(MOM_domain_type), optional, intent(in)  :: domain    !< The MOM domain descriptor being used
+  logical,               optional, intent(out) :: success   !< True if the field was read successfully
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: only_read_restart_field_3d: "//&
+      "Restart_CS must be initialized before it is used to read "//trim(name))
+
+  if (present(domain)) then
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=domain%mpp_domain, mandatory=.false., position=position)
+  else
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=CS%mpp_domain, mandatory=.false., position=position)
+  endif
+  call restore_SIS_state(CS, idr, directory=directory)
+
+  if (present(success)) success = query_initialized(CS, name)
+
+end subroutine only_read_restart_field_3d
+
+!> Try to read a named 2-d field from the restart files
+subroutine only_read_restart_field_2d(CS, name, f_ptr, position, directory, domain, success)
+  type(SIS_restart_CS),            pointer     :: CS        !< A pointer to a SIS_restart_CS object (intent in/out)
+  character(len=*),                intent(in)  :: name      !< The variable name to be used in the restart file
+  real, dimension(:,:),    target, intent(in)  :: f_ptr     !< A pointer to the field to be read
+  integer,               optional, intent(in)  :: position  !< A coded integer indicating the horizontal
+                                                            !! position of this variable
+  character(len=*),      optional, intent(in)  :: directory !< The directory in which to seek restart files.
+  type(MOM_domain_type), optional, intent(in)  :: domain    !< The MOM domain descriptor being used
+  logical,               optional, intent(out) :: success   !< True if the field was read successfully
+
+  integer :: idr
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_framework: only_read_restart_field_2d: "//&
+      "Restart_CS must be initialized before it is used to read "//trim(name))
+
+  if (present(domain)) then
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=domain%mpp_domain, mandatory=.false., position=position)
+  else
+    idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
+                                domain=CS%mpp_domain, mandatory=.false., position=position)
+  endif
+  call restore_SIS_state(CS, idr, directory=directory)
+
+  if (present(success)) success = query_initialized(CS, name)
+
+end subroutine only_read_restart_field_2d
+
+
+!> query_initialized_name determines whether a named field has been successfully
+!! read from a restart file yet.
+function query_initialized(CS, name) result(query_init)
+  type(SIS_restart_CS), pointer    :: CS !< A pointer to a SIS_restart_CS object (intent in)
+  character(len=*),     intent(in) :: name !< The name of the field that is being queried
+  logical :: query_init        !< The returned value, set to true if the named field has been
+                               !! read from a restart file
+  !   This subroutine returns .true. if the field referred to by name has
+  ! initialized from a restart file, and .false. otherwise.
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_restart " // &
+      "query_initialized: Module must be initialized before it is used.")
+
+  query_init = FMS1_query_initialized(CS%fms_restart, name)
+
+end function query_initialized
+
+!> query_inited determines whether a named field has been successfully read from a restart file yet.
+!! It is identical to query_initialized, but has a separate name to deal with an unexplained
+!! problem that the pgi compiler has with reused function names between modules.
+function query_inited(CS, name) result(query_initialized)
+  type(SIS_restart_CS), pointer    :: CS !< A pointer to a SIS_restart_CS object (intent in)
+  character(len=*),     intent(in) :: name !< The name of the field that is being queried
+  logical :: query_initialized !< The returned value, set to true if the named field has been
+                               !! read from a restart file
+  !   This subroutine returns .true. if the field referred to by name has
+  ! initialized from a restart file, and .false. otherwise.
+
+  if (.not.associated(CS)) call SIS_error(FATAL, "SIS_restart " // &
+      "query_initialized: Module must be initialized before it is used.")
+
+  query_initialized = FMS1_query_initialized(CS%fms_restart, name)
+
+end function query_inited
+
+!> save_restart saves all registered variables to restart files.
+subroutine save_restart(CS, time_stamp)
+  type(SIS_restart_CS),        pointer    :: CS !< A pointer to a SIS_restart_CS object (intent in)
+  character(len=*), optional , intent(in) :: time_stamp !< A date stamp to use in the restart file name
+
+  call save_restart_FMS1(CS%fms_restart, time_stamp)
+
+end subroutine save_restart
+
+!> Restore the entire state of the sea ice or a single varable using a SIS_restart control structure.
+subroutine restore_SIS_state(CS, id, directory)
+  type(SIS_restart_CS),       pointer    :: CS !< A pointer to a SIS_restart_CS object (intent in)
+  integer,          optional, intent(in) :: id !< The ID of a field given by a call to register_restart_field
+  character(len=*), optional, intent(in) :: directory !< The directory in which to seek restart files.
+
+  if (present(id)) then
+    call FMS1_restore_state(CS%fms_restart, id, directory=directory)
+  else
+    call FMS1_restore_state(CS%fms_restart, directory=directory)
+  endif
+
+end subroutine restore_SIS_state
+
+!> Deallocate memory associated with a MOM_restart_CS variable.
+subroutine SIS_restart_end(CS)
+  type(SIS_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object
+
+  if (associated(CS%fms_restart)) deallocate(CS%fms_restart)
+  deallocate(CS)
+
+end subroutine SIS_restart_end
+
 
 end module SIS_framework

--- a/src/SIS_framework.F90
+++ b/src/SIS_framework.F90
@@ -80,10 +80,10 @@ end subroutine SIS_initialize_framework
 
 
 !> Initialize and set up a restart control structure.
-subroutine SIS_restart_init(CS, filename, mpp_domain)
+subroutine SIS_restart_init(CS, filename, domain)
   type(SIS_restart_CS),  pointer    :: CS !< A pointer to a MOM_restart_CS object that is allocated here
   character(len=*),      intent(in) :: filename !< The path to the restart file.
-  type(domain2d),        pointer    :: mpp_domain !< The mpp domain descriptor
+  type(MOM_domain_type), intent(in) :: domain    !< The MOM domain descriptor being used
 
   if (associated(CS)) then
     call SIS_error(WARNING, "SIS_restart_init called with an associated control structure.")
@@ -93,7 +93,7 @@ subroutine SIS_restart_init(CS, filename, mpp_domain)
 
   allocate(CS%fms_restart)
   CS%restart_file = trim(filename)
-  CS%mpp_domain => mpp_domain
+  CS%mpp_domain => domain%mpp_domain
 
 end subroutine SIS_restart_init
 
@@ -261,7 +261,7 @@ subroutine only_read_restart_field_4d(CS, name, f_ptr, position, directory, doma
     idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
                                 domain=CS%mpp_domain, mandatory=.false., position=position)
   endif
-  call restore_SIS_state(CS, idr, directory=directory)
+  call FMS1_restore_state(CS%fms_restart, idr, directory=directory)
 
   if (present(success)) success = query_initialized(CS, name)
 
@@ -290,7 +290,7 @@ subroutine only_read_restart_field_3d(CS, name, f_ptr, position, directory, doma
     idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
                                 domain=CS%mpp_domain, mandatory=.false., position=position)
   endif
-  call restore_SIS_state(CS, idr, directory=directory)
+  call FMS1_restore_state(CS%fms_restart, idr, directory=directory)
 
   if (present(success)) success = query_initialized(CS, name)
 
@@ -319,7 +319,7 @@ subroutine only_read_restart_field_2d(CS, name, f_ptr, position, directory, doma
     idr = FMS1_register_restart(CS%fms_restart, CS%restart_file, name, f_ptr, read_only=.true., &
                                 domain=CS%mpp_domain, mandatory=.false., position=position)
   endif
-  call restore_SIS_state(CS, idr, directory=directory)
+  call FMS1_restore_state(CS%fms_restart, idr, directory=directory)
 
   if (present(success)) success = query_initialized(CS, name)
 
@@ -371,16 +371,11 @@ subroutine save_restart(CS, time_stamp)
 end subroutine save_restart
 
 !> Restore the entire state of the sea ice or a single varable using a SIS_restart control structure.
-subroutine restore_SIS_state(CS, id, directory)
+subroutine restore_SIS_state(CS, directory)
   type(SIS_restart_CS),       pointer    :: CS !< A pointer to a SIS_restart_CS object (intent in)
-  integer,          optional, intent(in) :: id !< The ID of a field given by a call to register_restart_field
   character(len=*), optional, intent(in) :: directory !< The directory in which to seek restart files.
 
-  if (present(id)) then
-    call FMS1_restore_state(CS%fms_restart, id, directory=directory)
-  else
-    call FMS1_restore_state(CS%fms_restart, directory=directory)
-  endif
+  call FMS1_restore_state(CS%fms_restart, directory=directory)
 
 end subroutine restore_SIS_state
 

--- a/src/SIS_framework.F90
+++ b/src/SIS_framework.F90
@@ -7,6 +7,7 @@ module SIS_framework
 use fms_io_mod,        only : set_domain, nullify_domain
 use fms_io_mod,        only : restart_file_type, register_restart_field
 use fms_io_mod,        only : save_restart, restore_state, query_initialized
+! use fms2_io_mod,       only : query_initialized=>is_registered_to_restart
 use mpp_mod,           only : SIS_chksum=>mpp_chksum
 use mpp_domains_mod,   only : domain2D, CORNER, EAST, NORTH
 use mpp_domains_mod,   only : get_layout=>mpp_get_layout, get_compute_domain=>mpp_get_compute_domain
@@ -14,6 +15,7 @@ use mpp_domains_mod,   only : redistribute_data=>mpp_redistribute
 use mpp_domains_mod,   only : broadcast_domain=>mpp_broadcast_domain
 
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
+use MOM_safe_alloc,    only : safe_alloc=>safe_alloc_alloc, safe_alloc_ptr
 use MOM_file_parser,   only : get_param, read_param, log_param, log_version, param_file_type
 
 implicit none ; private
@@ -21,7 +23,7 @@ implicit none ; private
 public :: SIS_chksum, redistribute_data, domain2D, CORNER, EAST, NORTH
 public :: set_domain, nullify_domain, get_layout, get_compute_domain, broadcast_domain
 public :: restart_file_type, register_restart_field, save_restart, restore_state, query_initialized
-public :: SIS_initialize_framework
+public :: SIS_initialize_framework, safe_alloc, safe_alloc_ptr
 
 contains
 

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -15,15 +15,15 @@ module SIS_ice_diags
 
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser, only : get_param, read_param, log_param, log_version, param_file_type
-use MOM_time_manager, only : time_type
-use MOM_unit_scaling, only : unit_scale_type
-use coupler_types_mod, only: coupler_type_initialized, coupler_type_send_data
+use MOM_file_parser,   only : get_param, read_param, log_param, log_version, param_file_type
+use MOM_time_manager,  only : time_type
+use MOM_unit_scaling,  only : unit_scale_type
 
 use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
 use SIS_diag_mediator, only : post_SIS_data, post_data=>post_SIS_data
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, SIS_diag_ctrl, safe_alloc_alloc
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
+use SIS_framework,     only : coupler_type_initialized, coupler_type_send_data
 use SIS_hor_grid,  only : SIS_hor_grid_type
 use SIS_types,     only : ocean_sfc_state_type, ice_ocean_flux_type, fast_ice_avg_type
 use SIS_types,     only : ice_state_type, IST_chksum, IST_bounds_check

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -150,7 +150,7 @@ subroutine ice_state_mass_init(IST, Ice, G, IG, US, PF, init_Time, just_read_par
   endif
 
   if (any_data_override) then
-    call data_override_init()      
+    call data_override_init()
     call data_override_unset_domains(unset_Ice=.true., must_be_set=.false.)
     call data_override_init(Ice_domain_in=Ice%slow_domain_NH)
   endif
@@ -312,7 +312,7 @@ subroutine ice_state_thermo_init(IST, Ice, G, IG, US, PF, init_Time, just_read_p
                         (trim(enth_snow_config)=="data_override")) .and. .not.just_read)
 
   if (any_data_override) then
-    call data_override_init()      
+    call data_override_init()
     call data_override_unset_domains(unset_Ice=.true., must_be_set=.false.)
     call data_override_init(Ice_domain_in=Ice%slow_domain_NH)
   endif

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -21,8 +21,8 @@ use MOM_hor_index,     only : hor_index_type, hor_index_init
 use MOM_io,            only : file_exists, MOM_read_data, slasher
 use MOM_time_manager,  only : time_type, time_type_to_real, real_to_time
 use MOM_unit_scaling,  only : unit_scale_type
-use SIS_framework,     only : restore_state, query_initialized
-use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : restore_SIS_state, query_initialized=>query_inited
+use SIS_framework,     only : register_restart_field, only_read_from_restarts
 use SIS_get_input,     only : directories
 use SIS_types,         only : ice_state_type
 use SIS_hor_grid,      only : SIS_hor_grid_type, set_hor_grid, SIS_hor_grid_end
@@ -913,8 +913,8 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 # include "version_variable.h"
   character(len=40)  :: mdl = "SIS_state_initialization" ! This module's name.
   character(len=8)   :: nstr
-  real, allocatable, target, dimension(:,:,:,:) :: t_ice_tmp, sal_ice_tmp
-  real, allocatable, target, dimension(:,:,:) :: t_snow_tmp
+  real, allocatable, target, dimension(:,:,:,:) :: t_ice_tmp
+  real, allocatable, target, dimension(:,:,:) :: t_snow_tmp, sal_ice_tmp
 
   real :: ice_bulk_salin ! The globally constant sea ice bulk salinity [gSalt kg-1] = [ppt]
                          ! that is used to calculate the ocean salt flux.
@@ -925,8 +925,7 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 
   integer :: i, j, k, l, i2, j2, k2, n
   integer :: isc, iec, jsc, jec, CatIce, NkIce
-  integer :: idr, id_sal
-  logical :: read_aux_restart
+  logical :: read_values, read_t_ice(IG%NkIce)
 
   if (associated(Ice%sCS)) then ; if (.not.associated(Ice%sCS%IST)) then
     call SIS_error(FATAL, "read_archaic_thermo_restarts called with an unassociated Ice%sCS%Ice_state structure.")
@@ -954,33 +953,21 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 
   restart_path = trim(dirs%restart_input_dir)//trim(restart_file)
 
-
   ! Approximately initialize state fields that are not present in the restart files that were read.
 
   if (.not.query_initialized(Ice%Ice_restart, 'sal_ice')) then
     ! Initialize the ice salinity from separate variables for each layer, perhaps from a SIS1 restart.
-    allocate(sal_ice_tmp(SZI_(G), SZJ_(G), CatIce, NkIce)) ; sal_ice_tmp(:,:,:,:) = 0.0
+    allocate(sal_ice_tmp(SZI_(G), SZJ_(G), CatIce)) ; sal_ice_tmp(:,:,:) = 0.0
     do n=1,NkIce
       write(nstr, '(I4)') n ; nstr = adjustl(nstr)
-      id_sal = register_restart_field(Ice%Ice_restart, restart_file, 'sal_ice'//trim(nstr), &
-                                   sal_ice_tmp(:,:,:,n), domain=sGD%mpp_domain, &
-                                   mandatory=.false., read_only=.true.)
-      call restore_state(Ice%Ice_restart, id_sal, directory=dirs%restart_input_dir)
-    enddo
-
-    if (query_initialized(Ice%Ice_restart, 'sal_ice1')) then
-      do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-        IST%sal_ice(i,j,k,1) = sal_ice_tmp(i,j,k,1)
-      enddo ; enddo ; enddo
-    else
-      IST%sal_ice(:,:,:,1) = ice_bulk_salin
-    endif
-    do n=2,NkIce
-      write(nstr, '(I4)') n ; nstr = adjustl(nstr)
-      if (query_initialized(Ice%Ice_restart, 'sal_ice'//trim(nstr))) then
+      call only_read_from_restarts(Ice%Ice_restart, 'sal_ice'//trim(nstr), sal_ice_tmp(:,:,:), &
+                                   directory=dirs%restart_input_dir, success=read_values)
+      if (read_values) then
         do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-          IST%sal_ice(i,j,k,n) = sal_ice_tmp(i,j,k,n)
+          IST%sal_ice(i,j,k,n) = sal_ice_tmp(i,j,k)
         enddo ; enddo ; enddo
+      elseif (n==1) then
+        IST%sal_ice(:,:,:,1) = ice_bulk_salin
       else
         IST%sal_ice(:,:,:,n) = IST%sal_ice(:,:,:,n-1)
       endif
@@ -989,49 +976,32 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
     deallocate(sal_ice_tmp)
   endif
 
-  read_aux_restart = (.not.query_initialized(Ice%Ice_restart, 'enth_ice')) .or. &
-                     (.not.query_initialized(Ice%Ice_restart, 'enth_snow'))
-  if (read_aux_restart) then
-    ! Try to initialize the ice enthalpy from separate temperature variables for each layer,
-    ! perhaps from a SIS1 restart.
-    allocate(t_snow_tmp(SZI_(G), SZJ_(G), CatIce)) ; t_snow_tmp(:,:,:) = 0.0
+  read_t_ice(:) = .false.
+  if ((.not.query_initialized(Ice%Ice_restart, 'enth_ice')) .or. &
+      (.not.query_initialized(Ice%Ice_restart, 'enth_snow'))) then
     allocate(t_ice_tmp(SZI_(G), SZJ_(G), CatIce, NkIce)) ; t_ice_tmp(:,:,:,:) = 0.0
 
-    idr = register_restart_field(Ice%Ice_restart, restart_file, 't_snow', t_snow_tmp, &
-                                 domain=sGD%mpp_domain, mandatory=.false., read_only=.true.)
-    call restore_state(Ice%Ice_restart, idr, directory=dirs%restart_input_dir)
     do n=1,NkIce
       write(nstr, '(I4)') n ; nstr = adjustl(nstr)
-      idr = register_restart_field(Ice%Ice_restart, restart_file, 't_ice'//trim(nstr), &
-                                   t_ice_tmp(:,:,:,n), domain=sGD%mpp_domain, &
-                                   mandatory=.false., read_only=.true.)
-      call restore_state(Ice%Ice_restart, idr, directory=dirs%restart_input_dir)
+      call only_read_from_restarts(Ice%Ice_restart, 't_ice'//trim(nstr), t_ice_tmp(:,:,:,n), &
+                                   directory=dirs%restart_input_dir, success=read_values)
+      read_t_ice(n) = read_values
     enddo
   endif
 
   ! Initialize the ice enthalpy.
   if (.not.query_initialized(Ice%Ice_restart, 'enth_ice')) then
-    if (.not.query_initialized(Ice%Ice_restart, 't_ice1')) then
+    ! Try to initialize the ice enthalpy from separate temperature variables for each layer,
+    ! perhaps from a SIS1 restart.
+    if (.not.read_t_ice(1)) then
       call SIS_error(FATAL, "Either t_ice1 or enth_ice must be present in the SIS2 restart file "//restart_path)
     endif
 
     S_col(:) = 0.0
     call get_SIS2_thermo_coefs(IST%ITV, ice_salinity=S_col, spec_thermo_salin=spec_thermo_sal)
 
-    if (spec_thermo_sal) then
-      do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-        IST%enth_ice(i,j,k,1) = Enth_from_TS(t_ice_tmp(i,j,k,1), S_col(1), IST%ITV)
-      enddo ; enddo ; enddo
-    else
-      do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-        IST%enth_ice(i,j,k,1) = Enth_from_TS(t_ice_tmp(i,j,k,1), &
-                 IST%sal_ice(i,j,k,1), IST%ITV)
-      enddo ; enddo ; enddo
-    endif
-
-    do n=2,NkIce
-      write(nstr, '(I4)') n ; nstr = adjustl(nstr)
-      if (.not.query_initialized(Ice%Ice_restart, 't_ice'//trim(nstr))) &
+    do n=1,NkIce
+      if ((n > 1) .and. (.not.read_t_ice(n))) &
         t_ice_tmp(:,:,:,n) = t_ice_tmp(:,:,:,n-1)
 
       if (spec_thermo_sal) then
@@ -1040,8 +1010,7 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
         enddo ; enddo ; enddo
       else
         do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-          IST%enth_ice(i,j,k,n) = Enth_from_TS(t_ice_tmp(i,j,k,n), &
-                           IST%sal_ice(i,j,k,n), IST%ITV)
+          IST%enth_ice(i,j,k,n) = Enth_from_TS(t_ice_tmp(i,j,k,n), IST%sal_ice(i,j,k,n), IST%ITV)
         enddo ; enddo ; enddo
       endif
     enddo
@@ -1049,22 +1018,27 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 
   ! Initialize the snow enthalpy.
   if (.not.query_initialized(Ice%Ice_restart, 'enth_snow')) then
-    if (.not.query_initialized(Ice%Ice_restart, 't_snow')) then
-      if (query_initialized(Ice%Ice_restart, 't_ice1')) then
+    ! Try to initialize the snow enthalpy from separate temperature variables for each layer,
+    ! perhaps from a SIS1 restart.
+    allocate(t_snow_tmp(SZI_(G), SZJ_(G), CatIce)) ; t_snow_tmp(:,:,:) = 0.0
+    call only_read_from_restarts(Ice%Ice_restart, 't_snow', t_snow_tmp, &
+                                   directory=dirs%restart_input_dir, success=read_values)
+    if (.not.read_values) then ! Try reading the ice temperature if snow is not available.
+      if (read_t_ice(1)) then
         t_snow_tmp(:,:,:) = t_ice_tmp(:,:,:,1)
       else
         do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
-          t_snow_tmp(i,j,k) = Temp_from_En_S(IST%enth_ice(i,j,k,1), &
-                                IST%sal_ice(i,j,k,1), IST%ITV)
+          t_snow_tmp(i,j,k) = Temp_from_En_S(IST%enth_ice(i,j,k,1), IST%sal_ice(i,j,k,1), IST%ITV)
         enddo ; enddo ; enddo
       endif
     endif
     do k=1,CatIce ; do j=jsc,jec ; do i=isc,iec
       IST%enth_snow(i,j,k,1) = Enth_from_TS(t_snow_tmp(i,j,k), 0.0, IST%ITV)
     enddo ; enddo ; enddo
+    deallocate(t_snow_tmp)
   endif
 
-  if (read_aux_restart) deallocate(t_snow_tmp, t_ice_tmp)
+  if (allocated(t_ice_tmp)) deallocate(t_ice_tmp)
 
   call callTree_leave("read_archaic_thermo_restarts(), SIS_state_initialization.F90")
 

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -2,7 +2,7 @@
 !! to a netcdf file and an ASCII output file.
 module SIS_sum_output
 
-! This file is a part of SIS2.  See LICNESE.md for the license.
+! This file is a part of SIS2.  See LICENSE.md for the license.
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !                                                                              !
@@ -30,8 +30,6 @@ use SIS_hor_grid,      only : SIS_hor_grid_type
 use ice_grid,          only : ice_grid_type
 use SIS2_ice_thm,      only : enthalpy_liquid_freeze, get_SIS2_thermo_coefs, ice_thermo_type
 use SIS_tracer_flow_control, only : SIS_tracer_flow_control_CS, SIS_call_tracer_stocks
-
-use netcdf
 
 implicit none ; private
 

--- a/src/SIS_tracer_flow_control.F90
+++ b/src/SIS_tracer_flow_control.F90
@@ -49,7 +49,7 @@ use ice_grid,            only : ice_grid_type
 use MOM_error_handler,   only : SIS_error=>MOM_error, FATAL, WARNING
 use MOM_file_parser,     only : get_param, log_version, param_file_type
 use SIS_diag_mediator,   only : time_type, SIS_diag_ctrl
-use SIS_framework,       only : restart_file_type
+use SIS_framework,       only : SIS_restart_CS
 use SIS_hor_grid,        only : SIS_hor_grid_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS_tracer_registry, only : register_SIS_tracer, register_SIS_tracer_pair
@@ -90,7 +90,7 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
                                                       !! control structure for the tracer flow control
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
-  type(restart_file_type),          intent(inout) :: Ice_restart !< The SIS restart structure
+  type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
   character(len=*),                 intent(in) :: restart_file !< The full path to the restart file.
 
   ! This include declares and sets the variable "version".

--- a/src/SIS_tracer_flow_control.F90
+++ b/src/SIS_tracer_flow_control.F90
@@ -1,7 +1,7 @@
 !> Contains subroutines into which calls to the tracer specific functions should be called.
 module SIS_tracer_flow_control
 
-! This file is a part of SIS2.  See LICNESE.md for the license.
+! This file is a part of SIS2.  See LICENSE.md for the license.
 
 !********+*********+*********+*********+*********+*********+*********+**
 !*                                                                     *
@@ -88,7 +88,7 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, Ice_rest
   type(SIS_tracer_flow_control_CS), pointer    :: CS  !< A pointer that is set to point to the
                                                       !! control structure for the tracer flow control
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
-  type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
+  type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to the SIS tracer registry
   type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
 
   ! This include declares and sets the variable "version".

--- a/src/SIS_tracer_flow_control.F90
+++ b/src/SIS_tracer_flow_control.F90
@@ -81,8 +81,7 @@ contains
 ! tracers and apply vertical column processes to tracers.
 
 !> Call the routines that register all of tracers in the tracer packages
-subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
-                                    Ice_restart, restart_file)
+subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, Ice_restart)
   type(SIS_hor_grid_type),          intent(in) :: G   !< The horizontal grid type
   type(ice_grid_type),              intent(in) :: IG  !< The sea-ice specific grid type
   type(param_file_type),            intent(in) :: param_file !< A structure to parse for run-time parameters
@@ -91,10 +90,9 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
   type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),                 intent(in) :: restart_file !< The full path to the restart file.
 
   ! This include declares and sets the variable "version".
-#include "version_variable.h"
+# include "version_variable.h"
   character(len=40)  :: mdl = "SIS_tracer_flow_control" ! This module's name.
 
   if (associated(CS)) then
@@ -114,7 +112,7 @@ subroutine SIS_call_tracer_register(G, IG, param_file, CS, diag, TrReg, &
   !  for some reason.  This then overrides the run-time selection from above.
   if (CS%use_ice_age) then
     CS%use_ice_age = register_ice_age_tracer(G, IG, param_file, CS%ice_age_tracer_CSp, &
-        diag, TrReg, Ice_restart, restart_file)
+                         diag, TrReg, Ice_restart)
   endif
 
 

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1,7 +1,7 @@
 !> Does the transport and redistribution between thickness categories for the SIS2 sea ice model.
 module SIS_transport
 
-! This file is a part of SIS2.  See LICENSE.md for the licnese.
+! This file is a part of SIS2.  See LICENSE.md for the license.
 
 use MOM_coms,          only : reproducing_sum, EFP_type, EFP_to_real, EFP_real_diff
 use MOM_domains,       only : pass_var, pass_vector, BGRID_NE, CGRID_NE
@@ -94,10 +94,10 @@ type, public :: cell_average_state_type ; private
   real, allocatable, dimension(:,:) :: mass0    !< The total mass of ice, snow and melt pond water
                                                 !! when the fields were populated [R Z ~> kg m-2].
   real, allocatable, dimension(:,:) :: uh_sum   !< The accumulated zonal mass fluxes of ice, snow
-                                                !! and melt pond water, summed acrosss categories,
+                                                !! and melt pond water, summed across categories,
                                                 !! since the fields were populated [R Z L2 ~> kg].
   real, allocatable, dimension(:,:) :: vh_sum   !< The accumulated meridional mass fluxes of ice, snow
-                                                !! and melt pond water, summed acrosss categories,
+                                                !! and melt pond water, summed across categories,
                                                 !! since the fields were populated [R Z L2 ~> kg].
   type(EFP_type) :: tot_ice                     !< The globally integrated mass of sea ice [kg].
   type(EFP_type) :: tot_snow                    !< The globally integrated mass of snow [kg].
@@ -557,10 +557,10 @@ subroutine adjust_ice_categories(mH_ice, mH_snow, mH_pond, part_sz, TrReg, G, IG
 ! thicker than the bounding limits of each category.
 
   ! Local variables
-  real :: mca_trans  ! The cell-averaged ice mass transfered between categories [R Z ~> kg m-2].
-  real :: part_trans ! The fractional area transfered between categories [nondim].
-  real :: snow_trans ! The cell-averaged snow transfered between categories [R Z ~> kg m-2].
-  real :: pond_trans ! The cell-averaged pond transfered between categories [R Z ~> kg m-2].
+  real :: mca_trans  ! The cell-averaged ice mass transferred between categories [R Z ~> kg m-2].
+  real :: part_trans ! The fractional area transferred between categories [nondim].
+  real :: snow_trans ! The cell-averaged snow transferred between categories [R Z ~> kg m-2].
+  real :: pond_trans ! The cell-averaged pond transferred between categories [R Z ~> kg m-2].
   real :: I_mH_lim1  ! The inverse of the lower thickness limit [R-1 Z-1 ~> m2 kg-1].
   real, dimension(SZI_(G),SZCAT_(IG)) :: &
     ! The mass of snow, pond and ice per unit total area in a cell [R Z ~> kg m-2].
@@ -820,13 +820,13 @@ subroutine compress_ice(part_sz, mH_ice, mH_snow, mH_pond, TrReg, G, US, IG, CS,
   real :: mca_old
 !  real :: Imca_new
   real :: mass_neglect
-  real :: part_trans ! The fractional area transfered into a thicker category [nondim].
+  real :: part_trans ! The fractional area transferred into a thicker category [nondim].
   real, dimension(SZI_(G),SZCAT_(IG)) :: &
     m0_ice, &  ! The initial mass per unit grid-cell area of ice in each category [R Z ~> kg m-2].
     m0_snow, & ! The initial mass per unit grid-cell area of snow in each category [R Z ~> kg m-2].
     m0_pond    ! The initial mass per unit grid-cell pond melt water in each category [R Z ~> kg m-2].
   real, dimension(SZI_(G),SZCAT_(IG)) :: &
-    trans_ice, trans_snow, trans_pond ! The masses tranferred into the next thicker category [R Z ~> kg m-2].
+    trans_ice, trans_snow, trans_pond ! The masses transferred into the next thicker category [R Z ~> kg m-2].
   real, dimension(SZI_(G),SZCAT_(IG)) :: mca_ice  ! The mass per unit grid-cell area
                                                   ! of the ice in each category [R Z ~> kg m-2].
   real, dimension(SZI_(G),SZCAT_(IG)) :: mca_snow ! The mass per unit grid-cell area
@@ -893,7 +893,7 @@ subroutine compress_ice(part_sz, mH_ice, mH_snow, mH_pond, TrReg, G, US, IG, CS,
             part_sz(i,j,k) = part_sz(i,j,k) - excess_cover(i,j)
             excess_cover(i,j) = 0.0
           else
-            ! Mass from this category needs to be transfered to the next thicker
+            ! Mass from this category needs to be transferred to the next thicker
             ! category after being compacted to thickness IG%mH_cat_bound(k+1).
             excess_cover(i,j) = excess_cover(i,j) - part_sz(i,j,k)*(1.0-compression_ratio)
 

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -3,30 +3,29 @@ module SIS_transport
 
 ! This file is a part of SIS2.  See LICENSE.md for the licnese.
 
-use MOM_coms, only : reproducing_sum, EFP_type, EFP_to_real, EFP_real_diff
-use MOM_domains,     only : pass_var, pass_vector, BGRID_NE, CGRID_NE
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
-use MOM_error_handler, only : SIS_mesg=>MOM_mesg, is_root_pe
-use MOM_file_parser, only : get_param, log_param, read_param, log_version, param_file_type
-use MOM_hor_index,   only : hor_index_type
+use MOM_coms,          only : reproducing_sum, EFP_type, EFP_to_real, EFP_real_diff
+use MOM_domains,       only : pass_var, pass_vector, BGRID_NE, CGRID_NE
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg, is_root_pe
+use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
+use MOM_hor_index,     only : hor_index_type
 use MOM_obsolete_params, only : obsolete_logical, obsolete_real
-use MOM_unit_scaling, only : unit_scale_type
-use SIS_continuity, only : SIS_continuity_init, SIS_continuity_end
-use SIS_continuity, only : continuity=>ice_continuity, SIS_continuity_CS
-use SIS_continuity, only : summed_continuity, proportionate_continuity
+use MOM_unit_scaling,  only : unit_scale_type
+use SIS_continuity,    only : SIS_continuity_init, SIS_continuity_end
+use SIS_continuity,    only : continuity=>ice_continuity, SIS_continuity_CS
+use SIS_continuity,    only : summed_continuity, proportionate_continuity
 use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
-use SIS_diag_mediator, only : safe_alloc_alloc
-use SIS_hor_grid, only : SIS_hor_grid_type
+use SIS_framework,     only : safe_alloc
+use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_tracer_advect, only : advect_tracers_thicker, SIS_tracer_advect_CS
 use SIS_tracer_advect, only : advect_SIS_tracers, SIS_tracer_advect_init, SIS_tracer_advect_end
 use SIS_tracer_advect, only : advect_scalar
 use SIS_tracer_registry, only : SIS_tracer_registry_type, get_SIS_tracer_pointer
 use SIS_tracer_registry, only : update_SIS_tracer_halos, set_massless_SIS_tracers
 use SIS_tracer_registry, only : check_SIS_tracer_bounds
-use SIS_types, only : ice_state_type
-use ice_grid, only : ice_grid_type
-use ice_ridging_mod, only : ice_ridging
+use SIS_types,         only : ice_state_type
+use ice_grid,          only : ice_grid_type
+use ice_ridging_mod,   only : ice_ridging
 
 implicit none ; private
 
@@ -1247,18 +1246,18 @@ subroutine alloc_cell_average_state_type(CAS, HI, IG, CS)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nCat = IG%CatIce
 
   if (.not.associated(CAS)) allocate(CAS)
-  call safe_alloc_alloc(CAS%m_ice, isd, ied, jsd, jed, ncat)
-  call safe_alloc_alloc(CAS%m_snow, isd, ied, jsd, jed, ncat)
-  call safe_alloc_alloc(CAS%m_pond, isd, ied, jsd, jed, ncat)
-  call safe_alloc_alloc(CAS%mH_ice, isd, ied, jsd, jed, ncat)
+  call safe_alloc(CAS%m_ice, isd, ied, jsd, jed, ncat)
+  call safe_alloc(CAS%m_snow, isd, ied, jsd, jed, ncat)
+  call safe_alloc(CAS%m_pond, isd, ied, jsd, jed, ncat)
+  call safe_alloc(CAS%mH_ice, isd, ied, jsd, jed, ncat)
 
   if (present(CS)) then
     if (CS%id_xprt>0) &
-      call safe_alloc_alloc(CAS%mass0, isd, ied, jsd, jed)
+      call safe_alloc(CAS%mass0, isd, ied, jsd, jed)
     if (CS%id_ix_trans>0) &
-      call safe_alloc_alloc(CAS%uh_sum, HI%IsdB, HI%IedB, jsd, jed)
+      call safe_alloc(CAS%uh_sum, HI%IsdB, HI%IedB, jsd, jed)
     if (CS%id_iy_trans>0) &
-      call safe_alloc_alloc(CAS%vh_sum, isd, ied, HI%JsdB, HI%JedB)
+      call safe_alloc(CAS%vh_sum, isd, ied, HI%JsdB, HI%JedB)
   endif
 end subroutine alloc_cell_average_state_type
 

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -478,12 +478,11 @@ end subroutine alloc_IST_arrays
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> ice_state_register_restarts registers any variables in the ice state type
 !!     that need to be includedin the restart files.
-subroutine ice_state_register_restarts(IST, G, IG, Ice_restart, restart_file)
+subroutine ice_state_register_restarts(IST, G, IG, Ice_restart)
   type(ice_state_type),    intent(inout) :: IST !< A type describing the state of the sea ice
   type(SIS_hor_grid_type), intent(in)    :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(in)    :: IG  !< The sea-ice specific grid type
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The name of the ice restart file
 
   ! Now register some of these arrays to be read from the restart files.
   if (associated(Ice_restart)) then
@@ -545,10 +544,9 @@ subroutine ice_state_register_restarts(IST, G, IG, Ice_restart, restart_file)
 
 end subroutine ice_state_register_restarts
 
-subroutine register_unit_conversion_restarts(US, Ice_restart, restart_file)
+subroutine register_unit_conversion_restarts(US, Ice_restart)
   type(unit_scale_type),   intent(inout) :: US    !< A structure with unit conversion factors
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The name of the ice restart file
 
   ! Register scalar unit conversion factors.
   call register_restart_field(Ice_restart, "m_to_Z", US%m_to_Z_restart, &
@@ -572,13 +570,11 @@ end subroutine register_unit_conversion_restarts
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> ice_state_read_alt_restarts reads in alternative variables that might have been in the restart
 !! file, specifically dealing with changing between symmetric and non-symmetric memory restart files.
-subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, &
-                                       restart_file, restart_dir)
+subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, restart_dir)
   type(ice_state_type),    intent(inout) :: IST !< A type describing the state of the sea ice
   type(SIS_hor_grid_type), intent(in)    :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(in)    :: IG  !< The sea-ice specific grid type
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The name of the ice restart file
   character(len=*),        intent(in)    :: restart_dir !< A directory in which to find the restart file
 
   ! These are temporary variables that will be used only here for reading and then discarded.
@@ -981,16 +977,13 @@ end subroutine alloc_total_sfc_flux
 !> ice_rad_register_restarts allocates the arrays in the ice_rad_type
 !!     and registers any variables in the ice rad type that need to be included
 !!     in the restart files.
-subroutine ice_rad_register_restarts(mpp_domain, HI, IG, param_file, Rad, &
-                                       Ice_restart, restart_file)
-  type(domain2d),          intent(in)    :: mpp_domain !< The mpp domain describing the ice decomposition
+subroutine ice_rad_register_restarts(HI, IG, param_file, Rad, Ice_restart)
   type(hor_index_type),    intent(in)    :: HI  !< The horizontal index type describing the domain
   type(ice_grid_type),     intent(in)    :: IG  !< The sea-ice specific grid type
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(ice_rad_type),      pointer       :: Rad !< A structure with fields related to the absorption,
                                                 !! reflection and transmission of shortwave radiation.
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The name of the ice restart file
 
   integer :: isd, ied, jsd, jed, CatIce, NkIce, idr
 

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -23,6 +23,7 @@ use SIS_debugging,     only : check_redundant_B, check_redundant_C
 use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, redistribute_data
 use SIS_framework,     only : register_restart_field, restart_file_type
 use SIS_framework,     only : restore_state, query_initialized
+use SIS_framework,     only : safe_alloc, safe_alloc_ptr
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS2_ice_thm,      only : ice_thermo_type, SIS2_ice_thm_CS, get_SIS2_thermo_coefs
@@ -1023,17 +1024,19 @@ subroutine ice_rad_register_restarts(mpp_domain, HI, IG, param_file, Rad, &
   CatIce = IG%CatIce ; NkIce = IG%NkIce
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
-  allocate(Rad%t_skin(isd:ied, jsd:jed, CatIce)) ; Rad%t_skin(:,:,:) = 0.0
-  allocate(Rad%Tskin_rad(isd:ied, jsd:jed, CatIce)) ; Rad%Tskin_rad(:,:,:) = 0.0
+  call safe_alloc(Rad%t_skin, isd, ied, jsd, jed, CatIce)
+  call safe_alloc(Rad%Tskin_rad, isd, ied, jsd, jed, CatIce)
 
-  allocate(Rad%sw_abs_sfc(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_sfc(:,:,:) = 0.0
-  allocate(Rad%sw_abs_snow(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_snow(:,:,:) = 0.0
-  allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce)) ; Rad%sw_abs_ice(:,:,:,:) = 0.0
-  allocate(Rad%sw_abs_ocn(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_ocn(:,:,:) = 0.0
-  allocate(Rad%sw_abs_int(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_int(:,:,:) = 0.0
+  call safe_alloc(Rad%sw_abs_sfc, isd, ied, jsd, jed, CatIce)
+  call safe_alloc(Rad%sw_abs_snow, isd, ied, jsd, jed, CatIce)
+  if (.not. allocated(Rad%sw_abs_ice)) then
+    allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce)) ; Rad%sw_abs_ice(:,:,:,:) = 0.0
+  endif
+  call safe_alloc(Rad%sw_abs_ocn, isd, ied, jsd, jed, CatIce)
+  call safe_alloc(Rad%sw_abs_int, isd, ied, jsd, jed, CatIce)
 
-  allocate(Rad%coszen_nextrad(isd:ied, jsd:jed)) ; Rad%coszen_nextrad(:,:) = 0.0
-  allocate(Rad%coszen_lastrad(isd:ied, jsd:jed)) ; Rad%coszen_lastrad(:,:) = 0.0
+  call safe_alloc(Rad%coszen_nextrad, isd, ied, jsd, jed)
+  call safe_alloc(Rad%coszen_lastrad, isd, ied, jsd, jed)
 
   idr = register_restart_field(Ice_restart, restart_file, 'coszen', Rad%coszen_nextrad, &
                                domain=mpp_domain, mandatory=.false.)

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -114,10 +114,10 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, Ice
   isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
 
   if (associated(CS)) then
-      call SIS_error(WARNING, "register_ice_age_tracer called with an "// &
-          "associated control structure.")
-      register_ice_age_tracer = .false.
-      return
+    call SIS_error(WARNING, "register_ice_age_tracer called with an "// &
+        "associated control structure.")
+    register_ice_age_tracer = .false.
+    return
   endif
   allocate(CS)
 
@@ -172,8 +172,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, Ice
 
   do m=1,CS%ntr
 
-    call query_vardesc(CS%tr_desc(m), name=var_name, &
-        caller="register_ice_age_tracer")
+    call query_vardesc(CS%tr_desc(m), name=var_name, caller="register_ice_age_tracer")
 
     ! Register the tracer for the restart file.
     call register_restart_field(Ice_restart, var_name, CS%tr(:,:,:,1,m), mandatory=.false.)

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -6,14 +6,11 @@ module ice_age_tracer
 ! ashao: Get all the dependencies from other modules (check against
 !   ideal_age_example.F90)
 
+use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_file_parser, only       : get_param, log_param, log_version, param_file_type
-use MOM_restart, only           : query_initialized, MOM_restart_CS
 use MOM_io, only                : vardesc, var_desc, query_vardesc, file_exists
-use MOM_time_manager, only      : time_type, time_type_to_real
-use MOM_sponge, only            : set_up_sponge_field, sponge_CS
-use MOM_error_handler, only     : SIS_error=>MOM_error, FATAL, WARNING
-use MOM_error_handler, only     : SIS_mesg=>MOM_mesg
 use MOM_string_functions, only  : slasher
+use MOM_time_manager, only      : time_type, time_type_to_real
 use MOM_unit_scaling, only      : unit_scale_type
 use SIS_diag_mediator, only     : register_SIS_diag_field, safe_alloc_ptr
 use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
@@ -38,7 +35,7 @@ type p3d
   real, dimension(:,:,:), pointer :: p => NULL() !< A pointer to a 3-d array
 end type p3d
 
-!> The controol structure for the ice age tracer module
+!> The control structure for the ice age tracer module
 type, public :: ice_age_tracer_CS
   integer :: ntr                              !< The number of tracers that are actually used.
   character(len = 200) :: IC_file             !< The file in which the age-tracer initial values
@@ -68,7 +65,7 @@ type, public :: ice_age_tracer_CS
   logical :: advect_vertical(NTR_MAX)         !< Whether the tracer should be advected "vertically" to thicker ice
   logical :: uniform_vertical(NTR_MAX)        !< Whether the tracer should uniform across ice thickness
                                               !! categories if so, "mix" the tracer by setting it to
-                                              !! the maximum age at the grid pont
+                                              !! the maximum age at the grid point
   logical :: do_ice_age_areal                 !< If true, use the areal age tracer
   logical :: do_ice_age_mass                  !< If true, use the areal age tracer
   real    :: min_thick_age                    !< The minimum thickness age
@@ -99,7 +96,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, Ice
   type(ice_age_tracer_CS),          pointer    :: CS  !<  A pointer that is set to point to the control
                                                       !! structure for the ice age tracer
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
-  type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
+  type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to the SIS tracer registry
   type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
 
   ! This subroutine is used to age register tracer fields and subroutines to be used with SIS.

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -17,8 +17,7 @@ use MOM_string_functions, only  : slasher
 use MOM_unit_scaling, only      : unit_scale_type
 use SIS_diag_mediator, only     : register_SIS_diag_field, safe_alloc_ptr
 use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
-use SIS_framework, only         : register_restart_field
-use SIS_framework, only         : restart_file_type
+use SIS_framework, only         : register_restart_field, SIS_restart_CS
 use SIS_hor_grid, only          : SIS_hor_grid_type
 use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type
 use SIS_utils, only             : post_avg
@@ -102,7 +101,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
                                                       !! structure for the ice age tracer
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
-  type(restart_file_type),          intent(inout) :: Ice_restart !< The SIS restart structure
+  type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
   character(len=*),                 intent(in) :: restart_file !< The full path to the restart file.
 
   ! This subroutine is used to age register tracer fields and subroutines to be used with SIS.
@@ -179,9 +178,7 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
         caller="register_ice_age_tracer")
 
     ! Register the tracer for the restart file.
-    CS%id_tracer(m) = register_restart_field(Ice_restart, restart_file, var_name, &
-        CS%tr(:,:,:,1,m), domain=G%domain%mpp_domain, &
-        mandatory=.false.)
+    call register_restart_field(Ice_restart, var_name, CS%tr(:,:,:,1,m), mandatory=.false.)
 
     ocean_BC_ptr => CS%ocean_BC(:,:,:,m)
     snow_BC_ptr  => CS%snow_BC(:,:,:,m)

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -17,7 +17,7 @@ use MOM_string_functions, only  : slasher
 use MOM_unit_scaling, only      : unit_scale_type
 use SIS_diag_mediator, only     : register_SIS_diag_field, safe_alloc_ptr
 use SIS_diag_mediator, only     : SIS_diag_ctrl, post_data=>post_SIS_data
-use SIS_framework, only         : register_restart_field, restore_state
+use SIS_framework, only         : register_restart_field
 use SIS_framework, only         : restart_file_type
 use SIS_hor_grid, only          : SIS_hor_grid_type
 use SIS_tracer_registry, only   : register_SIS_tracer, SIS_tracer_registry_type

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -92,8 +92,7 @@ end type ice_age_tracer_CS
 contains
 
 !> Register tracers from the ice age package
-logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
-                                         Ice_restart, restart_file)
+logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, Ice_restart)
   type(sis_hor_grid_type),          intent(in) :: G   !< The horizontal grid type
   type(ice_grid_type),              intent(in) :: IG  !< The sea-ice specific grid type
   type(param_file_type),            intent(in) :: param_file !< A structure to parse for run-time parameters
@@ -102,7 +101,6 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, &
   type(SIS_diag_ctrl),              target     :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_tracer_registry_type),   pointer    :: TrReg !< A pointer to thie SIS tracer registry
   type(SIS_restart_CS),             pointer    :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),                 intent(in) :: restart_file !< The full path to the restart file.
 
   ! This subroutine is used to age register tracer fields and subroutines to be used with SIS.
 

--- a/src/ice_boundary_types.F90
+++ b/src/ice_boundary_types.F90
@@ -9,10 +9,10 @@ module ice_boundary_types
 !   develoment effort.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
-use coupler_types_mod, only : coupler_2d_bc_type, coupler_3d_bc_type, coupler_type_write_chksums
 use MOM_error_handler, only : stdout
 use MOM_domains,       only : CGRID_NE, BGRID_NE, AGRID
-use SIS_framework,     only : SIS_chksum
+use SIS_framework,     only : coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : SIS_chksum, coupler_type_write_chksums
 
 implicit none ; private
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2085,6 +2085,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
     call set_domain(sGD%mpp_domain)
     if (.not.associated(Ice%Ice_restart)) allocate(Ice%Ice_restart)
+        !### call SIS_restart_init(Ice%Ice_restart, restart_file, sGD%mpp_domain)
 
     call ice_type_slow_reg_restarts(sGD%mpp_domain, CatIce, &
                       param_file, Ice, Ice%Ice_restart, restart_file)
@@ -2229,6 +2230,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     if (.not.slow_ice_PE) call set_domain(fGD%mpp_domain)
     if (split_restart_files) then
       if (.not.associated(Ice%Ice_fast_restart)) allocate(Ice%Ice_fast_restart)
+        !### call SIS_restart_init(Ice%Ice_fast_restart, fast_rest_file, fGD%mpp_domain)
     else
       Ice%Ice_fast_restart => Ice%Ice_restart
     endif
@@ -2316,8 +2318,8 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
         call SIS_dyn_trans_read_alt_restarts(Ice%sCS%dyn_trans_CSp, sG, US, Ice%Ice_restart, &
                                        restart_file, dirs%restart_input_dir)
 
-
       call rescale_ice_state_restart_fields(sIST, sG, US, sIG, H_to_kg_m2_tmp, Rho_ice, Rho_snow)
+
       sIG%H_to_kg_m2 = H_to_kg_m2_tmp
 
       if ((.not.query_initialized(Ice%Ice_restart, 'enth_ice')) .or. &

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -42,10 +42,6 @@ use MOM_time_manager,  only : operator(>), operator(*), operator(/), operator(/=
 use MOM_unit_scaling,  only : unit_scale_type, unit_scaling_init
 use MOM_unit_scaling,  only : unit_scaling_end, fix_restart_unit_scaling
 
-use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
-use coupler_types_mod, only : coupler_type_spawn, coupler_type_initialized
-use coupler_types_mod, only : coupler_type_rescale_data, coupler_type_copy_data
-
 use astronomy_mod, only : astronomy_init, astronomy_end
 use astronomy_mod, only : universal_time, orbital_time, diurnal_solar, daily_mean_solar
 use ocean_albedo_mod, only : compute_ocean_albedo            ! ice sets ocean surface
@@ -79,6 +75,9 @@ use SIS_fast_thermo,   only : redo_update_ice_model_fast, find_excess_fluxes
 use SIS_fast_thermo,   only : infill_array, SIS_fast_thermo_init, SIS_fast_thermo_end
 use SIS_framework,     only : set_domain, nullify_domain, broadcast_domain
 use SIS_framework,     only : restore_SIS_state, query_initialized=>query_inited, SIS_restart_init
+use SIS_framework,     only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : coupler_type_spawn, coupler_type_initialized
+use SIS_framework,     only : coupler_type_rescale_data, coupler_type_copy_data
 use SIS_fixed_initialization, only : SIS_initialize_fixed
 use SIS_get_input,     only : Get_SIS_input, directories
 use SIS_hor_grid,      only : SIS_hor_grid_type, set_hor_grid, SIS_hor_grid_end, set_first_direction

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -11,7 +11,7 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MO
 use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_hor_grid,      only : SIS_hor_grid_type
-use SIS_framework,     only : register_restart_field, restart_file_type
+use SIS_framework,     only : register_restart_field
 
 implicit none ; private
 

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -11,7 +11,6 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MO
 use MOM_file_parser,   only : get_param, log_param, read_param, log_version, param_file_type
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_hor_grid,      only : SIS_hor_grid_type
-use SIS_framework,     only : register_restart_field
 
 implicit none ; private
 

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -163,13 +163,12 @@ contains
 !! predominantly associated with the slow processors, and register any variables
 !! in the ice data type that need to be included in the slow ice restart files.
 subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
-                                      Ice_restart, restart_file, gas_fluxes)
+                                      Ice_restart, gas_fluxes)
   type(domain2d),          intent(in)    :: domain   !< The ice models' FMS domain type
   integer,                 intent(in)    :: CatIce   !< The number of ice thickness categories
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
-  type(ice_data_type),     intent(inout) :: Ice !< The publicly visible ice data type.
+  type(ice_data_type),     intent(inout) :: Ice      !< The publicly visible ice data type.
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The ice restart file name
   type(coupler_1d_bc_type), &
                  optional, intent(in)    :: gas_fluxes !< If present, this type describes the
                                               !! additional gas or other tracer fluxes between the
@@ -255,13 +254,12 @@ end subroutine ice_type_slow_reg_restarts
 !! predominantly associated with the fast processors, and registers any variables
 !! in the ice data type that need to be included in the fast ice restart files.
 subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
-                                      Ice_restart, restart_file, gas_fields_ocn)
+                                      Ice_restart, gas_fields_ocn)
   type(domain2d),          intent(in)    :: domain   !< The ice models' FMS domain type
   integer,                 intent(in)    :: CatIce   !< The number of ice thickness categories
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(ice_data_type),     intent(inout) :: Ice !< The publicly visible ice data type.
   type(SIS_restart_CS),    pointer       :: Ice_restart !< The control structure for the ice restarts
-  character(len=*),        intent(in)    :: restart_file !< The ice restart file name
   type(coupler_1d_bc_type), &
                  optional, intent(in)    :: gas_fields_ocn !< If present, this type describes the
                                               !! ocean and surface-ice fields that will participate

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -19,6 +19,7 @@ use SIS_diag_mediator, only : register_SIS_diag_field
 use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, SIS_chksum, get_compute_domain
 use SIS_framework,     only : register_restart_field, restart_file_type
 use SIS_framework,     only : save_restart, restore_state, query_initialized
+use SIS_framework,     only : safe_alloc, safe_alloc_ptr
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_types,         only : ice_state_type, fast_ice_avg_type
 use SIS2_ice_thm,      only : ice_thermo_type, enth_from_TS, energy_melt_EnthS
@@ -149,7 +150,7 @@ type ice_data_type !  ice_public_type
           !< A pointer to the SIS slow ice update control structure
   type(unit_scale_type), pointer :: US => NULL()
           !< structure containing various unit conversion factors
-   type(restart_file_type), pointer :: Ice_restart => NULL()
+  type(restart_file_type), pointer :: Ice_restart => NULL()
           !< A pointer to the slow ice restart control structure
   type(restart_file_type), pointer :: Ice_fast_restart => NULL()
           !< A pointer to the fast ice restart control structure
@@ -183,37 +184,37 @@ subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
 
   ! The fields t_surf, s_surf, and part_size are only available on fast PEs.
 
-  allocate(Ice%flux_u(isc:iec, jsc:jec)) ; Ice%flux_u(:,:) = 0.0
-  allocate(Ice%flux_v(isc:iec, jsc:jec)) ; Ice%flux_v(:,:) = 0.0
-  allocate(Ice%flux_t(isc:iec, jsc:jec)) ; Ice%flux_t(:,:) = 0.0
-  allocate(Ice%flux_q(isc:iec, jsc:jec)) ; Ice%flux_q(:,:) = 0.0
-  allocate(Ice%flux_sw_vis_dir(isc:iec, jsc:jec)) ; Ice%flux_sw_vis_dir(:,:) = 0.0
-  allocate(Ice%flux_sw_vis_dif(isc:iec, jsc:jec)) ; Ice%flux_sw_vis_dif(:,:) = 0.0
-  allocate(Ice%flux_sw_nir_dir(isc:iec, jsc:jec)) ; Ice%flux_sw_nir_dir(:,:) = 0.0
-  allocate(Ice%flux_sw_nir_dif(isc:iec, jsc:jec)) ; Ice%flux_sw_nir_dif(:,:) = 0.0
-  allocate(Ice%flux_lw(isc:iec, jsc:jec)) ; Ice%flux_lw(:,:) = 0.0
-  allocate(Ice%flux_lh(isc:iec, jsc:jec)) ; Ice%flux_lh(:,:) = 0.0 !NI
-  allocate(Ice%lprec(isc:iec, jsc:jec)) ; Ice%lprec(:,:) = 0.0
-  allocate(Ice%fprec(isc:iec, jsc:jec)) ; Ice%fprec(:,:) = 0.0
-  allocate(Ice%p_surf(isc:iec, jsc:jec)) ; Ice%p_surf(:,:) = 0.0
-  allocate(Ice%runoff(isc:iec, jsc:jec)) ; Ice%runoff(:,:) = 0.0
-  allocate(Ice%calving(isc:iec, jsc:jec)) ; Ice%calving(:,:) = 0.0
-  allocate(Ice%runoff_hflx(isc:iec, jsc:jec)) ; Ice%runoff_hflx(:,:) = 0.0
-  allocate(Ice%calving_hflx(isc:iec, jsc:jec)) ; Ice%calving_hflx(:,:) = 0.0
-  allocate(Ice%flux_salt(isc:iec, jsc:jec)) ; Ice%flux_salt(:,:) = 0.0
+  call safe_alloc_ptr(Ice%flux_u, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_v, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_t, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_q, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_sw_vis_dir, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_sw_vis_dif, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_sw_nir_dir, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_sw_nir_dif, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_lw, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_lh, isc, iec, jsc, jec)  !NI
+  call safe_alloc_ptr(Ice%lprec, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%fprec, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%p_surf, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%runoff, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%calving, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%runoff_hflx, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%calving_hflx, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%flux_salt, isc, iec, jsc, jec)
 
-  allocate(Ice%SST_C(isc:iec, jsc:jec)) ; Ice%SST_C(:,:) = 0.0
-  allocate(Ice%area(isc:iec, jsc:jec)) ; Ice%area(:,:) = 0.0
-  allocate(Ice%mi(isc:iec, jsc:jec)) ; Ice%mi(:,:) = 0.0 !NR
+  call safe_alloc_ptr(Ice%SST_C, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%area, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%mi, isc, iec, jsc, jec)  !NR
 
   if (Ice%sCS%pass_stress_mag) then
-    allocate(Ice%stress_mag(isc:iec, jsc:jec)) ; Ice%stress_mag(:,:) = 0.0
+    call safe_alloc_ptr(Ice%stress_mag, isc, iec, jsc, jec)
   endif
 
   if (Ice%sCS%pass_iceberg_area_to_ocean) then
-    allocate(Ice%ustar_berg(isc:iec, jsc:jec)) ; Ice%ustar_berg(:,:) = 0.0
-    allocate(Ice%area_berg(isc:iec, jsc:jec)) ; Ice%area_berg(:,:) = 0.0
-    allocate(Ice%mass_berg(isc:iec, jsc:jec)) ; Ice%mass_berg(:,:) = 0.0
+    call safe_alloc_ptr(Ice%ustar_berg, isc, iec, jsc, jec)
+    call safe_alloc_ptr(Ice%area_berg, isc, iec, jsc, jec)
+    call safe_alloc_ptr(Ice%mass_berg, isc, iec, jsc, jec)
   endif
 
   if (present(gas_fluxes)) &
@@ -284,23 +285,25 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   call get_compute_domain(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
-  allocate(Ice%t_surf(isc:iec, jsc:jec, km)) ; Ice%t_surf(:,:,:) = 0.0
-  allocate(Ice%s_surf(isc:iec, jsc:jec)) ; Ice%s_surf(:,:) = 0.0
-  allocate(Ice%part_size(isc:iec, jsc:jec, km)) ; Ice%part_size(:,:,:) = 0.0
+  call safe_alloc_ptr(Ice%t_surf, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%s_surf, isc, iec, jsc, jec)
+  call safe_alloc_ptr(Ice%part_size, isc, iec, jsc, jec, km)
 
-  allocate(Ice%u_surf(isc:iec, jsc:jec, km)) ; Ice%u_surf(:,:,:) = 0.0
-  allocate(Ice%v_surf(isc:iec, jsc:jec, km)) ; Ice%v_surf(:,:,:) = 0.0
-  allocate(Ice%ocean_pt(isc:iec, jsc:jec)) ; Ice%ocean_pt(:,:) = .false. !derived
+  call safe_alloc_ptr(Ice%u_surf, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%v_surf, isc, iec, jsc, jec, km)
+  if (.not.associated(Ice%ocean_pt)) then
+    allocate(Ice%ocean_pt(isc:iec, jsc:jec)) ; Ice%ocean_pt(:,:) = .false. !derived
+  endif
 
-  allocate(Ice%rough_mom(isc:iec, jsc:jec, km)) ; Ice%rough_mom(:,:,:) = 0.0
-  allocate(Ice%rough_heat(isc:iec, jsc:jec, km)) ; Ice%rough_heat(:,:,:) = 0.0
-  allocate(Ice%rough_moist(isc:iec, jsc:jec, km)) ; Ice%rough_moist(:,:,:) = 0.0
+  call safe_alloc_ptr(Ice%rough_mom, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%rough_heat, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%rough_moist, isc, iec, jsc, jec, km)
 
-  allocate(Ice%albedo(isc:iec, jsc:jec, km)) ; Ice%albedo(:,:,:) = 0.0  ! Derived?
-  allocate(Ice%albedo_vis_dir(isc:iec, jsc:jec, km)) ; Ice%albedo_vis_dir(:,:,:) = 0.0
-  allocate(Ice%albedo_nir_dir(isc:iec, jsc:jec, km)) ; Ice%albedo_nir_dir(:,:,:) = 0.0
-  allocate(Ice%albedo_vis_dif(isc:iec, jsc:jec, km)) ; Ice%albedo_vis_dif(:,:,:) = 0.0
-  allocate(Ice%albedo_nir_dif(isc:iec, jsc:jec, km)) ; Ice%albedo_nir_dif(:,:,:) = 0.0
+  call safe_alloc_ptr(Ice%albedo, isc, iec, jsc, jec, km)  ! Derived?
+  call safe_alloc_ptr(Ice%albedo_vis_dir, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%albedo_nir_dir, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%albedo_vis_dif, isc, iec, jsc, jec, km)
+  call safe_alloc_ptr(Ice%albedo_nir_dif, isc, iec, jsc, jec, km)
 
   if (present(gas_fields_ocn)) &
     call coupler_type_spawn(gas_fields_ocn, Ice%ocean_fields, (/isc,isc,iec,iec/), &

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -1,8 +1,6 @@
 !> maintains the sea ice data, reads/writes restarts, reads the namelist and initializes diagnostics.
 module ice_type_mod
 
-use coupler_types_mod, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
-use coupler_types_mod, only : coupler_type_spawn, coupler_type_write_chksums
 use ice_bergs,         only : icebergs, icebergs_stock_pe, icebergs_save_restart
 use ice_grid,          only : ice_grid_type
 use MOM_coms,          only : PE_here
@@ -18,8 +16,9 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field
 use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, SIS_chksum, get_compute_domain
 use SIS_framework,     only : register_restart_field, SIS_restart_CS
-use SIS_framework,     only : save_restart, query_initialized
-use SIS_framework,     only : safe_alloc, safe_alloc_ptr
+use SIS_framework,     only : save_restart, query_initialized, safe_alloc, safe_alloc_ptr
+use SIS_framework,     only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : coupler_type_spawn, coupler_type_write_chksums
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_types,         only : ice_state_type, fast_ice_avg_type
 use SIS2_ice_thm,      only : ice_thermo_type, enth_from_TS, energy_melt_EnthS

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -300,9 +300,9 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   ! Now register some of these arrays to be read from the restart files.
   ! These are used by the atmospheric model, and need to be in the fast PE restarts.
   if (associated(Ice_restart)) then
-    call register_restart_field(Ice_restart, 'rough_mom',   Ice%rough_mom)
-    call register_restart_field(Ice_restart, 'rough_heat',  Ice%rough_heat)
-    call register_restart_field(Ice_restart, 'rough_moist', Ice%rough_moist)
+    call register_restart_field(Ice_restart, 'rough_mom',   Ice%rough_mom, dim_3="cat0")
+    call register_restart_field(Ice_restart, 'rough_heat',  Ice%rough_heat, dim_3="cat0")
+    call register_restart_field(Ice_restart, 'rough_moist', Ice%rough_moist, dim_3="cat0")
   endif
 
 end subroutine ice_type_fast_reg_restarts

--- a/src/slab_ice.F90
+++ b/src/slab_ice.F90
@@ -13,7 +13,6 @@ use MOM_obsolete_params, only : obsolete_logical, obsolete_real
 use MOM_unit_scaling,   only : unit_scale_type
 ! use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_diag_ctrl
 ! use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
-! use SIS_diag_mediator, only : safe_alloc_alloc
 use SIS_hor_grid, only : SIS_hor_grid_type
 use ice_grid, only : ice_grid_type
 

--- a/src/slab_ice.F90
+++ b/src/slab_ice.F90
@@ -1,12 +1,11 @@
 !> Does the transport and redistribution between thickness categories for the SIS2 sea ice model.
 module slab_ice
 
-! This file is a part of SIS2.  See LICENSE.md for the licnese.
+! This file is a part of SIS2.  See LICENSE.md for the license.
 
 ! use MOM_coms, only : reproducing_sum, EFP_type, EFP_to_real, EFP_real_diff
 use MOM_domains,       only : pass_var, pass_vector, BGRID_NE, CGRID_NE
-use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING
-use MOM_error_handler, only : SIS_mesg=>MOM_mesg, is_root_pe
+use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 ! use MOM_file_parser, only : get_param, log_param, read_param, log_version, param_file_type
 use MOM_hor_index,   only : hor_index_type
 use MOM_obsolete_params, only : obsolete_logical, obsolete_real


### PR DESCRIPTION
  Restructured the SIS2 code so that all calls related to restarts and other
infrastructure calls are directed via the SIS_framework module, in preparation
for the transparent support of both the FMS1 and FMS2 i/o interfaces.  There are
a number of new public interfaces, notably in SIS_framework.F90 and there are
widespread changes, mostly related to these new interfaces, but no algorithms
are changed in any way, and all answers and output files are bitwise identical.

  The commits in this PR include:

- NOAA-GFDL/SIS2@e9c96df +Access coupler_types via SIS_framework
- NOAA-GFDL/SIS2@7d10fd6 Add FMS2_io non-implementation error messages
- NOAA-GFDL/SIS2@6bcd45e Specify dimensions in register_restart_field calls
- NOAA-GFDL/SIS2@0e7a5ba +Add option to specify that restarts use FMS2
- NOAA-GFDL/SIS2@794e922 +Removed various unused arguments
- NOAA-GFDL/SIS2@fea2ff0 +Use SIS-specific restart interfaces
- NOAA-GFDL/SIS2@4cd7acf Use safe_alloc calls for allocation
