### PR TITLE
SIS2: Revise the SIS2 use of framework code

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -12,8 +12,7 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_dyn_trans,     only : dyn_trans_CS
 use SIS_fast_thermo,   only : fast_thermo_CS
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH
-use SIS_framework,     only : coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : domain2D, coupler_2d_bc_type, coupler_3d_bc_type
 use SIS_framework,     only : coupler_type_initialized, coupler_type_set_diags
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_optics,        only : SIS_optics_CS

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -21,13 +21,13 @@ module SIS_slow_thermo
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
 
-use data_override_mod, only : data_override
 
 use ice_grid,          only : ice_grid_type
 use ice_spec_mod,      only : get_sea_surface
 
 use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,     only : CLOCK_COMPONENT, CLOCK_LOOP, CLOCK_ROUTINE
+use MOM_data_override, only : data_override
 use MOM_EOS,           only : EOS_type, calculate_density_derivs
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -9,10 +9,10 @@ module SIS_state_initialization
 ! routines have options that just read and log their input parameters.         !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
-use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
 use ice_grid,          only : ice_grid_type
 use ice_type_mod,      only : ice_data_type, dealloc_ice_arrays
 use ice_type_mod,      only : ice_type_slow_reg_restarts
+use MOM_data_override, only : data_override, data_override_init, data_override_unset_domains
 use MOM_domains,       only : MOM_domain_type
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -16,7 +16,7 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_debugging,     only : chksum, Bchksum, Bchksum_pair, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, redistribute_data
+use SIS_framework,     only : domain2D, CORNER, EAST_FACE, NORTH_FACE, redistribute_data
 use SIS_framework,     only : register_restart_field, SIS_restart_CS, restore_SIS_state
 use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts
 use SIS_framework,     only : safe_alloc, safe_alloc_ptr
@@ -517,14 +517,14 @@ subroutine ice_state_register_restarts(IST, G, IG, Ice_restart)
     if (IST%Cgrid_dyn) then
       if (G%symmetric) then
         call register_restart_field(Ice_restart, 'sym_u_ice_C', IST%u_ice_C, &
-                                    position=EAST, mandatory=.false.)
+                                    position=EAST_FACE, mandatory=.false.)
         call register_restart_field(Ice_restart, 'sym_v_ice_C', IST%v_ice_C, &
-                                    position=NORTH, mandatory=.false.)
+                                    position=NORTH_FACE, mandatory=.false.)
       else
         call register_restart_field(Ice_restart, 'u_ice_C', IST%u_ice_C, &
-                                    position=EAST, mandatory=.false.)
+                                    position=EAST_FACE, mandatory=.false.)
         call register_restart_field(Ice_restart, 'v_ice_C', IST%v_ice_C, &
-                                    position=NORTH, mandatory=.false.)
+                                    position=NORTH_FACE, mandatory=.false.)
       endif
     else
       if (G%symmetric) then
@@ -604,9 +604,9 @@ subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, restart_dir)
     if (IST%Cgrid_dyn .and. (.not.u_set)) then
       call safe_alloc(u_tmp, G%isd, G%ied, G%jsd, G%jed)
       call safe_alloc(v_tmp, G%isd, G%ied, G%jsd, G%jed)
-      call only_read_from_restarts(Ice_restart, 'u_ice_C', u_tmp, position=EAST, &
+      call only_read_from_restarts(Ice_restart, 'u_ice_C', u_tmp, position=EAST_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_u)
-      call only_read_from_restarts(Ice_restart, 'v_ice_C', v_tmp, position=NORTH, &
+      call only_read_from_restarts(Ice_restart, 'v_ice_C', v_tmp, position=NORTH_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_v)
       if (read_u .and. read_v) then
         ! The non-symmetric variant of this vector has been successfully read.
@@ -655,9 +655,9 @@ subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, restart_dir)
     if (IST%Cgrid_dyn .and. (.not.u_set)) then
       call safe_alloc(u_tmp, G%isd-1, G%ied, G%jsd, G%jed)
       call safe_alloc(v_tmp, G%isd, G%ied, G%jsd-1, G%jed)
-      call only_read_from_restarts(Ice_restart, 'sym_u_ice_C', u_tmp, position=EAST, &
+      call only_read_from_restarts(Ice_restart, 'sym_u_ice_C', u_tmp, position=EAST_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_u)
-      call only_read_from_restarts(Ice_restart, 'sym_v_ice_C', v_tmp, position=NORTH, &
+      call only_read_from_restarts(Ice_restart, 'sym_v_ice_C', v_tmp, position=NORTH_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_v)
       if (read_u .and. read_v) then
         ! The symmetric variant of this vector has been successfully read.

--- a/src/ice_spec.F90
+++ b/src/ice_spec.F90
@@ -1,10 +1,10 @@
 !> sea ice and SST specified from data as per GFDL climate group
 module ice_spec_mod
 
-use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
 use fms_mod, only : write_version_number
 use mpp_mod, only : input_nml_file
 
+use MOM_data_override, only : data_override, data_override_init, data_override_unset_domains
 use MOM_error_handler, only : stdlog, stdout
 use MOM_hor_index,     only : hor_index_type
 use MOM_io,            only : open_namelist_file, check_nml_error, close_file

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -13,11 +13,9 @@ use MOM_time_manager,  only : time_type, time_type_to_real
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_ctrl_types,    only : SIS_fast_CS, SIS_slow_CS
 use SIS_debugging,     only : chksum
-use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
-use SIS_diag_mediator, only : register_SIS_diag_field
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, SIS_chksum, get_compute_domain
-use SIS_framework,     only : register_restart_field, SIS_restart_CS
-use SIS_framework,     only : save_restart, query_initialized, safe_alloc, safe_alloc_ptr
+use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data, register_SIS_diag_field
+use SIS_framework,     only : domain2D, SIS_chksum, get_domain_extent, safe_alloc, safe_alloc_ptr
+use SIS_framework,     only : register_restart_field, save_restart, SIS_restart_CS, query_initialized
 use SIS_framework,     only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
 use SIS_framework,     only : coupler_type_spawn, coupler_type_write_chksums
 use SIS_hor_grid,      only : SIS_hor_grid_type
@@ -179,7 +177,7 @@ subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_domain_extent(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   ! The fields t_surf, s_surf, and part_size are only available on fast PEs.
@@ -271,7 +269,7 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_domain_extent(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   call safe_alloc_ptr(Ice%t_surf, isc, iec, jsc, jec, km)


### PR DESCRIPTION
  This PR contains a series of commits that coordinate the SIS2 infrastructure
calls with the MOM6 infrastructure calls and make calls to the underlying FMS
infrastructure via that MOM6 framework or config_src/infra modules.  All answers
and output are bitwise identical, but there are some interface changes, and the
version of MOM6 that is used must include the changes in MOM6 PR #1363 to
dev/gfdl (merged in on April 6, 2021).  The changes in this PR include:

- NOAA-GFDL/SIS2@b10799c Use EAST_FACE instead of EAST to denote positions
- NOAA-GFDL/SIS2@27d462a Eliminate unused module use entries
- NOAA-GFDL/SIS2@3e342e9 Use MOM6/config_src/infra in SIS_framework.F90
- NOAA-GFDL/SIS2@6b24054 Call data_override via MOM_data_override
- NOAA-GFDL/SIS2@783f937 +Use same_domain from MOM_domain_infra
- NOAA-GFDL/SIS2@d451bc6 SIS_diag_mediator goes via MOM_diag_manager_infra
