### PR TITLE
+Rescale G%Rad_Earth and set it via dG%Rad_Earth_L

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -187,7 +187,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                                                     !! sea ice velocities.  The default is true.
 
   real, dimension(G%isc:G%iec,G%jsc:G%jec) :: tmp_diag ! A temporary diagnostic array
-  real                  :: I_area_Earth ! The inverse of the area of the sphere [m-2].
+  real                  :: I_area_Earth ! The inverse of the area of the sphere [L-2 ~> m-2].
   real, parameter       :: missing = -1e34  ! The fill value for missing data.
   integer               :: id_geo_lon, id_geo_lat, id_sin_rot, id_cos_rot, id_cell_area
   logical               :: Cgrid_dyn
@@ -225,21 +225,21 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                'rate of rain fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_runoff   = register_SIS_diag_field('ice_model', 'RUNOFF', diag%axesT1, Time, &
                'liquid runoff', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
-  FIA%id_calving  = register_SIS_diag_field('ice_model', 'CALVING',diag%axesT1, Time, &
+  FIA%id_calving  = register_SIS_diag_field('ice_model', 'CALVING', diag%axesT1, Time, &
                'frozen runoff', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_runoff_hflx  = register_SIS_diag_field('ice_model', 'RUNOFF_HFLX', diag%axesT1, Time, &
                'liquid runoff sensible heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
-  FIA%id_calving_hflx = register_SIS_diag_field('ice_model', 'CALVING_HFLX',diag%axesT1, Time, &
+  FIA%id_calving_hflx = register_SIS_diag_field('ice_model', 'CALVING_HFLX', diag%axesT1, Time, &
                'frozen runoff sensible heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
   FIA%id_evap     = register_SIS_diag_field('ice_model', 'EVAP',diag%axesT1, Time, &
                'evaporation', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   IOF%id_saltf    = register_SIS_diag_field('ice_model', 'SALTF', diag%axesT1, Time, &
                'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
-  FIA%id_tmelt    = register_SIS_diag_field('ice_model', 'TMELT' , diag%axesT1, Time, &
+  FIA%id_tmelt    = register_SIS_diag_field('ice_model', 'TMELT', diag%axesT1, Time, &
                'upper surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
-  FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT' , diag%axesT1, Time, &
+  FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT', diag%axesT1, Time, &
                'bottom surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
-  FIA%id_bheat    = register_SIS_diag_field('ice_model', 'BHEAT' , diag%axesT1, Time, &
+  FIA%id_bheat    = register_SIS_diag_field('ice_model', 'BHEAT', diag%axesT1, Time, &
                'ocean to ice heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
 
   if (coupler_type_initialized(IOF%tr_flux_ocn_top)) &
@@ -364,7 +364,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
     I_area_Earth = 1.0 / (16.0*atan(1.0)*G%Rad_Earth**2)
     !$OMP parallel do default(shared)
     do j=jsc,jec ; do i=isc,iec
-      tmp_diag(i,j) = (US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j)) * I_area_Earth
+      tmp_diag(i,j) = (G%areaT(i,j) * G%mask2dT(i,j)) * I_area_Earth
     enddo ; enddo
     call post_data(id_cell_area, tmp_diag, diag, is_static=.true.)
   endif

--- a/src/SIS_hor_grid.F90
+++ b/src/SIS_hor_grid.F90
@@ -159,7 +159,7 @@ type, public :: SIS_hor_grid_type
   real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
   real :: len_lat = 0.  !< The latitudinal (or y-coord) extent of physical domain
   real :: len_lon = 0.  !< The longitudinal (or x-coord) extent of physical domain
-  real :: Rad_Earth = 6.378e6 !< The radius of the planet [m].
+  real :: Rad_Earth     !< The radius of the planet [L ~> m], by default 6.378e6 m
   real :: max_depth     !< The maximum depth of the ocean [m].
 end type SIS_hor_grid_type
 

--- a/src/SIS_transcribe_grid.F90
+++ b/src/SIS_transcribe_grid.F90
@@ -111,7 +111,7 @@ subroutine copy_dyngrid_to_SIS_horgrid(dG, SG)
 !   SG%areaT_global = dG%areaT_global ; SG%IareaT_global = dG%IareaT_global
   SG%south_lat = dG%south_lat ; SG%west_lon  = dG%west_lon
   SG%len_lat = dG%len_lat ; SG%len_lon = dG%len_lon
-  SG%Rad_Earth = dG%Rad_Earth ; SG%max_depth = dG%max_depth
+  SG%Rad_Earth = dG%Rad_Earth_L ; SG%max_depth = dG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
   call pass_var(SG%areaT, SG%Domain)
@@ -240,7 +240,7 @@ subroutine copy_SIS_horgrid_to_dyngrid(SG, dG)
 !   dG%areaT_global = SG%areaT_global ; dG%IareaT_global = SG%IareaT_global
   dG%south_lat = SG%south_lat ; dG%west_lon  = SG%west_lon
   dG%len_lat = SG%len_lat ; dG%len_lon = SG%len_lon
-  dG%Rad_Earth = SG%Rad_Earth ; dG%max_depth = SG%max_depth
+  dG%Rad_Earth_L = SG%Rad_Earth ; dG%max_depth = SG%max_depth
 
 ! Update the halos in case the dynamic grid has smaller halos than the ocean grid.
   call pass_var(dG%areaT, dG%Domain)


### PR DESCRIPTION
  Rescaled the units of the Rad_Earth element of SIS_hor_grid_type and set it
using the equivalently scale variable dG%Rad_Earth_L from the dyn_grid type.
This change led naturally to changed units for the I_area_Earth internal
variable in ice_diagnostics_init() and the cancellation of some grid rescaling
factors that were there before.  This commit requires that SIS2 use a recent
(November 27, 2021 or later) version of MOM6 from the dev/gfdl branch, and will
not compile with earlier versions of the MOM6 code.  All answers are bitwise
identical, but there is one minor interface change in a widely used transparent
type.