### PR TITLE
(*)+Stop ignoring SIS2 namelist entries

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -12,8 +12,7 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_dyn_trans,     only : dyn_trans_CS
 use SIS_fast_thermo,   only : fast_thermo_CS
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH
-use SIS_framework,     only : coupler_2d_bc_type, coupler_3d_bc_type
+use SIS_framework,     only : domain2D, coupler_2d_bc_type, coupler_3d_bc_type
 use SIS_framework,     only : coupler_type_initialized, coupler_type_set_diags
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_optics,        only : SIS_optics_CS

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -21,13 +21,13 @@ module SIS_slow_thermo
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
 
-use data_override_mod, only : data_override
 
 use ice_grid,          only : ice_grid_type
 use ice_spec_mod,      only : get_sea_surface
 
 use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,     only : CLOCK_COMPONENT, CLOCK_LOOP, CLOCK_ROUTINE
+use MOM_data_override, only : data_override
 use MOM_EOS,           only : EOS_type, calculate_density_derivs
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -9,10 +9,10 @@ module SIS_state_initialization
 ! routines have options that just read and log their input parameters.         !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
-use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
 use ice_grid,          only : ice_grid_type
 use ice_type_mod,      only : ice_data_type, dealloc_ice_arrays
 use ice_type_mod,      only : ice_type_slow_reg_restarts
+use MOM_data_override, only : data_override, data_override_init, data_override_unset_domains
 use MOM_domains,       only : MOM_domain_type
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, SIS_mesg=>MOM_mesg
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -16,7 +16,7 @@ use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
 use SIS_diag_mediator, only : register_SIS_diag_field, register_static_field
 use SIS_debugging,     only : chksum, Bchksum, Bchksum_pair, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, redistribute_data
+use SIS_framework,     only : domain2D, CORNER, EAST_FACE, NORTH_FACE, redistribute_data
 use SIS_framework,     only : register_restart_field, SIS_restart_CS, restore_SIS_state
 use SIS_framework,     only : query_initialized=>query_inited, only_read_from_restarts
 use SIS_framework,     only : safe_alloc, safe_alloc_ptr
@@ -517,14 +517,14 @@ subroutine ice_state_register_restarts(IST, G, IG, Ice_restart)
     if (IST%Cgrid_dyn) then
       if (G%symmetric) then
         call register_restart_field(Ice_restart, 'sym_u_ice_C', IST%u_ice_C, &
-                                    position=EAST, mandatory=.false.)
+                                    position=EAST_FACE, mandatory=.false.)
         call register_restart_field(Ice_restart, 'sym_v_ice_C', IST%v_ice_C, &
-                                    position=NORTH, mandatory=.false.)
+                                    position=NORTH_FACE, mandatory=.false.)
       else
         call register_restart_field(Ice_restart, 'u_ice_C', IST%u_ice_C, &
-                                    position=EAST, mandatory=.false.)
+                                    position=EAST_FACE, mandatory=.false.)
         call register_restart_field(Ice_restart, 'v_ice_C', IST%v_ice_C, &
-                                    position=NORTH, mandatory=.false.)
+                                    position=NORTH_FACE, mandatory=.false.)
       endif
     else
       if (G%symmetric) then
@@ -604,9 +604,9 @@ subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, restart_dir)
     if (IST%Cgrid_dyn .and. (.not.u_set)) then
       call safe_alloc(u_tmp, G%isd, G%ied, G%jsd, G%jed)
       call safe_alloc(v_tmp, G%isd, G%ied, G%jsd, G%jed)
