### PR TITLE
+Added 4 new diagnostics to comply with CMOR

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -299,6 +299,9 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                'surface temperature', 'C', missing_value=missing)
   FIA%id_sitemptop= register_SIS_diag_field('ice_model', 'sitemptop', diag%axesT1, Time, &
                'surface temperature', 'C', missing_value=missing)
+  FIA%id_sitemptop_CMOR = register_SIS_diag_field('ice_model', 'sitemptop_CMOR', diag%axesT1, Time, &
+               'Surface Temperature of Sea ice', 'Kelvin', missing_value=missing, &
+               standard_name="SeaIceSurfaceTemperature")
 
   ! diagnostics for quantities produced outside the ice model
   FIA%id_slp   = register_SIS_diag_field('ice_model', 'SLP', diag%axesT1, Time, &

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -163,6 +163,8 @@ subroutine post_flux_diagnostics(IST, FIA, IOF, CS, G, US, IG, Idt_slow)
 
   real, dimension(G%isd:G%ied,G%jsd:G%jed) :: tmp2d, net_sw, sw_dn ! Shortwave fluxes[Q R Z T-1 ~> W m-2]
   real :: sw_cat ! [Q R Z T-1 ~> W m-2]
+  real, parameter :: T_0degC = 273.15 ! 0 degrees C in Kelvin
+  real, parameter :: missing = -1e34  ! A missing data fill value
   integer :: i, j, k, m, n, b, nb, isc, iec, jsc, jec, ncat
 
   isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec ; ncat = IG%CatIce
@@ -223,6 +225,13 @@ subroutine post_flux_diagnostics(IST, FIA, IOF, CS, G, US, IG, Idt_slow)
   endif
   if (FIA%id_tsfc>0) call post_data(FIA%id_tsfc, FIA%Tskin_avg, CS%diag)
   if (FIA%id_sitemptop>0) call post_data(FIA%id_sitemptop, FIA%Tskin_avg, CS%diag)
+  if (FIA%id_sitemptop_CMOR>0) then
+    tmp2d(:,:) = missing
+    do j=jsc,jec ; do i=isc,iec
+      if (FIA%Tskin_avg(i,j) /= missing) tmp2d(i,j) = FIA%Tskin_avg(i,j) + T_0degC
+    enddo ; enddo
+    call post_data(FIA%id_sitemptop_CMOR, tmp2d, CS%diag)
+  endif
 
   if (FIA%id_sh0>0) call post_data(FIA%id_sh0, FIA%flux_sh0, CS%diag)
   if (FIA%id_evap0>0) call post_data(FIA%id_evap0, FIA%evap0, CS%diag)

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -257,7 +257,7 @@ type fast_ice_avg_type
   integer :: id_sw_vis=-1, id_sw_dir=-1, id_sw_dif=-1, id_sw_dn=-1, id_albedo=-1
   integer :: id_runoff=-1, id_calving=-1, id_runoff_hflx=-1, id_calving_hflx=-1
   integer :: id_tmelt=-1, id_bmelt=-1, id_bheat=-1
-  integer :: id_tsfc=-1, id_sitemptop=-1
+  integer :: id_tsfc=-1, id_sitemptop=-1, id_sitemptop_CMOR=-1
 
   integer :: id_evap_cat=-1, id_lw_cat=-1, id_sh_cat=-1, id_tsfc_cat=-1
   integer :: id_evap0=-1, id_lw0=-1, id_sh0=-1


### PR DESCRIPTION
  Added 4 new diagnostics to comply with CMOR requirements for units and how the
diagnostics are calculated.  Because the suggested CMOR names were already in
use, they have been added with _CMOR appended to their names.  The four new
diagnostics in question are "siconc_CMOR", "sivol_CMOR", "sisnconc_CMOR" and
"sitemptop_CMOR", and of course there are new entries in the SIS.available_diags
files.  This PR closes SIS2 issues #91, #92, and #93.  In addition by making the
axes in the registration call for "RDG_FRAC" consistent with the dimensionality
of the diagnostic that is written out, this PR might also have addressed SIS2
issue #138.  The new diagnostics have been visually confirmed to be credible,
and all solutions are bitwise identical.