### PR TITLE
Use allocate with source to initialize arrays

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -443,7 +443,7 @@ subroutine safe_alloc_ids_1d(ids, nids)
   integer,              intent(in)    :: nids   !< The number of IDs to allocate
 
   if (.not.ALLOCATED(ids)) then
-    allocate(ids(nids)) ; ids(:) = -1
+    allocate(ids(nids), source=-1)
   endif
 end subroutine safe_alloc_ids_1d
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -296,8 +296,8 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
                    "Velocity for Lemieux landfast ice.", &
                    units="m s-1", default=5.e-5, scale=US%m_s_to_L_T)
 
-    allocate(CS%Tb_u(G%IsdB:G%IedB,G%jsd:G%jed)) ; CS%Tb_u(:,:) = 0.0
-    allocate(CS%Tb_v(G%isd:G%ied,G%JsdB:G%JedB)) ; CS%Tb_v(:,:) = 0.0
+    allocate(CS%Tb_u(G%IsdB:G%IedB,G%jsd:G%jed), source=0.0)
+    allocate(CS%Tb_v(G%isd:G%ied,G%JsdB:G%JedB), source=0.0)
   endif
 
 !  if (len_trim(dirs%output_directory) > 0) then
@@ -1811,7 +1811,7 @@ subroutine SIS_C_dyn_read_alt_restarts(CS, G, US, Ice_restart, restart_dir)
 
     call clone_MOM_domain(G%domain, domain_tmp, symmetric=.false., &
                           domain_name="ice temporary domain")
-    allocate(str_tmp(G%isd:G%ied, G%jsd:G%jed)) ; str_tmp(:,:) = 0.0
+    allocate(str_tmp(G%isd:G%ied, G%jsd:G%jed), source=0.0)
 
     call only_read_from_restarts(Ice_restart, 'str_s', str_tmp, domain_tmp, position=CORNER, &
                                  directory=restart_dir, success=read_values)
@@ -1827,7 +1827,7 @@ subroutine SIS_C_dyn_read_alt_restarts(CS, G, US, Ice_restart, restart_dir)
 
     call clone_MOM_domain(G%domain, domain_tmp, symmetric=.true., &
                           domain_name="ice temporary domain")
-    allocate(str_tmp(G%isd-1:G%ied, G%jsd-1:G%jed)) ; str_tmp(:,:) = 0.0
+    allocate(str_tmp(G%isd-1:G%ied, G%jsd-1:G%jed), source=0.0)
 
     call only_read_from_restarts(Ice_restart, 'sym_str_s', str_tmp, domain_tmp, position=CORNER, &
                                  directory=restart_dir, success=read_values)

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -2373,12 +2373,12 @@ subroutine increase_max_tracer_step_memory(DS2d, G, max_nts)
     allocate(tmp_array(G%isd:G%ied, G%jsd:G%jed, 0:nts_prev))
     tmp_array(:,:,0:nts_prev) = DS2d%mca_step(:,:,0:nts_prev)
     deallocate(DS2d%mca_step)
-    allocate(DS2d%mca_step(G%isd:G%ied, G%jsd:G%jed, 0:DS2d%max_nts)) ; DS2d%mca_step(:,:,:) = 0.0
+    allocate(DS2d%mca_step(G%isd:G%ied, G%jsd:G%jed, 0:DS2d%max_nts), source=0.0)
     ! Copy over the data that had been set before.
     DS2d%mca_step(:,:,0:nts_prev) = tmp_array(:,:,0:nts_prev)
     deallocate(tmp_array)
   else
-    allocate(DS2d%mca_step(G%isd:G%ied, G%jsd:G%jed, 0:DS2d%max_nts)) ; DS2d%mca_step(:,:,:) = 0.0
+    allocate(DS2d%mca_step(G%isd:G%ied, G%jsd:G%jed, 0:DS2d%max_nts), source=0.0)
   !  This is the equivalent for when the 6 argument version of safe_alloc is available.
   !      call safe_alloc(DS2d%mca_step, G%isd, G%ied, G%jsd, G%jed, 0, DS2d%max_nts)
   endif
@@ -2386,7 +2386,7 @@ subroutine increase_max_tracer_step_memory(DS2d, G, max_nts)
   if (allocated(DS2d%uh_step)) then
     if (nts_prev > 0) then
       allocate(tmp_array(G%IsdB:G%IedB, G%jsd:G%jed, nts_prev))
-      if (nts_prev > 0) tmp_array(:,:,1:nts_prev) = DS2d%uh_step(:,:,1:nts_prev)
+      tmp_array(:,:,1:nts_prev) = DS2d%uh_step(:,:,1:nts_prev)
     endif
     deallocate(DS2d%uh_step)
     call safe_alloc(DS2d%uh_step, G%IsdB, G%IedB, G%jsd, G%jed, DS2d%max_nts)
@@ -2401,7 +2401,7 @@ subroutine increase_max_tracer_step_memory(DS2d, G, max_nts)
   if (allocated(DS2d%vh_step)) then
     if (nts_prev > 0) then
       allocate(tmp_array(G%isd:G%ied, G%JsdB:G%JedB, nts_prev))
-      if (nts_prev > 0) tmp_array(:,:,1:nts_prev) = DS2d%vh_step(:,:,1:nts_prev)
+      tmp_array(:,:,1:nts_prev) = DS2d%vh_step(:,:,1:nts_prev)
     endif
     deallocate(DS2d%vh_step)
     call safe_alloc(DS2d%vh_step, G%isd, G%ied, G%JsdB, G%JedB, DS2d%max_nts)

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -1312,8 +1312,8 @@ subroutine SIS_fast_thermo_init(Time, G, IG, param_file, diag, CS)
   call SIS2_ice_thm_init(G%US, param_file, CS%ice_thm_CSp)
 
   if (CS%column_check) then
