### PR TITLE
+Change opt. arg. to set_massless_SIS_tracers

### DIFF
--- a/src/SIS_tracer_registry.F90
+++ b/src/SIS_tracer_registry.F90
@@ -412,23 +412,24 @@ subroutine update_SIS_tracer_halos(TrReg, G, complete)
 end subroutine update_SIS_tracer_halos
 
 !> Set the properties of the ice tracers where there is no ice mass
-subroutine set_massless_SIS_tracers(mass, TrReg, G, IG, compute_domain, do_snow, do_ice)
+subroutine set_massless_SIS_tracers(mass, TrReg, G, IG, halos, do_snow, do_ice)
   type(SIS_hor_grid_type),        intent(inout) :: G   !< The horizontal grid type
   type(ice_grid_type),            intent(inout) :: IG  !< The sea-ice specific grid type
   real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)), &
                                   intent(in)    :: mass !< The ice or snow mass [R Z ~> kg m-2].
   type(SIS_tracer_registry_type), intent(inout) :: TrReg !< A pointer to the SIS tracer registry
-  logical,              optional, intent(in) :: compute_domain !< If true, work over the whole data domain
-  logical,              optional, intent(in) :: do_snow !< If true, work on snow tracers; the default is true.
-  logical,              optional, intent(in) :: do_ice  !< If true, work on ice tracers; the default is true.
+  integer,              optional, intent(in)    :: halos !< The halo size to work over, 0 by default
+  logical,              optional, intent(in)    :: do_snow !< If true, work on snow tracers; the default is true.
+  logical,              optional, intent(in)    :: do_ice  !< If true, work on ice tracers; the default is true.
 
   integer :: i, j, k, m, n, is, ie, js, je, nCat
   logical :: do_snow_tr, do_ice_tr
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nCat = IG%CatIce
-  if (present(compute_domain)) then ; if (compute_domain) then
-    is = G%isd ; ie = G%ied ; js = G%jsd ; je = G%jed
-  endif ; endif
+  if (present(halos)) then
+    is = max(G%isc-halos, G%isd) ; ie = min(G%iec+halos, G%ied)
+    js = max(G%jsc-halos, G%jsd) ; je = min(G%jec+halos, G%jed)
+  endif
 
   do_snow_tr = .true. ; do_ice_tr = .true.
   if (present(do_snow)) do_snow_tr = do_snow

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -153,8 +153,8 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   if (CAS%dt_sum <= 0.0) then
-    call set_massless_SIS_tracers(CAS%m_snow, TrReg, G, IG, compute_domain=.true., do_ice=.false.)
-    call set_massless_SIS_tracers(CAS%m_ice, TrReg, G, IG, compute_domain=.true., do_snow=.false.)
+    call set_massless_SIS_tracers(CAS%m_snow, TrReg, G, IG, halos=0, do_ice=.false.)
+    call set_massless_SIS_tracers(CAS%m_ice, TrReg, G, IG, halos=0, do_snow=.false.)
 
     if (CS%bounds_check) call check_SIS_tracer_bounds(TrReg, G, IG, "SIS_transport set massless 1")
   endif
@@ -287,8 +287,8 @@ subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
     mca0_ice(i,j,k) = IST%part_size(i,j,k)*IST%mH_ice(i,j,k)
     mca0_snow(i,j,k) = IST%part_size(i,j,k)*IST%mH_snow(i,j,k)
   enddo ; enddo ; enddo
-  call set_massless_SIS_tracers(mca0_snow, TrReg, G, IG, compute_domain=.true., do_ice=.false.)
-  call set_massless_SIS_tracers(mca0_ice, TrReg, G, IG, compute_domain=.true., do_snow=.false.)
+  call set_massless_SIS_tracers(mca0_snow, TrReg, G, IG, halos=0, do_ice=.false.)
+  call set_massless_SIS_tracers(mca0_ice, TrReg, G, IG, halos=0, do_snow=.false.)
 
   if (CS%bounds_check) call check_SIS_tracer_bounds(TrReg, G, IG, "SIS_transport set massless 2")
 


### PR DESCRIPTION
  Changed the interface to set_massless_SIS_tracers by replacing the optional
compute_domain logical argument (which took the opposite sense of what its name
seems to imply) with a new optional integer argument, halos, to specify the
size of the halos that this works on.  Previously calls to this routine from
ice_cat_transport and finish_ice_transport had led to uninitialized data being
used, but this change fixes this problem.  All answers are bitwise identical,
although there is a change to a public interface.