### PR TITLE
+(*)Report heat stocks relative to liquid at 0 degC

### DIFF
--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -18,7 +18,7 @@ public :: ice_resize_SIS2, add_frazil_SIS2, rebalance_ice_layers
 public :: get_SIS2_thermo_coefs, ice_thermo_init, ice_thermo_end
 public :: Temp_from_Enth_S, Temp_from_En_S, enth_from_TS, enthalpy_from_TS
 public :: enthalpy_liquid_freeze, T_Freeze, calculate_T_Freeze, enthalpy_liquid
-public :: e_to_melt_TS, energy_melt_enthS, latent_sublimation
+public :: e_to_melt_TS, energy_melt_enthS, energy_0degC, latent_sublimation
 
 !> This type contains the parameters regulating sea-ice thermodyanmics
 type, public :: ice_thermo_type ; private
@@ -2137,6 +2137,20 @@ function energy_melt_enthS(En, S, ITV) result(e_to_melt)
   e_to_melt = ITV%Q_to_J_kg * (enthalpy_liquid_freeze(S, ITV) - En)
 
 end function energy_melt_enthS
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+!> energy_0degC returns the energy needed to melt a given snow/ice
+!!      configuration and raise it to 0 degrees C [J kg-1].
+function energy_0degC(En, ITV) result(energy_0)
+  real, intent(in) :: En !< The ice enthalpy, in enthalpy units [Q ~> J kg-1]
+  type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
+
+  real :: energy_0  !< The energy required to melt this mixture of ice and brine
+                    !! and warm it to 0 degrees C [J kg-1].
+
+  energy_0 = ITV%Q_to_J_kg * (ITV%enth_liq_0 - En)
+
+end function energy_0degC
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> get_SIS2_thermo_coefs returns various thermodynamic coefficients, rescaling the units

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -57,8 +57,7 @@ use SIS_transport,     only : ice_cat_transport, finish_ice_transport
 use SIS_types,         only : ocean_sfc_state_type, ice_ocean_flux_type, fast_ice_avg_type
 use SIS_types,         only : ice_state_type, IST_chksum, IST_bounds_check
 use SIS_utils,         only : get_avg, post_avg, ice_line !, ice_grid_chksum
-use SIS2_ice_thm,      only : get_SIS2_thermo_coefs, enthalpy_liquid_freeze
-use SIS2_ice_thm,      only : enth_from_TS, Temp_from_En_S
+use SIS2_ice_thm,      only : get_SIS2_thermo_coefs
 use slab_ice,          only : slab_ice_advect, slab_ice_dynamics
 use ice_bergs,         only : icebergs, icebergs_run, icebergs_init, icebergs_end
 use ice_grid,          only : ice_grid_type

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -36,8 +36,7 @@ use SIS_optics,        only : VIS_DIR, VIS_DIF, NIR_DIR, NIR_DIF
 use SIS_types,         only : ice_state_type, IST_chksum, IST_bounds_check, ice_rad_type
 use SIS_types,         only : fast_ice_avg_type, simple_OSS_type, total_sfc_flux_type, FIA_chksum
 use SIS2_ice_thm,      only : SIS2_ice_thm_CS, SIS2_ice_thm_init, SIS2_ice_thm_end
-use SIS2_ice_thm,      only : ice_temp_SIS2, latent_sublimation
-use SIS2_ice_thm,      only : get_SIS2_thermo_coefs, enth_from_TS, Temp_from_En_S
+use SIS2_ice_thm,      only : ice_temp_SIS2, latent_sublimation, get_SIS2_thermo_coefs
 
 implicit none ; private
 

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -26,7 +26,7 @@ use SIS_framework,     only : coupler_type_redistribute_data, coupler_type_copy_
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type
 use SIS2_ice_thm,      only : ice_thermo_type, SIS2_ice_thm_CS, get_SIS2_thermo_coefs
-use SIS2_ice_thm,      only : enth_from_TS, energy_melt_EnthS, temp_from_En_S
+use SIS2_ice_thm,      only : enth_from_TS, temp_from_En_S
 
 implicit none ; private
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -112,8 +112,7 @@ use SIS_types,         only : redistribute_IST_to_IST, redistribute_FIA_to_FIA
 use SIS_types,         only : redistribute_sOSS_to_sOSS, FIA_chksum, IOF_chksum, translate_OSS_to_sOSS
 use SIS_utils,         only : post_avg, ice_grid_chksum
 use SIS2_ice_thm,      only : ice_temp_SIS2, SIS2_ice_thm_init, SIS2_ice_thm_end
-use SIS2_ice_thm,      only : ice_thermo_init, ice_thermo_end, get_SIS2_thermo_coefs
-use SIS2_ice_thm,      only : enth_from_TS, Temp_from_En_S, T_freeze, ice_thermo_type
+use SIS2_ice_thm,      only : ice_thermo_init, ice_thermo_end, T_freeze, ice_thermo_type
 use specified_ice,     only : specified_ice_dynamics, specified_ice_init, specified_ice_CS
 use specified_ice,     only : specified_ice_end, specified_ice_sum_output_CS
 


### PR DESCRIPTION
  Revised ice_stock_pe() to report the heat stock relative to liquid water at 0
degrees C, rather than just the heat required to melt the ice, as this gives a
much more robust estimates of the enthalpy budget when sea ice salinities are
allowed to vary.  To help implement this, the new function energy_0degC was
added to SIS2_ice_thm.F90.  Several module use statements that were referring to
unused routines from within SIS2_ice_thm were also redacted.  All solutions are
bitwise identical, but there are changes in the reported stock values, and there
is a new publicly visible function.