-    allocate(CS%enth_prev(G%HI%isd:G%HI%ied, G%HI%jsd:G%HI%jed, IG%CatIce)) ; CS%enth_prev(:,:,:) = 0.0
-    allocate(CS%heat_in(G%HI%isd:G%HI%ied, G%HI%jsd:G%HI%jed, IG%CatIce)) ; CS%heat_in(:,:,:) = 0.0
+    allocate(CS%enth_prev(G%HI%isd:G%HI%ied, G%HI%jsd:G%HI%jed, IG%CatIce), source=0.0)
+    allocate(CS%heat_in(G%HI%isd:G%HI%ied, G%HI%jsd:G%HI%jed, IG%CatIce), source=0.0)
   endif
 
   call callTree_leave("SIS_fast_thermo_init()")

--- a/src/SIS_hor_grid.F90
+++ b/src/SIS_hor_grid.F90
@@ -488,10 +488,10 @@ subroutine allocate_metrics(G)
   ALLOC_(G%sin_rot(isd:ied,jsd:jed)) ; G%sin_rot(:,:) = 0.0
   ALLOC_(G%cos_rot(isd:ied,jsd:jed)) ; G%cos_rot(:,:) = 1.0
 
-  allocate(G%gridLonT(isg:ieg))   ; G%gridLonT(:) = 0.0
-  allocate(G%gridLonB(isg-1:ieg)) ; G%gridLonB(:) = 0.0
-  allocate(G%gridLatT(jsg:jeg))   ; G%gridLatT(:) = 0.0
-  allocate(G%gridLatB(jsg-1:jeg)) ; G%gridLatB(:) = 0.0
+  allocate(G%gridLonT(isg:ieg), source=0.0)
+  allocate(G%gridLonB(isg-1:ieg), source=0.0)
+  allocate(G%gridLatT(jsg:jeg), source=0.0)
+  allocate(G%gridLatB(jsg-1:jeg), source=0.0)
 
 end subroutine allocate_metrics
 

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -396,7 +396,7 @@ subroutine safe_alloc_ids_1d(ids, nids)
   integer,              intent(in)    :: nids   !< The number of IDs to allocate
 
   if (.not.ALLOCATED(ids)) then
-    allocate(ids(nids)) ; ids(:) = -1
+    allocate(ids(nids), source=-1)
   endif;
 end subroutine safe_alloc_ids_1d
 

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1499,7 +1499,7 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "varying rate as a form of outflow open boundary condition.", default=.false.)
   if (CS%transmute_ice) then
 