-      call only_read_from_restarts(Ice_restart, 'u_ice_C', u_tmp, position=EAST, &
+      call only_read_from_restarts(Ice_restart, 'u_ice_C', u_tmp, position=EAST_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_u)
-      call only_read_from_restarts(Ice_restart, 'v_ice_C', v_tmp, position=NORTH, &
+      call only_read_from_restarts(Ice_restart, 'v_ice_C', v_tmp, position=NORTH_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_v)
       if (read_u .and. read_v) then
         ! The non-symmetric variant of this vector has been successfully read.
@@ -655,9 +655,9 @@ subroutine ice_state_read_alt_restarts(IST, G, IG, Ice_restart, restart_dir)
     if (IST%Cgrid_dyn .and. (.not.u_set)) then
       call safe_alloc(u_tmp, G%isd-1, G%ied, G%jsd, G%jed)
       call safe_alloc(v_tmp, G%isd, G%ied, G%jsd-1, G%jed)
-      call only_read_from_restarts(Ice_restart, 'sym_u_ice_C', u_tmp, position=EAST, &
+      call only_read_from_restarts(Ice_restart, 'sym_u_ice_C', u_tmp, position=EAST_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_u)
-      call only_read_from_restarts(Ice_restart, 'sym_v_ice_C', v_tmp, position=NORTH, &
+      call only_read_from_restarts(Ice_restart, 'sym_v_ice_C', v_tmp, position=NORTH_FACE, &
                    directory=restart_dir, domain=domain_tmp, success=read_v)
       if (read_u .and. read_v) then
         ! The symmetric variant of this vector has been successfully read.

--- a/src/ice_spec.F90
+++ b/src/ice_spec.F90
@@ -1,10 +1,10 @@
 !> sea ice and SST specified from data as per GFDL climate group
 module ice_spec_mod
 
-use data_override_mod, only : data_override, data_override_init, data_override_unset_domains
 use fms_mod, only : write_version_number
 use mpp_mod, only : input_nml_file
 
+use MOM_data_override, only : data_override, data_override_init, data_override_unset_domains
 use MOM_error_handler, only : stdlog, stdout
 use MOM_hor_index,     only : hor_index_type
 use MOM_io,            only : open_namelist_file, check_nml_error, close_file

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -13,11 +13,9 @@ use MOM_time_manager,  only : time_type, time_type_to_real
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_ctrl_types,    only : SIS_fast_CS, SIS_slow_CS
 use SIS_debugging,     only : chksum
-use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data
-use SIS_diag_mediator, only : register_SIS_diag_field
-use SIS_framework,     only : domain2D, CORNER, EAST, NORTH, SIS_chksum, get_compute_domain
-use SIS_framework,     only : register_restart_field, SIS_restart_CS
-use SIS_framework,     only : save_restart, query_initialized, safe_alloc, safe_alloc_ptr
+use SIS_diag_mediator, only : SIS_diag_ctrl, post_data=>post_SIS_data, register_SIS_diag_field
+use SIS_framework,     only : domain2D, SIS_chksum, get_domain_extent, safe_alloc, safe_alloc_ptr
+use SIS_framework,     only : register_restart_field, save_restart, SIS_restart_CS, query_initialized
 use SIS_framework,     only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
 use SIS_framework,     only : coupler_type_spawn, coupler_type_write_chksums
 use SIS_hor_grid,      only : SIS_hor_grid_type
@@ -179,7 +177,7 @@ subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_domain_extent(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   ! The fields t_surf, s_surf, and part_size are only available on fast PEs.
@@ -271,7 +269,7 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   ! registers the appopriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
-  call get_compute_domain(domain, isc, iec, jsc, jec )
+  call get_domain_extent(domain, isc, iec, jsc, jec )
   km = CatIce + 1
 
   call safe_alloc_ptr(Ice%t_surf, isc, iec, jsc, jec, km)

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -153,6 +153,8 @@ type ice_data_type !  ice_public_type
           !< A pointer to the slow ice restart control structure
   type(SIS_restart_CS), pointer :: Ice_fast_restart => NULL()
           !< A pointer to the fast ice restart control structure
+  character(len=240) :: restart_output_dir = './RESTART/'
+          !< The directory into which to write restart files.
 end type ice_data_type !  ice_public_type
 
 contains
@@ -503,13 +505,16 @@ subroutine ice_model_restart(Ice, time_stamp)
   character(len=*), optional, intent(in)    :: time_stamp !< A date stamp to include in the restart file name
 
   if (associated(Ice%Ice_restart)) then
-    call save_restart(Ice%Ice_restart, time_stamp)
+    call save_restart(Ice%restart_output_dir, Ice%Time, Ice%sCS%G, Ice%Ice_restart, IG=Ice%sCS%IG, &
+                      time_stamp=time_stamp)
     if (associated(Ice%Ice_fast_restart)) then
-      if (.not.associated(Ice%Ice_fast_restart,Ice%Ice_restart)) &
-        call save_restart(Ice%Ice_fast_restart, time_stamp)
+      if (.not.associated(Ice%Ice_fast_restart, Ice%Ice_restart)) &
+        call save_restart(Ice%restart_output_dir, Ice%Time, Ice%fCS%G, Ice%Ice_fast_restart, &
+                          IG=Ice%fCS%IG, time_stamp=time_stamp)
     endif
   elseif (associated(Ice%Ice_fast_restart)) then
-    call save_restart(Ice%Ice_fast_restart, time_stamp)
+    call save_restart(Ice%restart_output_dir, Ice%Time, Ice%fCS%G, Ice%Ice_fast_restart, &
+                      IG=Ice%fCS%IG, time_stamp=time_stamp)
   endif
   call icebergs_save_restart(Ice%icebergs, time_stamp)
 


### PR DESCRIPTION
  Revised the handling of the SIS2 namelist entries so that they are no longer
ignored, addressing SIS2 issue #96.  This includes modification so that the
behavior when input_filename = 'F' is exactly the same as if it is 'n' if there
are no restart files in the restart_input_dir, or as if it is 'r' if the restart
files are there.  Previously there had been differences in the output files
generated, but the solutions were always if input_filename = 'F'.  The entries
in dirs%restart_output_dir are now used to guide where SIS2 writes its restarts,
whereas this had previously been ignored with the output always going into
"./RESTART/".  As a part of this change, a 5 routines have been imported from
MOM_restart.F90 to help determine when this is a new run in 'F' mode, and there
have been a number of new arguments added to the restart-related interfaces,
both to support these changes, and to align these interfaces with those of
MOM_restart.F90.  Answers can change unless input_filename = 'F', and there can
be changes in which output files are written and the presence of one entry in
the SIS_parameter_doc.all files.

  Despite appearances to the contrary, this is actually a relatively simple single-commit
PR (commit 5e5525c...) with just three files modified, that builds on SIS2 PR #140.