### PR TITLE
FMS2 requires units for all netcdf dimension

### DIFF
--- a/src/SIS_restart.F90
+++ b/src/SIS_restart.F90
@@ -1047,14 +1047,15 @@ subroutine save_restart(directory, time, G, CS, IG, time_stamp)
   if (PRESENT(time_stamp)) restartname = trim(CS%restartfile)//trim(time_stamp)
 
   if (present(IG)) then
-    call set_axis_info(extra_axes(1), "cat", longname="Ice thickness categories", ax_size=IG%CatIce)
-    call set_axis_info(extra_axes(2), "cat0", longname="Ice thickness categories with open water", ax_size=IG%CatIce+1)
-    call set_axis_info(extra_axes(3), "z_ice", longname="Ice vertical layers", &
+    call set_axis_info(extra_axes(1), "cat", longname="Ice thickness categories", units="None", ax_size=IG%CatIce)
+    call set_axis_info(extra_axes(2), "cat0", longname="Ice thickness categories with open water", units="None", &
+                       ax_size=IG%CatIce+1)
+    call set_axis_info(extra_axes(3), "z_ice", longname="Ice vertical layers", units="None", &
                        cartesian='Z', sense=-1, ax_size=IG%NkIce)
-    call set_axis_info(extra_axes(4), "z_snow", longname="Snow vertical layers", &
+    call set_axis_info(extra_axes(4), "z_snow", longname="Snow vertical layers", units="None", &
                        cartesian='Z', sense=-1, ax_size=IG%NkSnow)
     call set_axis_info(extra_axes(5), "band", longname="Frequency and angular band of shortwave radiation", &
-                       cartesian='Z', sense=-1, ax_size=4) !### This size is hard-coded for now.
+                       units="None", cartesian='Z', sense=-1, ax_size=4) !### This size is hard-coded for now.
   endif
 
   call create_dyn_horgrid(dG, G%HI)


### PR DESCRIPTION
- All ocean-ice tests were failing to read from their own restart files because FMS2
  could not find "units" for a few new netcdf dims cat,cat0,z_ice,z_snow

- Mode of failure was
```
FATAL from PE    32: NetCDF: Attribute not found
Image              PC                Routine            Line        Source
fms_MOM6_SIS2_com  0000000002519CE1  Unknown               Unknown  Unknown
fms_MOM6_SIS2_com  000000000173F7FC  mpp_mod_mp_mpp_er          68  mpp_util_mpi.inc
fms_MOM6_SIS2_com  0000000001812E00  fms_io_utils_mod_         194  fms_io_utils.F90
fms_MOM6_SIS2_com  0000000001760277  netcdf_io_mod_mp_         337  netcdf_io.F90
fms_MOM6_SIS2_com  00000000007A7D5E  mom_io_infra_mp_g         502  MOM_io_infra.F90
fms_MOM6_SIS2_com  0000000000668784  sis_restart_mp_re        1240  SIS_restart.F90
fms_MOM6_SIS2_com  00000000004B0152  ice_model_mod_mp_        2311  ice_model.F90
fms_MOM6_SIS2_com  000000000040C5CB  coupler_main_IP_c        1697  coupler_main.F90
fms_MOM6_SIS2_com  0000000000401B42  MAIN__                    568  coupler_main.F90
```