-    allocate(CS%transmutation_rate(SZI_(G), SZJ_(G))) ; CS%transmutation_rate(:,:) = 0.0
+    allocate(CS%transmutation_rate(SZI_(G), SZJ_(G)), source=0.0)
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     call get_param(param_file, mdl, "TRANSMUTATION_RATE_FILE", transmute_file, &
                  "The file from which the transmutation rate should be read.", &

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -958,7 +958,7 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 
   if (.not.query_initialized(Ice%Ice_restart, 'sal_ice')) then
     ! Initialize the ice salinity from separate variables for each layer, perhaps from a SIS1 restart.
-    allocate(sal_ice_tmp(SZI_(G), SZJ_(G), CatIce)) ; sal_ice_tmp(:,:,:) = 0.0
+    allocate(sal_ice_tmp(SZI_(G), SZJ_(G), CatIce), source=0.0)
     do n=1,NkIce
       write(nstr, '(I4)') n ; nstr = adjustl(nstr)
       call only_read_from_restarts(Ice%Ice_restart, 'sal_ice'//trim(nstr), sal_ice_tmp(:,:,:), &
@@ -980,7 +980,7 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
   read_t_ice(:) = .false.
   if ((.not.query_initialized(Ice%Ice_restart, 'enth_ice')) .or. &
       (.not.query_initialized(Ice%Ice_restart, 'enth_snow'))) then
-    allocate(t_ice_tmp(SZI_(G), SZJ_(G), CatIce, NkIce)) ; t_ice_tmp(:,:,:,:) = 0.0
+    allocate(t_ice_tmp(SZI_(G), SZJ_(G), CatIce, NkIce), source=0.0)
 
     do n=1,NkIce
       write(nstr, '(I4)') n ; nstr = adjustl(nstr)
@@ -1021,7 +1021,7 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
   if (.not.query_initialized(Ice%Ice_restart, 'enth_snow')) then
     ! Try to initialize the snow enthalpy from separate temperature variables for each layer,
     ! perhaps from a SIS1 restart.
-    allocate(t_snow_tmp(SZI_(G), SZJ_(G), CatIce)) ; t_snow_tmp(:,:,:) = 0.0
+    allocate(t_snow_tmp(SZI_(G), SZJ_(G), CatIce), source=0.0)
     call only_read_from_restarts(Ice%Ice_restart, 't_snow', t_snow_tmp, G%domain, &
                                  directory=dirs%restart_input_dir, success=read_values)
     if (.not.read_values) then ! Try reading the ice temperature if snow is not available.

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -168,13 +168,13 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
 
   CS%Start_time = Input_start_time
 
-  allocate(CS%water_in_col(G%isd:G%ied, G%jsd:G%jed)) ; CS%water_in_col(:,:) = 0.0
-  allocate(CS%heat_in_col(G%isd:G%ied, G%jsd:G%jed))  ; CS%heat_in_col(:,:) = 0.0
-  allocate(CS%salt_in_col(G%isd:G%ied, G%jsd:G%jed))  ; CS%salt_in_col(:,:) = 0.0
+  allocate(CS%water_in_col(G%isd:G%ied, G%jsd:G%jed), source=0.0)
+  allocate(CS%heat_in_col(G%isd:G%ied, G%jsd:G%jed), source=0.0)
+  allocate(CS%salt_in_col(G%isd:G%ied, G%jsd:G%jed), source=0.0)
   if (CS%column_check) then
-    allocate(CS%water_col_prev(G%isd:G%ied, G%jsd:G%jed)) ; CS%water_col_prev(:,:) = 0.0
-    allocate(CS%heat_col_prev(G%isd:G%ied, G%jsd:G%jed))  ; CS%heat_col_prev(:,:) = 0.0
-    allocate(CS%salt_col_prev(G%isd:G%ied, G%jsd:G%jed))  ; CS%salt_col_prev(:,:) = 0.0
+    allocate(CS%water_col_prev(G%isd:G%ied, G%jsd:G%jed), source=0.0)
+    allocate(CS%heat_col_prev(G%isd:G%ied, G%jsd:G%jed), source=0.0)
+    allocate(CS%salt_col_prev(G%isd:G%ied, G%jsd:G%jed), source=0.0)
   endif
 
 end subroutine SIS_sum_output_init

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -444,36 +444,36 @@ subroutine alloc_IST_arrays(HI, IG, IST, omit_velocities, omit_Tsurf, do_ridging
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
   IST%valid_IST = .true.
-  allocate(IST%part_size(isd:ied, jsd:jed, 0:CatIce)) ; IST%part_size(:,:,:) = 0.0
-  allocate(IST%mH_pond(  isd:ied, jsd:jed, CatIce)) ; IST%mH_pond(:,:,:) = 0.0
-  allocate(IST%mH_snow(  isd:ied, jsd:jed, CatIce)) ; IST%mH_snow(:,:,:) = 0.0
-  allocate(IST%enth_snow(isd:ied, jsd:jed, CatIce, 1)) ; IST%enth_snow(:,:,:,:) = 0.0
-  allocate(IST%mH_ice(   isd:ied, jsd:jed, CatIce)) ; IST%mH_ice(:,:,:) = 0.0
-  allocate(IST%enth_ice( isd:ied, jsd:jed, CatIce, NkIce)) ; IST%enth_ice(:,:,:,:) = 0.0
-  allocate(IST%sal_ice(  isd:ied, jsd:jed, CatIce, NkIce)) ; IST%sal_ice(:,:,:,:) = 0.0
+  allocate(IST%part_size(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(IST%mH_pond(  isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(IST%mH_snow(  isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(IST%enth_snow(isd:ied, jsd:jed, CatIce, 1), source=0.0)
+  allocate(IST%mH_ice(   isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(IST%enth_ice( isd:ied, jsd:jed, CatIce, NkIce), source=0.0)
+  allocate(IST%sal_ice(  isd:ied, jsd:jed, CatIce, NkIce), source=0.0)
 
   if (present(do_ridging)) then ; if (do_ridging) then
-    allocate(IST%snow_to_ocn(isd:ied, jsd:jed)) ; IST%snow_to_ocn(:,:) = 0.0
-    allocate(IST%water_to_ocn(isd:ied, jsd:jed)) ; IST%water_to_ocn(:,:) = 0.0
-    allocate(IST%enth_snow_to_ocn(isd:ied, jsd:jed)) ; IST%enth_snow_to_ocn(:,:) = 0.0
-    allocate(IST%rdg_rate(isd:ied, jsd:jed)) ; IST%rdg_rate(:,:) = 0.0
-    allocate(IST%rdg_mice(isd:ied, jsd:jed, CatIce)) ; IST%rdg_mice(:,:,:) = 0.0
+    allocate(IST%snow_to_ocn(isd:ied, jsd:jed), source=0.0)
+    allocate(IST%water_to_ocn(isd:ied, jsd:jed), source=0.0)
+    allocate(IST%enth_snow_to_ocn(isd:ied, jsd:jed), source=0.0)
+    allocate(IST%rdg_rate(isd:ied, jsd:jed), source=0.0)
+    allocate(IST%rdg_mice(isd:ied, jsd:jed, CatIce), source=0.0)
   endif ; endif
 
   if (do_vel) then
     ! These velocities are only required for the slow ice processes, and hence
     ! can use the memory macros.
-    allocate(IST%u_ice_C(SZIB_(HI), SZJ_(HI))) ; IST%u_ice_C(:,:) = 0.0
-    allocate(IST%v_ice_C(SZI_(HI), SZJB_(HI))) ; IST%v_ice_C(:,:) = 0.0
+    allocate(IST%u_ice_C(SZIB_(HI), SZJ_(HI)), source=0.0)
+    allocate(IST%v_ice_C(SZI_(HI), SZJB_(HI)), source=0.0)
     if (.not.IST%Cgrid_dyn) then
-      allocate(IST%u_ice_B(SZIB_(HI), SZJB_(HI))) ; IST%u_ice_B(:,:) = 0.0
-      allocate(IST%v_ice_B(SZIB_(HI), SZJB_(HI))) ; IST%v_ice_B(:,:) = 0.0
+      allocate(IST%u_ice_B(SZIB_(HI), SZJB_(HI)), source=0.0)
+      allocate(IST%v_ice_B(SZIB_(HI), SZJB_(HI)), source=0.0)
     endif
   endif
 
   if (do_Tsurf) then
     ! IST%tsurf is only used with some older options.
-    allocate(IST%t_surf(isd:ied, jsd:jed, CatIce)) ; IST%t_surf(:,:,:) = T_0degC
+    allocate(IST%t_surf(isd:ied, jsd:jed, CatIce), source=T_0degC)
   endif
 
 end subroutine alloc_IST_arrays
@@ -896,46 +896,46 @@ subroutine alloc_fast_ice_avg(FIA, HI, IG, interp_fluxes, gas_fluxes)
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
   FIA%avg_count = 0
-  allocate(FIA%flux_u_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_u_top(:,:,:) = 0.0
-  allocate(FIA%flux_v_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_v_top(:,:,:) = 0.0
-  allocate(FIA%flux_sh_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_sh_top(:,:,:) = 0.0
-  allocate(FIA%evap_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%evap_top(:,:,:) = 0.0
-  allocate(FIA%flux_sw_top(isd:ied, jsd:jed, 0:CatIce, NBANDS)) ; FIA%flux_sw_top(:,:,:,:) = 0.0
-  allocate(FIA%flux_lw_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_lw_top(:,:,:) = 0.0
-  allocate(FIA%flux_lh_top(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_lh_top(:,:,:) = 0.0
-  allocate(FIA%lprec_top(isd:ied, jsd:jed, 0:CatIce)) ;  FIA%lprec_top(:,:,:) = 0.0
-  allocate(FIA%fprec_top(isd:ied, jsd:jed, 0:CatIce)) ;  FIA%fprec_top(:,:,:) = 0.0
-  allocate(FIA%runoff(isd:ied, jsd:jed)) ; FIA%runoff(:,:) = 0.0
-  allocate(FIA%calving(isd:ied, jsd:jed)) ; FIA%calving(:,:) = 0.0
-  allocate(FIA%calving_preberg(isd:ied, jsd:jed)) ; FIA%calving_preberg(:,:) = 0.0 ! diag
-  allocate(FIA%runoff_hflx(isd:ied, jsd:jed)) ; FIA%runoff_hflx(:,:) = 0.0
-  allocate(FIA%calving_hflx(isd:ied, jsd:jed)) ; FIA%calving_hflx(:,:) = 0.0
-  allocate(FIA%calving_hflx_preberg(isd:ied, jsd:jed)) ; FIA%calving_hflx_preberg(:,:) = 0.0 ! diag
+  allocate(FIA%flux_u_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%flux_v_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%flux_sh_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%evap_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%flux_sw_top(isd:ied, jsd:jed, 0:CatIce, NBANDS), source=0.0)
+  allocate(FIA%flux_lw_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%flux_lh_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%lprec_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%fprec_top(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+  allocate(FIA%runoff(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%calving(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%calving_preberg(isd:ied, jsd:jed), source=0.0) ! diag
+  allocate(FIA%runoff_hflx(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%calving_hflx(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%calving_hflx_preberg(isd:ied, jsd:jed), source=0.0) ! diag
 
-  allocate(FIA%frazil_left(isd:ied, jsd:jed)) ; FIA%frazil_left(:,:) = 0.0
-  allocate(FIA%tmelt(isd:ied, jsd:jed, CatIce)) ; FIA%tmelt(:,:,:) = 0.0
-  allocate(FIA%bmelt(isd:ied, jsd:jed, CatIce)) ; FIA%bmelt(:,:,:) = 0.0
-  allocate(FIA%WindStr_x(isd:ied, jsd:jed)) ; FIA%WindStr_x(:,:) = 0.0
-  allocate(FIA%WindStr_y(isd:ied, jsd:jed)) ; FIA%WindStr_y(:,:) = 0.0
-  allocate(FIA%WindStr_ocn_x(isd:ied, jsd:jed)) ; FIA%WindStr_ocn_x(:,:) = 0.0
-  allocate(FIA%WindStr_ocn_y(isd:ied, jsd:jed)) ; FIA%WindStr_ocn_y(:,:) = 0.0
-  allocate(FIA%p_atm_surf(isd:ied, jsd:jed)) ; FIA%p_atm_surf(:,:) = 0.0
-  allocate(FIA%Tskin_avg(isd:ied, jsd:jed)) ; FIA%Tskin_avg(:,:) = 0.0 ! diag
-  allocate(FIA%ice_free(isd:ied, jsd:jed))  ; FIA%ice_free(:,:) = 0.0
-  allocate(FIA%ice_cover(isd:ied, jsd:jed)) ; FIA%ice_cover(:,:) = 0.0
+  allocate(FIA%frazil_left(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%tmelt(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(FIA%bmelt(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(FIA%WindStr_x(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%WindStr_y(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%WindStr_ocn_x(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%WindStr_ocn_y(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%p_atm_surf(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%Tskin_avg(isd:ied, jsd:jed), source=0.0) ! diag
+  allocate(FIA%ice_free(isd:ied, jsd:jed), source=0.0)
+  allocate(FIA%ice_cover(isd:ied, jsd:jed), source=0.0)
 
   if (interp_fluxes) then
-    allocate(FIA%flux_sh0(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_sh0(:,:,:) = 0.0
-    allocate(FIA%evap0(isd:ied, jsd:jed, 0:CatIce)) ; FIA%evap0(:,:,:) = 0.0
-    allocate(FIA%flux_lw0(isd:ied, jsd:jed, 0:CatIce)) ; FIA%flux_lw0(:,:,:) = 0.0
-    allocate(FIA%dshdt(isd:ied, jsd:jed, 0:CatIce)) ; FIA%dshdt(:,:,:) = 0.0
-    allocate(FIA%devapdt(isd:ied, jsd:jed, 0:CatIce)) ; FIA%devapdt(:,:,:) = 0.0
-    allocate(FIA%dlwdt(isd:ied, jsd:jed, 0:CatIce)) ; FIA%dlwdt(:,:,:) = 0.0
-    allocate(FIA%Tskin_cat(isd:ied, jsd:jed, 0:CatIce)) ; FIA%Tskin_cat(:,:,:) = 0.0
+    allocate(FIA%flux_sh0(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%evap0(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%flux_lw0(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%dshdt(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%devapdt(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%dlwdt(isd:ied, jsd:jed, 0:CatIce), source=0.0)
+    allocate(FIA%Tskin_cat(isd:ied, jsd:jed, 0:CatIce), source=0.0)
   endif
 
-  allocate(FIA%flux_sw_dn(isd:ied, jsd:jed, NBANDS)) ; FIA%flux_sw_dn(:,:,:) = 0.0
-  allocate(FIA%sw_abs_ocn(isd:ied, jsd:jed, CatIce)) ; FIA%sw_abs_ocn(:,:,:) = 0.0
+  allocate(FIA%flux_sw_dn(isd:ied, jsd:jed, NBANDS), source=0.0)
+  allocate(FIA%sw_abs_ocn(isd:ied, jsd:jed, CatIce), source=0.0)
 
   if (present(gas_fluxes)) &
     call coupler_type_spawn(gas_fluxes, FIA%tr_flux, (/isd, isc, iec, ied/), &
@@ -960,15 +960,15 @@ subroutine alloc_total_sfc_flux(TSF, HI, gas_fluxes)
   isc = HI%isc ; iec = HI%iec ; jsc = HI%jsc ; jec = HI%jec
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
-  allocate(TSF%flux_u(isd:ied, jsd:jed)) ; TSF%flux_u(:,:) = 0.0
-  allocate(TSF%flux_v(isd:ied, jsd:jed)) ; TSF%flux_v(:,:) = 0.0
-  allocate(TSF%flux_sh(isd:ied, jsd:jed)) ; TSF%flux_sh(:,:) = 0.0
-  allocate(TSF%flux_sw(isd:ied, jsd:jed, NBANDS)) ; TSF%flux_sw(:,:,:) = 0.0
-  allocate(TSF%flux_lw(isd:ied, jsd:jed)) ; TSF%flux_lw(:,:) = 0.0
-  allocate(TSF%flux_lh(isd:ied, jsd:jed)) ; TSF%flux_lh(:,:) = 0.0
-  allocate(TSF%evap(isd:ied, jsd:jed)) ; TSF%evap(:,:) = 0.0
-  allocate(TSF%lprec(isd:ied, jsd:jed)) ;  TSF%lprec(:,:) = 0.0
-  allocate(TSF%fprec(isd:ied, jsd:jed)) ;  TSF%fprec(:,:) = 0.0
+  allocate(TSF%flux_u(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%flux_v(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%flux_sh(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%flux_sw(isd:ied, jsd:jed, NBANDS), source=0.0)
+  allocate(TSF%flux_lw(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%flux_lh(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%evap(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%lprec(isd:ied, jsd:jed), source=0.0)
+  allocate(TSF%fprec(isd:ied, jsd:jed), source=0.0)
   if (present(gas_fluxes)) &
     call coupler_type_spawn(gas_fluxes, TSF%tr_flux, (/isd, isc, iec, ied/), &
                             (/jsd, jsc, jec, jed/))
@@ -1000,7 +1000,7 @@ subroutine ice_rad_register_restarts(HI, IG, param_file, Rad, Ice_restart)
   call safe_alloc(Rad%sw_abs_sfc, isd, ied, jsd, jed, CatIce)
   call safe_alloc(Rad%sw_abs_snow, isd, ied, jsd, jed, CatIce)
   if (.not. allocated(Rad%sw_abs_ice)) then
-    allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce)) ; Rad%sw_abs_ice(:,:,:,:) = 0.0
+    allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce), source=0.0)
   endif
   call safe_alloc(Rad%sw_abs_ocn, isd, ied, jsd, jed, CatIce)
   call safe_alloc(Rad%sw_abs_int, isd, ied, jsd, jed, CatIce)
@@ -1025,17 +1025,17 @@ subroutine alloc_ice_rad(Rad, HI, IG)
   CatIce = IG%CatIce ; NkIce = IG%NkIce
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
-  allocate(Rad%t_skin(isd:ied, jsd:jed, CatIce)) ; Rad%t_skin(:,:,:) = 0.0
-  allocate(Rad%Tskin_rad(isd:ied, jsd:jed, CatIce)) ; Rad%Tskin_rad(:,:,:) = 0.0
+  allocate(Rad%t_skin(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(Rad%Tskin_rad(isd:ied, jsd:jed, CatIce), source=0.0)
 
-  allocate(Rad%sw_abs_sfc(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_sfc(:,:,:) = 0.0
-  allocate(Rad%sw_abs_snow(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_snow(:,:,:) = 0.0
-  allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce)) ; Rad%sw_abs_ice(:,:,:,:) = 0.0
-  allocate(Rad%sw_abs_ocn(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_ocn(:,:,:) = 0.0
-  allocate(Rad%sw_abs_int(isd:ied, jsd:jed, CatIce)) ; Rad%sw_abs_int(:,:,:) = 0.0
+  allocate(Rad%sw_abs_sfc(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(Rad%sw_abs_snow(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(Rad%sw_abs_ice(isd:ied, jsd:jed, CatIce, NkIce), source=0.0)
+  allocate(Rad%sw_abs_ocn(isd:ied, jsd:jed, CatIce), source=0.0)
+  allocate(Rad%sw_abs_int(isd:ied, jsd:jed, CatIce), source=0.0)
 
-  allocate(Rad%coszen_nextrad(isd:ied, jsd:jed)) ; Rad%coszen_nextrad(:,:) = 0.0
-  allocate(Rad%coszen_lastrad(isd:ied, jsd:jed)) ; Rad%coszen_lastrad(:,:) = 0.0
+  allocate(Rad%coszen_nextrad(isd:ied, jsd:jed), source=0.0)
+  allocate(Rad%coszen_lastrad(isd:ied, jsd:jed), source=0.0)
 
 end subroutine alloc_ice_rad
 
@@ -1060,40 +1060,40 @@ subroutine alloc_ice_ocean_flux(IOF, HI, do_stress_mag, do_iceberg_fields, do_tr
 
   if (.not.associated(IOF)) allocate(IOF)
 
-  allocate(IOF%flux_salt(SZI_(HI), SZJ_(HI))) ; IOF%flux_salt(:,:) = 0.0
+  allocate(IOF%flux_salt(SZI_(HI), SZJ_(HI)), source=0.0)
   if (do_transmute) then
-    allocate(IOF%transmutation_salt_flux(SZI_(HI), SZJ_(HI))) ; IOF%transmutation_salt_flux(:,:) = 0.0
+    allocate(IOF%transmutation_salt_flux(SZI_(HI), SZJ_(HI)), source=0.0)
   endif
 
-  allocate(IOF%flux_sh_ocn_top(SZI_(HI), SZJ_(HI))) ;  IOF%flux_sh_ocn_top(:,:) = 0.0
-  allocate(IOF%evap_ocn_top(SZI_(HI), SZJ_(HI))) ;  IOF%evap_ocn_top(:,:) = 0.0
-  allocate(IOF%flux_lw_ocn_top(SZI_(HI), SZJ_(HI))) ; IOF%flux_lw_ocn_top(:,:) = 0.0
-  allocate(IOF%flux_lh_ocn_top(SZI_(HI), SZJ_(HI))) ; IOF%flux_lh_ocn_top(:,:) = 0.0
-  allocate(IOF%flux_sw_ocn(SZI_(HI), SZJ_(HI), NBANDS)) ;  IOF%flux_sw_ocn(:,:,:) = 0.0
-  allocate(IOF%lprec_ocn_top(SZI_(HI), SZJ_(HI))) ;  IOF%lprec_ocn_top(:,:) = 0.0
-  allocate(IOF%fprec_ocn_top(SZI_(HI), SZJ_(HI))) ;  IOF%fprec_ocn_top(:,:) = 0.0
-  allocate(IOF%flux_u_ocn(SZI_(HI), SZJ_(HI)))    ;  IOF%flux_u_ocn(:,:) = 0.0
-  allocate(IOF%flux_v_ocn(SZI_(HI), SZJ_(HI)))    ;  IOF%flux_v_ocn(:,:) = 0.0
+  allocate(IOF%flux_sh_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%evap_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%flux_lw_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%flux_lh_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%flux_sw_ocn(SZI_(HI), SZJ_(HI), NBANDS), source=0.0)
+  allocate(IOF%lprec_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%fprec_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%flux_u_ocn(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%flux_v_ocn(SZI_(HI), SZJ_(HI)), source=0.0)
   if (alloc_stress_mag) then
-    allocate(IOF%stress_mag(SZI_(HI), SZJ_(HI)))  ;  IOF%stress_mag(:,:) = 0.0
+    allocate(IOF%stress_mag(SZI_(HI), SZJ_(HI)), source=0.0)
   endif
-  allocate(IOF%pres_ocn_top(SZI_(HI), SZJ_(HI)))  ; IOF%pres_ocn_top(:,:) = 0.0
-  allocate(IOF%mass_ice_sn_p(SZI_(HI), SZJ_(HI))) ; IOF%mass_ice_sn_p(:,:) = 0.0
+  allocate(IOF%pres_ocn_top(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%mass_ice_sn_p(SZI_(HI), SZJ_(HI)), source=0.0)
 
-  allocate(IOF%Enth_Mass_in_atm(SZI_(HI), SZJ_(HI)))  ; IOF%Enth_Mass_in_atm(:,:) = 0.0
-  allocate(IOF%Enth_Mass_out_atm(SZI_(HI), SZJ_(HI))) ; IOF%Enth_Mass_out_atm(:,:) = 0.0
-  allocate(IOF%Enth_Mass_in_ocn(SZI_(HI), SZJ_(HI)))  ; IOF%Enth_Mass_in_ocn(:,:) = 0.0
-  allocate(IOF%Enth_Mass_out_ocn(SZI_(HI), SZJ_(HI))) ; IOF%Enth_Mass_out_ocn(:,:) = 0.0
+  allocate(IOF%Enth_Mass_in_atm(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%Enth_Mass_out_atm(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%Enth_Mass_in_ocn(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(IOF%Enth_Mass_out_ocn(SZI_(HI), SZJ_(HI)), source=0.0)
   if (do_transmute) then
-    allocate(IOF%transmutation_enth(SZI_(HI), SZJ_(HI))) ; IOF%transmutation_enth(:,:) = 0.0
+    allocate(IOF%transmutation_enth(SZI_(HI), SZJ_(HI)), source=0.0)
   endif
   ! Allocating iceberg fields (only used if pass_iceberg_area_to_ocean=.True.)
   ! Please note that these are only allocated on the computational domain so that they
   ! can be passed conveniently to the iceberg code.
   if (alloc_bergs) then
-    allocate(IOF%mass_berg(HI%isc:HI%iec, HI%jsc:HI%jec)) ; IOF%mass_berg(:,:) = 0.0
-    allocate(IOF%ustar_berg(HI%isc:HI%iec, HI%jsc:HI%jec)) ; IOF%ustar_berg(:,:) = 0.0
-    allocate(IOF%area_berg(HI%isc:HI%iec, HI%jsc:HI%jec)) ; IOF%area_berg(:,:) = 0.0
+    allocate(IOF%mass_berg(HI%isc:HI%iec, HI%jsc:HI%jec), source=0.0)
+    allocate(IOF%ustar_berg(HI%isc:HI%iec, HI%jsc:HI%jec), source=0.0)
+    allocate(IOF%area_berg(HI%isc:HI%iec, HI%jsc:HI%jec), source=0.0)
   endif
 
 end subroutine alloc_ice_ocean_flux
@@ -1119,19 +1119,19 @@ subroutine alloc_ocean_sfc_state(OSS, HI, Cgrid_dyn, gas_fields_ocn)
   if (.not.associated(OSS)) allocate(OSS)
 
   ! The ocean_sfc_state_type only occurs on slow ice PEs, so it can use the memory macros.
-  allocate(OSS%s_surf(SZI_(HI), SZJ_(HI))) ; OSS%s_surf(:,:) = 0.0
-  allocate(OSS%SST_C(SZI_(HI), SZJ_(HI)))  ; OSS%SST_C(:,:) = 0.0
-  allocate(OSS%T_fr_ocn(SZI_(HI), SZJ_(HI))) ; OSS%T_fr_ocn(:,:) = 0.0
-  allocate(OSS%sea_lev(SZI_(HI), SZJ_(HI))) ; OSS%sea_lev(:,:) = 0.0
-  allocate(OSS%bheat(SZI_(HI), SZJ_(HI)))  ; OSS%bheat(:,:) = 0.0
-  allocate(OSS%frazil(SZI_(HI), SZJ_(HI))) ; OSS%frazil(:,:) = 0.0
+  allocate(OSS%s_surf(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(OSS%SST_C(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(OSS%T_fr_ocn(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(OSS%sea_lev(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(OSS%bheat(SZI_(HI), SZJ_(HI)), source=0.0)
+  allocate(OSS%frazil(SZI_(HI), SZJ_(HI)), source=0.0)
 
   if (Cgrid_dyn) then
-    allocate(OSS%u_ocn_C(SZIB_(HI), SZJ_(HI))) ; OSS%u_ocn_C(:,:) = 0.0
-    allocate(OSS%v_ocn_C(SZI_(HI), SZJB_(HI))) ; OSS%v_ocn_C(:,:) = 0.0
+    allocate(OSS%u_ocn_C(SZIB_(HI), SZJ_(HI)), source=0.0)
+    allocate(OSS%v_ocn_C(SZI_(HI), SZJB_(HI)), source=0.0)
   else
-    allocate(OSS%u_ocn_B(SZIB_(HI), SZJB_(HI))) ; OSS%u_ocn_B(:,:) = 0.0
-    allocate(OSS%v_ocn_B(SZIB_(HI), SZJB_(HI))) ; OSS%v_ocn_B(:,:) = 0.0
+    allocate(OSS%u_ocn_B(SZIB_(HI), SZJB_(HI)), source=0.0)
+    allocate(OSS%v_ocn_B(SZIB_(HI), SZJB_(HI)), source=0.0)
   endif
 
   OSS%Cgrid_dyn = Cgrid_dyn
@@ -1162,14 +1162,14 @@ subroutine alloc_simple_OSS(OSS, HI, gas_fields_ocn)
   isc = HI%isc ; iec = HI%iec ; jsc = HI%jsc ; jec = HI%jec
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed
 
-  allocate(OSS%s_surf(isd:ied, jsd:jed)) ; OSS%s_surf(:,:) = 0.0
-  allocate(OSS%SST_C(isd:ied, jsd:jed))  ; OSS%SST_C(:,:) = 0.0
-  allocate(OSS%T_fr_ocn(isd:ied, jsd:jed)) ; OSS%T_fr_ocn(:,:) = 0.0
-  allocate(OSS%bheat(isd:ied, jsd:jed))   ; OSS%bheat(:,:) = 0.0
-  allocate(OSS%u_ocn_A(isd:ied, jsd:jed)) ; OSS%u_ocn_A(:,:) = 0.0
-  allocate(OSS%v_ocn_A(isd:ied, jsd:jed)) ; OSS%v_ocn_A(:,:) = 0.0
-  allocate(OSS%u_ice_A(isd:ied, jsd:jed)) ; OSS%u_ice_A(:,:) = 0.0
-  allocate(OSS%v_ice_A(isd:ied, jsd:jed)) ; OSS%v_ice_A(:,:) = 0.0
+  allocate(OSS%s_surf(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%SST_C(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%T_fr_ocn(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%bheat(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%u_ocn_A(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%v_ocn_A(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%u_ice_A(isd:ied, jsd:jed), source=0.0)
+  allocate(OSS%v_ice_A(isd:ied, jsd:jed), source=0.0)
   if (present(gas_fields_ocn)) &
     call coupler_type_spawn(gas_fields_ocn, OSS%tr_fields, (/isd, isc, iec, ied/), &
                             (/jsd, jsc, jec, jed/))

--- a/src/ice_age_tracer.F90
+++ b/src/ice_age_tracer.F90
@@ -159,10 +159,10 @@ logical function register_ice_age_tracer(G, IG, param_file, CS, diag, TrReg, Ice
   CS%min_mass = 1.0e-7*G%US%kg_m3_to_R*G%US%m_to_Z
 
   ! Allocate the main tracer arrays
-  allocate(CS%tr(SZI_(G), SZJ_(G),IG%CatIce,IG%NkIce,CS%ntr)) ; CS%tr(:,:,:,:,:) = 0.0
+  allocate(CS%tr(SZI_(G), SZJ_(G), IG%CatIce, IG%NkIce, CS%ntr), source=0.0)
   ! Boundary condition arrays
-  allocate(CS%ocean_BC(SZI_(G), SZJ_(G),IG%CatIce,CS%ntr)) ; CS%ocean_BC(:,:,:,:) = 0.0
-  allocate(CS%snow_BC(SZI_(G), SZJ_(G),IG%CatIce,CS%ntr)) ; CS%snow_BC(:,:,:,:)  = 0.0
+  allocate(CS%ocean_BC(SZI_(G), SZJ_(G), IG%CatIce, CS%ntr), source=0.0)
+  allocate(CS%snow_BC(SZI_(G), SZJ_(G), IG%CatIce, CS%ntr), source=0.0)
 
   ! Make sure that diag manager is assigned
   CS%diag => diag

--- a/src/ice_grid.F90
+++ b/src/ice_grid.F90
@@ -126,8 +126,8 @@ subroutine allocate_ice_metrics(IG)
 
   ! This subroutine allocates any extensive elements of the ice_grid_type
   ! and zeros them out.
-  allocate(IG%cat_thick_lim(1:IG%CatIce+1)) ; IG%cat_thick_lim(:) = 0.0
-  allocate(IG%mH_cat_bound(1:IG%CatIce+1)) ; IG%mH_cat_bound(:) = 0.0
+  allocate(IG%cat_thick_lim(1:IG%CatIce+1), source=0.0)
+  allocate(IG%mH_cat_bound(1:IG%CatIce+1), source=0.0)
 end subroutine allocate_ice_metrics
 
 !---------------------------------------------------------------------

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2335,9 +2335,9 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       if (Ice%sCS%pass_stress_mag .and. .not.query_initialized(Ice%Ice_restart, 'stress_mag')) then
         ! Determine the magnitude of the stresses from the (non-symmetric-memory) stresses
         ! in the Ice type, which will have been read from the restart files.
-        allocate(str_x(sG%isd:sG%ied,sG%jsd:sG%jed)) ; str_x(:,:) = 0.0
-        allocate(str_y(sG%isd:sG%ied,sG%jsd:sG%jed)) ; str_y(:,:) = 0.0
-        allocate(stress_mag(sG%isd:sG%ied,sG%jsd:sG%jed)) ; stress_mag(:,:) = 0.0
+        allocate(str_x(sG%isd:sG%ied, sG%jsd:sG%jed), source=0.0)
+        allocate(str_y(sG%isd:sG%ied, sG%jsd:sG%jed), source=0.0)
+        allocate(stress_mag(sG%isd:sG%ied, sG%jsd:sG%jed), source=0.0)
 
         i_off = LBOUND(Ice%stress_mag,1) - sG%isc ; j_off = LBOUND(Ice%stress_mag,2) - sG%jsc
         do j=sG%jsc,sG%jec ; do i=sG%isc,sG%iec ; i2 = i+i_off ; j2 = j+j_off ! Correct for indexing differences.
@@ -2404,7 +2404,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       call get_sea_surface(Ice%sCS%Time, sG%HI, SST=Ice%sCS%OSS%SST_C, ice_domain=Ice%slow_domain_NH)
 
       !### Perhaps ice_conc and h_ice_input should also be read with the get_sea_surface limits.
-      ! allocate(h_ice_input(sG%isd:sG%ied,sG%jsd:sG%jed)) ; h_ice_input(:,:) = 0.0
+      ! allocate(h_ice_input(sG%isd:sG%ied, sG%jsd:sG%jed), source=0.0)
       ! call get_sea_surface(Ice%sCS%Time, sG%HI, SST=Ice%sCS%OSS%SST_C, ice_conc=sIST%part_size(:,:,1), &
       !                      ice_thick=h_ice_input, ice_domain=Ice%slow_domain_NH)
       ! do j=jsc,jec ; do i=isc,iec

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -281,7 +281,7 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
   call safe_alloc_ptr(Ice%u_surf, isc, iec, jsc, jec, km)
   call safe_alloc_ptr(Ice%v_surf, isc, iec, jsc, jec, km)
   if (.not.associated(Ice%ocean_pt)) then
-    allocate(Ice%ocean_pt(isc:iec, jsc:jec)) ; Ice%ocean_pt(:,:) = .false. !derived
+    allocate(Ice%ocean_pt(isc:iec, jsc:jec), source=.false.) !derived
   endif
 
   call safe_alloc_ptr(Ice%rough_mom, isc, iec, jsc, jec, km)


### PR DESCRIPTION
  Use the allocate call's source optional argument to initialize 145 arrays in
14 files.  This change simplifies and shortens the code and will make it easier
to identify uninitialized allocated arrays.  This change was only made to arrays
that were already being initialized on the same line as the allocate or shortly
thereafter.  All answers are bitwise identical.