### PR TITLE
Correct variable unit descriptions

### DIFF
--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -1,4 +1,4 @@
-!> Routines to do SIS2 ice thermodynamic calcualtions
+!> Routines to do SIS2 ice thermodynamic calculations
 module SIS2_ice_thm
 
 ! This file is part of SIS2. See LICENSE.md for the license.
@@ -20,7 +20,7 @@ public :: Temp_from_Enth_S, Temp_from_En_S, enth_from_TS, enthalpy_from_TS
 public :: enthalpy_liquid_freeze, T_Freeze, calculate_T_Freeze, enthalpy_liquid
 public :: e_to_melt_TS, energy_melt_enthS, latent_sublimation
 
-!> This type contains the parameters regulating sea-ice thermodyanmics
+!> This type contains the parameters regulating sea-ice thermodynamics
 type, public :: ice_thermo_type ; private
   real :: Cp_ice            !< The heat capacity of ice [Q degC-1 ~> J kg-1 degC-1].
   real :: Cp_water          !< The heat capacity of liquid water in the ice model,
@@ -226,7 +226,7 @@ subroutine ice_temp_SIS2(m_pond, m_snow, m_ice, enthalpy, sice, SF_0, dSF_dT, so
   real :: tflux_sfc   ! [Q R Z ~> J m-2]
   ! These are used in diagnostic calculations that could be uncommented for debugging.
   ! real :: sum_sol     ! The time integrated shortwave heating [Q R Z ~> J m-2]
-  ! real :: tfb_diff_err  ! A diagostic estimate of errors from roundoff [Q R Z ~> J m-2]
+  ! real :: tfb_diff_err  ! A diagnostic estimate of errors from roundoff [Q R Z ~> J m-2]
   ! real :: tfb_resid_err ! A diagnostic estimate of the residual due to roundoff [Q R Z ~> J m-2]
   ! real :: d_tflux_bot, tflux_bot_diff, tflux_bot_resid ! Diagnostic terms [Q R Z ~> J m-2]
   real :: hsnow_eff    ! The effective thickness of the snow layer [Z ~> m]
@@ -860,7 +860,7 @@ subroutine update_lay_enth(m_lay, sice, enth, ftop, ht_body, fbot, dftop_dT, &
                            dfbot_dT, dtt, hf_err_rat, ITV, US, extra_heat, temp_new, temp_max)
   real, intent(in) :: m_lay    !< This layers mass of ice [R Z ~> kg m-2]
   real, intent(in) :: sice     !< ice salinity [gSalt kg-1]
-  real, intent(inout) :: enth  !< ice enthalpy in enthaly units [Q ~> J kg-1].
+  real, intent(inout) :: enth  !< ice enthalpy in enthalpy units [Q ~> J kg-1].
   real, intent(inout) :: ftop  !< Downward heat flux atop the layer at T = 0 degC, or
                                !! the prescribed heat flux if dftop_dT = 0 [Q R Z T-1 ~> W m-2].
   real, intent(in) :: ht_body  !< Body heating to layer [Q R Z T-1 ~> W m-2]
@@ -1110,8 +1110,8 @@ subroutine ice_check(ms, mi, enthalpy, s_ice, NkIce, msg_part, ITV, &
   integer, intent(in) :: NkIce !< The number of vertical temperature layers in the ice
   character(len=*), intent(in) :: msg_part !< An identifying message
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
-  real, optional, intent(in) :: bmelt  !< The heat flux assocated with bottom melt [Q R Z ~> J m-2] or [J m-2]
-  real, optional, intent(in) :: tmelt  !< The heat flux assocated with top melt [Q R Z ~> J m-2] or [J m-2]
+  real, optional, intent(in) :: bmelt  !< The heat flux associated with bottom melt [Q R Z ~> J m-2] or [J m-2]
+  real, optional, intent(in) :: tmelt  !< The heat flux associated with top melt [Q R Z ~> J m-2] or [J m-2]
   real, optional, intent(in) :: t_sfc  !< The ice surface temperature [degC]
   type(unit_scale_type), optional, intent(in) :: US  !< A structure with unit conversion factors
 
@@ -1657,7 +1657,7 @@ end subroutine SIS2_ice_thm_end
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !  Everything above this point pertains to the updating of the ice state due to
-!  themrmodyanmic forcing.  Everything after this point relates to more basic
+!  thermodyanmic forcing.  Everything after this point relates to more basic
 !  calculations of sea ice thermodynamics.  They could be separated into two
 !  modules, but by keeping them together compliers stand a better chance of
 !  inlining various small subroutines and achieving better performance.
@@ -1854,7 +1854,7 @@ function enth_melt(T, S, ITV) result (emelt)
   real, intent(in)  :: T  !< The ice temperature [degC]
   real, intent(in)  :: S  !< The ice bulk salinity [gSalt kg-1]
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
-  real             :: emelt !< The enthaply change needed to melt the frozen water [Q ~> J kg-1]
+  real             :: emelt !< The enthalpy change needed to melt the frozen water [Q ~> J kg-1]
 
   emelt = enthalpy_liquid_freeze(S, ITV) - enth_from_TS(T, S, ITV)
 end function enth_melt
@@ -1909,7 +1909,7 @@ subroutine Temp_from_Enth_S(En, S, Temp, ITV)
 end subroutine Temp_from_Enth_S
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-!> dTemp_dEnth_EnS returns the partial deriative of sea ice temperature with enthalpy
+!> dTemp_dEnth_EnS returns the partial derivative of sea ice temperature with enthalpy
 !! for ice of a given enthalpy and salinity.
 function dTemp_dEnth_EnS(En, S, ITV) result(dT_dE)
   real, intent(in)  :: En !< The ice enthalpy, in enthalpy units [Q ~> J kg-1]
@@ -1948,7 +1948,7 @@ function dTemp_dEnth_EnS(En, S, ITV) result(dT_dE)
 end function dTemp_dEnth_EnS
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-!> dTemp_dEnth_TS returns the partial deriative of sea ice temperature with enthalpy
+!> dTemp_dEnth_TS returns the partial derivative of sea ice temperature with enthalpy
 !! for ice of a given temperature and salinity.
 function dTemp_dEnth_TS(Temp, S, ITV) result(dT_dE)
   real, intent(in)  :: Temp !< The ice temperature [degC]

--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -176,7 +176,7 @@ subroutine ice_temp_SIS2(m_pond, m_snow, m_ice, enthalpy, sice, SF_0, dSF_dT, so
   real, intent(in   ) :: dtt   !< timestep [T ~> s]
   integer, intent(in   ) :: NkIce !< The number of ice layers.
   real, intent(inout) :: tmelt !< accumulated top melting energy  [Q R Z ~> J m-2]
-  real, intent(inout) :: bmelt !< accumulated bottom melting energy [Q R Z ~>  J m-2]
+  real, intent(inout) :: bmelt !< accumulated bottom melting energy [Q R Z ~> J m-2]
   type(SIS2_ice_thm_CS), intent(in) :: CS  !< The SIS2 ice thermodynamics control structure
   type(unit_scale_type), intent(in) :: US  !< A structure with unit conversion factors
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
@@ -592,7 +592,7 @@ subroutine estimate_tsurf(m_pond, m_snow, m_ice, enthalpy, sice, SF_0, dSF_dT, &
   real :: Cp_ice   ! The heat capacity of ice [Q degC-1 ~> J kg-1 degC-1].
   real :: Cp_brine ! The heat capacity of liquid water in the brine pockets,
                    ! [Q degC-1 ~> J kg-1 degC-1].
-  real :: Lat_fus  ! The latent heat of fusion [Q degC-1 ~> J kg-1].
+  real :: Lat_fus  ! The latent heat of fusion [Q ~> J kg-1].
   integer :: k
 
   temp_IC(0) = temp_from_En_S(enthalpy(0), 0.0, ITV)
@@ -703,9 +703,9 @@ function laytemp_SIS2(m_ice, T_fr, Qf, bf, tp, enth, salin, dtt, ITV, US) result
   real, intent(in) :: m_ice !< mass of ice [R Z ~> kg m-2]
   real, intent(in) :: T_fr !< ice freezing temp [degC] (determined by salinity)
   real, intent(in) :: Qf   !< Inward forcing [Q R Z T-1 ~> W m-2]
-  real, intent(in) :: bf   !< response of outward heat flux to local temperature [Q R Z T-1 ~> W m-2 degC]
+  real, intent(in) :: bf   !< response of outward heat flux to local temperature [Q R Z T-1 degC-1 ~> W m-2 degC-1]
   real, intent(in) :: tp   !< prior step temperature [degC]
-  real, intent(in) :: enth !< prior step enthalpy
+  real, intent(in) :: enth !< prior step enthalpy [Q ~> J kg-1] (unused)
   real, intent(in) :: salin !< ice salinity [gSalt kg-1].
   real, intent(in) :: dtt  !< timestep [T ~> s]
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
@@ -865,8 +865,8 @@ subroutine update_lay_enth(m_lay, sice, enth, ftop, ht_body, fbot, dftop_dT, &
                                !! the prescribed heat flux if dftop_dT = 0 [Q R Z T-1 ~> W m-2].
   real, intent(in) :: ht_body  !< Body heating to layer [Q R Z T-1 ~> W m-2]
   real, intent(inout) :: fbot  !< Downward heat below the layer at T = 0 degC [Q R Z T-1 ~> W m-2].
-  real, intent(in) :: dftop_dT !< The linearization of ftop with layer temperature [Q R Z T-1 ~> W m-2 degC-1].
-  real, intent(in) :: dfbot_dT !< The linearization of fbot with layer temperature [Q R Z T-1 ~> W m-2 degC-1].
+  real, intent(in) :: dftop_dT !< The linearization of ftop with layer temperature [Q R Z T-1 degC-1 ~> W m-2 degC-1].
+  real, intent(in) :: dfbot_dT !< The linearization of fbot with layer temperature [Q R Z T-1 degC-1 ~> W m-2 degC-1].
   real, intent(in) :: dtt      !< The timestep [T ~> s]
   real, intent(in) :: hf_err_rat  !< A conversion factor for comparing the errors
                                !! in explicit and implicit estimates of the updated
@@ -909,7 +909,7 @@ subroutine update_lay_enth(m_lay, sice, enth, ftop, ht_body, fbot, dftop_dT, &
                    ! [Q degC-1 ~> J kg-1 degC-1].
   real :: Cp_water ! The heat capacity of liquid water in the ice model,
                    ! but not in the brine pockets [Q degC-1 ~> J kg-1 degC-1].
-  real :: LI       ! The latent heat of fusion [Q degC-1 ~> J kg-1].
+  real :: LI       ! The latent heat of fusion [Q ~> J kg-1].
   integer :: itt
   ! real :: T_itt(20), dTemp(20), Err_itt(20)
 
@@ -1210,7 +1210,7 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
                                       ! enthalpy [Q ~> J kg-1].
   real :: min_dEnth_freeze    ! The minimum enthalpy change that must occur when freezing water,
                               ! usually enough to account for the latent heat of fusion
-                              ! in a small fraction of the water [Q ~> J kg-2].
+                              ! in a small fraction of the water [Q ~> J kg-1].
   real :: m_freeze            ! The newly formed ice from freezing [R Z ~> kg m-2].
   real :: M_melt              ! The ice mass lost to melting [R Z ~> kg m-2].
   real :: evap_left           ! The remaining evaporation [R Z ~> kg m-2].
@@ -1502,12 +1502,12 @@ subroutine add_frazil_SIS2(m_lay, Enthalpy, Sice_therm, Salin, npassive, TrLay, 
   ! Local variables
   real :: enth_frazil       ! The enthalpy of newly formed frazil ice [Q ~> J kg-1].
   real :: frazil_per_layer  ! The frazil heat sink from each of the sublayers of
-                            ! of the ice [Q R Z ~> J kg-1].
+                            ! of the ice [Q R Z ~> J m-2].
   real :: t_frazil          ! The temperature which with the frazil-ice is created [degC].
   real :: m_frazil          ! The newly-formed mass per unit area of frazil ice [R Z ~> kg m-2].
   real :: min_dEnth_freeze  ! The minimum enthalpy change that must occur when freezing water,
                             ! usually enough to account for the latent heat of fusion
-                            ! in a small fraction of the water [Q ~> J kg-2].
+                            ! in a small fraction of the water [Q ~> J kg-1].
   real :: salin_freeze      ! The salinity of newly frozen ice [gSalt kg-1].
   real :: enthM_freezing    ! The enthalpy gain due to the mass gain by freezing [Q R Z ~> J m-2].
   real :: LI                ! The latent heat of fusion [Q ~> J kg-1].
@@ -1591,7 +1591,7 @@ subroutine rebalance_ice_layers(m_lay, mtot_ice, Enthalpy, Salin, NkIce, npassiv
                               intent(inout) :: TrLay !< Passive tracer in the column layer [Conc]
 
   real, dimension(NkIce) :: mlay_new     ! New mass in a layer [R Z ~> kg m-2]
-  real, dimension(NkIce) :: enth_ice_new ! New integrated enthalpy [R Z Q ~> kg m-2 Enth]
+  real, dimension(NkIce) :: enth_ice_new ! New integrated enthalpy [Q R Z ~> J m-2]
   real, dimension(NkIce) :: sal_ice_new  ! New integrated salinity [R Z gSalt kg-1 ~> gSalt m-2]
   real, dimension(NkIce,npassive) :: tr_ice_new ! New integrated tracer amount [R Z Conc ~> kg Conc m-2]
   real :: m_k1_to_k2   ! The being transferred from layer k1 to layer k2 [R Z ~> kg m-2]
@@ -1993,7 +1993,7 @@ function Temp_from_En_S(En, S, ITV) result(Temp)
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
   real :: Temp  !< Temperature [degC].
 
-  real :: I_Cp_Ice, I_Cp_Water  ! Inverse heat capacities [degC Q ~> kg degC J-1].
+  real :: I_Cp_Ice, I_Cp_Water  ! Inverse heat capacities [degC Q-1 ~> degC kg J-1].
   real :: BB    ! A temporary variable [Q ~> J kg-1]
   real :: T_fr  ! The freezing temperature [degC].
   real :: En_J  ! Enthalpy with 0 offset [Q ~> J kg-1].

--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -218,7 +218,7 @@ subroutine ice_temp_SIS2(m_pond, m_snow, m_ice, enthalpy, sice, SF_0, dSF_dT, so
                                 ! MOM6 that interface K is below layer k.
   real :: I_liq_lim     ! The inverse of CS%liq_lim [nondim].
   real :: heat_flux_err_rat ! A factor used to estimate which of two approaches is more
-                            ! accurate [Q T-1 degC-1 ~> W kg-1 degC-1]
+                            ! accurate [degC T Q-1 ~> kg degC W-1]
   real :: col_enth1, col_enth2, col_enth2b, col_enth3  ! [Q R Z ~> J m-2]
   real :: d_e_extra   ! [Q R Z ~> J m-2]
   real :: e_extra_sum ! [Q R Z ~> J m-2]
@@ -1197,11 +1197,11 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
 
   real, intent(  out) :: ablation      !< The mass loss from bottom melt [R Z ~> kg m-2].
   real, intent(  out) :: enthalpy_evap !< The enthalpy loss due to the mass loss
-                                       !! by evaporation / sublimation. [Q kg m-2 ~> J m-2]
+                                       !! by evaporation / sublimation. [Q R Z ~> J m-2]
   real, intent(  out) :: enthalpy_melt !< The enthalpy loss due to the mass loss
                                        !! by melting [Q R Z ~> J m-2].
   real, intent(  out) :: enthalpy_freeze !< The enthalpy gain due to the mass gain
-                                       !! by freezing [Q kg m-2 ~> J m-2].
+                                       !! by freezing [Q R Z ~> J m-2].
 
   real :: top_melt, bot_melt, melt_left ! Heating amounts, all in [Q R Z ~> J m-2]
   real :: mtot_ice    ! The summed ice mass [R Z ~> kg m-2].
@@ -1593,7 +1593,7 @@ subroutine rebalance_ice_layers(m_lay, mtot_ice, Enthalpy, Salin, NkIce, npassiv
   real, dimension(NkIce) :: mlay_new     ! New mass in a layer [R Z ~> kg m-2]
   real, dimension(NkIce) :: enth_ice_new ! New integrated enthalpy [Q R Z ~> J m-2]
   real, dimension(NkIce) :: sal_ice_new  ! New integrated salinity [R Z gSalt kg-1 ~> gSalt m-2]
-  real, dimension(NkIce,npassive) :: tr_ice_new ! New integrated tracer amount [R Z Conc ~> kg Conc m-2]
+  real, dimension(NkIce,npassive) :: tr_ice_new ! New integrated tracer amount [Conc R Z ~> Conc kg m-2]
   real :: m_k1_to_k2   ! The being transferred from layer k1 to layer k2 [R Z ~> kg m-2]
   real :: m_ice_avg    ! The average mass per layer [R Z ~> kg m-2]
   integer :: k, k1, k2, kold, knew, tr

--- a/src/SIS_continuity.F90
+++ b/src/SIS_continuity.F90
@@ -1191,7 +1191,7 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
     I_htot, &  ! The inverse of htot or 0 [R-1 Z-1 ~> m2 kg-1].
     hl, hr     ! Left and right face thicknesses [R Z ~> kg m-2].
   real, dimension(SZI_(G)) :: &
-    vhtot      ! The total transports [R Z L2 s-1 ~> kg s-1].
+    vhtot      ! The total transports [R Z L2 T-1 ~> kg s-1].
   real :: CFL ! The CFL number based on the local velocity and grid spacing [nondim].
   real :: curv_3 ! A measure of the thickness curvature over a grid length,
                  ! with the same units as h_in.
@@ -1310,7 +1310,7 @@ subroutine meridional_mass_flux(v, dt, G, US, IG, CS, LB, h_in, vh, htot_in, vh_
       enddo
     elseif (present(vh_tot)) then
       do i=ish,ieh
-        vh_tot(i,J) = vhtot(I)
+        vh_tot(i,J) = vhtot(i)
       enddo
     endif
 

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -37,7 +37,7 @@ public :: ice_diagnostics_init, ice_diags_fast_init
 type SIS_fast_CS
   type(time_type) :: Time  !< The current sea ice model time.
   type(time_type) :: Time_step_fast !< The sea ice fast thermodynamics time step.
-  type(time_type) :: Time_step_slow !< The sea ice dynamcis and slow thermodynamics time step.
+  type(time_type) :: Time_step_slow !< The sea ice dynamics and slow thermodynamics time step.
 
   logical :: bounds_check   !< If true, check for sensible values of thicknesses
                             !! temperatures, fluxes, etc.
@@ -89,7 +89,7 @@ end type SIS_fast_CS
 !! approach.
 type SIS_slow_CS
   type(time_type) :: Time  !< The current sea ice model time.
-  type(time_type) :: Time_step_slow !< The sea ice dynamcis and slow thermodynamics time step.
+  type(time_type) :: Time_step_slow !< The sea ice dynamics and slow thermodynamics time step.
 
   logical :: Cgrid_dyn      !< If true use a C-grid discretization of the
                             !! sea-ice dynamics.
@@ -169,7 +169,7 @@ contains
 !=======================================================================
 
 !> ice_diagnostics_init does the registration for a variety of sea-ice model
-!! diagnostics and saves several static diagnotic fields.
+!! diagnostics and saves several static diagnostic fields.
 subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   type(ice_ocean_flux_type),  intent(inout) :: IOF !< A structure containing fluxes from the ice to
                                                    !! the ocean that are calculated by the ice model.
@@ -336,7 +336,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   if (coupler_type_initialized(OSS%tr_fields)) &
     call coupler_type_set_diags(OSS%tr_fields, 'ice_model', diag%axesT1%handles, Time)
 
-!  These are omitted diagnotics with no imminent plans to add them.
+!  These are omitted diagnostics with no imminent plans to add them.
 !  XYZ%id_strna = register_SIS_diag_field('ice_model', 'STRAIN_ANGLE', diag%axesT1,Time, &
 !               'strain angle', 'none', missing_value=missing)
 !  XYZ%id_obi   = register_SIS_diag_field('ice_model', 'OBI', diag%axesT1, Time, &

--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -1,7 +1,7 @@
 !> Routines that perform various error checking and debugging functions for SIS2
 module SIS_debugging
 
-! This file is a part of SIS2.  See LICENSE.md for the lisense file.
+! This file is a part of SIS2.  See LICENSE.md for the license file.
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !   This module contains subroutines that perform various error checking and   !
@@ -78,7 +78,7 @@ contains
 ! =====================================================================
 
 !> SIS_debugging_init initializes the SIS_debugging module, and sets
-!! the parameterts that control which checks are active for SIS2.
+!! the parameters that control which checks are active for SIS2.
 subroutine SIS_debugging_init(param_file)
   type(param_file_type),   intent(in)    :: param_file !< A structure to parse for run-time parameters
 ! This include declares and sets the variable "version".

--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -1,4 +1,4 @@
-!> Convenient wrappers to the FMS diag_manager interfaces with additional diagnostic capabilies.
+!> Convenient wrappers to the FMS diag_manager interfaces with additional diagnostic capabilities.
 module SIS_diag_mediator
 
 ! This file is a part of SIS2. See LICENSE.md for the license.
@@ -106,7 +106,7 @@ type, public :: SIS_diag_ctrl
   type(diag_type), dimension(:), allocatable :: diags !< The array of diagnostics
   integer :: next_free_diag_id !< The next unused diagnostic ID
 
-  !> default missing value to be sent to ALL diagnostics registerations
+  !> default missing value to be sent to ALL diagnostics registrations
   real :: missing_value = -1.0e34
 
 end type SIS_diag_ctrl
@@ -152,7 +152,7 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
   G%x_axis_units = "degrees_E"
   G%y_axis_units = "degrees_N"
   if (index(lowercase(trim(grid_config)),"cartesian") > 0) then
-    ! This is a cartesian grid, and may have different axis units.
+    ! This is a Cartesian grid, and may have different axis units.
     Cartesian_grid = .true.
     call get_param(param_file, mdl, "AXIS_UNITS", units_temp, &
                  "The units for the x- and y- axis labels.  AXIS_UNITS "//&
@@ -240,7 +240,7 @@ subroutine set_SIS_axes_info(G, IG, param_file, diag_cs, set_vertical, axes_set_
 
 end subroutine set_SIS_axes_info
 
-!> Define an a group of axes from a list of handles
+!> Define a group of axes from a list of handles
 subroutine defineAxes(diag_cs, handles, axes)
   ! Defines "axes" from list of handle and associates mask
   type(SIS_diag_ctrl), target, intent(in)  :: diag_cs !< A structure that is used to regulate diagnostic output
@@ -773,7 +773,7 @@ subroutine SIS_diag_mediator_init(G, IG, param_file, diag_cs, component, err_msg
   type(ice_grid_type),        intent(inout) :: IG  !< The sea-ice specific grid type
   type(param_file_type),      intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(SIS_diag_ctrl),        intent(inout) :: diag_cs !< A structure that is used to regulate diagnostic output
-  character(len=*), optional, intent(in)    :: component !< An opitonal component name
+  character(len=*), optional, intent(in)    :: component !< An optional component name
   character(len=*), optional, intent(out)   :: err_msg !< A string for a returned error message
   character(len=*), optional, intent(in)    :: doc_file_dir !< A directory in which to create the file
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -185,7 +185,7 @@ subroutine find_ice_strength(mi, ci, ice_strength, G, US, CS) !, nCat)
   type(unit_scale_type),            intent(in)  :: US  !< A structure with unit conversion factors
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: mi  !< Mass per unit ocean area of sea ice [R Z ~> kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: ci  !< Sea ice concentration [nondim]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: ice_strength  !< The ice strength [R Z L2 T-2 ~> N m-1]
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: ice_strength  !< The ice strength [R Z L2 T-2 ~> Pa m]
   type(SIS_B_dyn_CS),               pointer     :: CS  !< The control structure for this module
   ! integer, intent(in) :: nCat !< The number of sea ice categories.
 
@@ -278,7 +278,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
 
   ! Local variables
   real, dimension(SZIB_(G),SZJB_(G)) :: fxic, fyic  ! ice internal stresses [R Z L2 T-2 ~> Pa m]
-  real, dimension(SZIB_(G),SZJB_(G)) :: fxco, fyco  ! Coriolis force [R Z L T-2 ~> kg m-1 s-2 = Pa]
+  real, dimension(SZIB_(G),SZJB_(G)) :: fxco, fyco  ! Coriolis force [R Z L T-2 ~> Pa]
 
   real, dimension(SZI_(G),SZJ_(G)) :: prs                    ! Ice internal pressure [R Z L2 T-2 ~> Pa m]
   real                             :: zeta, eta              ! bulk/shear viscosities [R Z L2 T-1 ~> Pa m s]

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -462,7 +462,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
           zeta = 2.50e8*US%s_to_T * prs(i,j)
         endif
 
-        ! Hibler uses the following dimensonal constant ceiling to prevent nonlinear instability.
+        ! Hibler uses the following dimensional constant ceiling to prevent nonlinear instability.
         zeta = max(zeta, 4.0e8*US%kg_m2s_to_RZ_T*US%m_to_L**2)
 
         eta = zeta*EC2I
@@ -614,7 +614,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
     if (CS%id_fcy>0) call post_SIS_data(CS%id_fcy, fyco, CS%diag)
     if (CS%id_fwx>0) call post_SIS_data(CS%id_fwx, fxoc, CS%diag) ! water force on ice
     if (CS%id_fwy>0) call post_SIS_data(CS%id_fwy, fyoc, CS%diag) ! ...= -ice on water
-    !  The diagnistics of fxat and fyat are supposed to be taken over all partitions
+    !  The diagnostics of fxat and fyat are supposed to be taken over all partitions
     !  (ocean & ice), whereas fxat and fyat here are only averaged over the ice.
 
     if (CS%id_sigi>0) then
@@ -744,11 +744,11 @@ subroutine ice_stress_old(isc,iec,jsc,jec,prs,strn11,strn22,strn12,edt,EC, &
   real, dimension(isc:iec,jsc:jec), intent(in   ) :: strn22 !< The yy component of the strain rate [s-1]
   real, dimension(isc:iec,jsc:jec), intent(in   ) :: strn12 !< The xy & yx component of the strain rate [s-1]
   real, dimension(isc:iec,jsc:jec), intent(in   ) :: edt   !< The ice elasticity times a time-step [Pa m s].
-  real,                             intent(in   ) :: EC    !< The yeild curve axis ratio
+  real,                             intent(in   ) :: EC    !< The yield curve axis ratio
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig11 !< The xx component of the stress tensor [N m-1]
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig22 !< The yy component of the stress tensor [N m-1]
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig12 !< The xy & yx component of the stress tensor [N m-1]
-  real, dimension(isc:iec,jsc:jec), intent(  out) :: del2  !< An elipticity modulated estimate of
+  real, dimension(isc:iec,jsc:jec), intent(  out) :: del2  !< An ellipticity modulated estimate of
                                                            !! the squared strain rate [s-2].
   logical, dimension(isc:iec,jsc:jec), intent(in) :: ice_present !< True where there is any ice present in a cell
   !
@@ -817,11 +817,11 @@ subroutine ice_stress_new(isc,iec,jsc,jec,prs,strn11,strn22,strn12,edt, EC, &
   real, dimension(isc:iec,jsc:jec), intent(in   ) :: strn22 !< The yy component of the strain rate
   real, dimension(isc:iec,jsc:jec), intent(in   ) :: strn12 !< The xy & yx component of the strain rate
   real,                             intent(in   ) :: edt   !< The ice elasticity times a time-step [Pa m s].
-  real,                             intent(in   ) :: EC    !< The yeild curve axis ratio
+  real,                             intent(in   ) :: EC    !< The yield curve axis ratio
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig11 !< The xx component of the stress tensor
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig22 !< The yy component of the stress tensor
   real, dimension(isc:iec,jsc:jec), intent(inout) :: sig12 !< The xy & yx component of the stress tensor
-  real, dimension(isc:iec,jsc:jec), intent(  out) :: del2  !< An elipticity modulated estimate of
+  real, dimension(isc:iec,jsc:jec), intent(  out) :: del2  !< An ellipticity modulated estimate of
                                                            !! the squared strain rate [s-2].
   logical, dimension(isc:iec,jsc:jec), intent(in) :: ice_present !< True where there is any ice present in a cell
   !

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -34,7 +34,7 @@ type, public :: SIS_B_dyn_CS ; private
   real, dimension(:,:), pointer :: &
     sig11 => NULL(), &  !< The xx component of the stress tensor [R Z L2 T-2 ~> Pa m] (or N m-1).
     sig12 => NULL(), &  !< The xy and yx component of the stress tensor [R Z L2 T-2 ~> Pa m] (or N m-1).
-    sig22 => NULL()     !< The yy component of the stress tensor [RZ Z L2 T-2 ~> Pa m] (or N m-1).
+    sig22 => NULL()     !< The yy component of the stress tensor [R Z L2 T-2 ~> Pa m] (or N m-1).
 
   ! parameters for calculating water drag and internal ice stresses
   real :: p0                  !< Hibbler rheology pressure constant [R L2 T-2 ~> Pa]
@@ -642,10 +642,10 @@ function sigI(mi, ci, sig11, sig22, sig12, G, US, CS)
   type(SIS_hor_grid_type),          intent(in) :: G   !< The horizontal grid type
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: mi  !< Mass per unit ocean area of sea ice [R Z ~> kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: ci  !< Sea ice concentration [nondim]
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig11 !< The xx component of the stress tensor [RZ Z L2 T-2 ~> Pa m]
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig22 !< The yy component of the stress tensor [RZ Z L2 T-2 ~> Pa m]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig11 !< The xx component of the stress tensor [R Z L2 T-2 ~> Pa m]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig22 !< The yy component of the stress tensor [R Z L2 T-2 ~> Pa m]
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig12 !< The xy & yx component of the stress
-                                                        !! tensor [RZ Z L2 T-2 ~> Pa m] (or N m-1)
+                                                        !! tensor [R Z L2 T-2 ~> Pa m] (or N m-1)
   real, dimension(SZI_(G),SZJ_(G))             :: sigI !< The first stress invariant [nondim]
   type(unit_scale_type),            intent(in) :: US   !< A structure with unit conversion factors
   type(SIS_B_dyn_CS),               pointer    :: CS  !< The control structure for this module
@@ -667,10 +667,10 @@ function sigII(mi, ci, sig11, sig22, sig12, G, US, CS)
   type(SIS_hor_grid_type),          intent(in) :: G   !< The horizontal grid type
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: mi  !< Mass per unit ocean area of sea ice [R Z ~> kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: ci  !< Sea ice concentration [nondim]
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig11 !< The xx component of the stress tensor [RZ Z L2 T-2 ~> Pa m]
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig22 !< The yy component of the stress tensor [RZ Z L2 T-2 ~> Pa m]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig11 !< The xx component of the stress tensor [R Z L2 T-2 ~> Pa m]
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig22 !< The yy component of the stress tensor [R Z L2 T-2 ~> Pa m]
   real, dimension(SZI_(G),SZJ_(G)), intent(in) :: sig12 !< The xy & yx component of the stress
-                                                        !! tensor [RZ Z L2 T-2 ~> Pa m] (or N m-1)
+                                                        !! tensor [R Z L2 T-2 ~> Pa m] (or N m-1)
   real, dimension(SZI_(G),SZJ_(G))             :: sigII !< The second stress invariant [nondim]
   type(unit_scale_type),            intent(in) :: US   !< A structure with unit conversion factors
   type(SIS_B_dyn_CS),               pointer    :: CS  !< The control structure for this module

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -47,7 +47,7 @@ type, public :: SIS_C_dyn_CS ; private
   real, allocatable, dimension(:,:) :: &
     str_t, &  !< The tension stress tensor component [R Z L2 T-2 ~> Pa m].
     str_d, &  !< The divergence stress tensor component [R Z L2 T-2 ~> Pa m].
-    str_s     !< The shearing stress tensor component (cross term) [T Z L2 T-2 ~> Pa m].
+    str_s     !< The shearing stress tensor component (cross term) [R Z L2 T-2 ~> Pa m].
 
   ! parameters for calculating water drag and internal ice stresses
   real :: p0                  !< Pressure constant in the Hibler rheology [R L2 T-2 ~> Pa]

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -82,7 +82,7 @@ type, public :: SIS_C_dyn_CS ; private
                               !! changes due to the convergent or divergent ice flow.
   logical :: weak_coast_stress = .false. !< If true, do not use land masks in determining the area
                               !! for stress convergence, which acts to weaken the stress-driven
-                              !! acceleation in coastal points.
+                              !! acceleration in coastal points.
   logical :: weak_low_shear = .false. !< If true, the divergent stresses go toward 0 in the C-grid
                               !! dynamics when the shear magnitudes are very weak.
                               !! Otherwise they go to -P_ice.  This setting is temporary.
@@ -106,7 +106,7 @@ type, public :: SIS_C_dyn_CS ; private
                               !! written by this PE during the current run.
   integer :: max_writes       !< The maximum number of times any PE can write out
                               !! a column's worth of accelerations during a run.
-  logical :: lemieux_landfast !< If true, use the lemieux landfast ice parameterization.
+  logical :: lemieux_landfast !< If true, use the Lsemieux landfast ice parameterization.
   real :: lemieux_k1          !< 1st free parameter for landfast parameterization [nondim]
   real :: lemieux_k2          !< second free parameter (N/m^3) for landfast parametrization [R L T-2 ~> N m-3]
   real :: lemieux_alphab      !< Cb factor in Lemieux et al 2015 [nondim]
@@ -596,7 +596,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
                   ! velocities, but with the influence going in opposite
                   ! directions.
 
-  real :: Cor       ! A Coriolis accleration [L T-2 ~> m s-2].
+  real :: Cor       ! A Coriolis acceleration [L T-2 ~> m s-2].
   real :: fxic_now  ! Zonal ice internal stress convergence [R Z L T-2 ~> kg m-1 s-2].
   real :: fyic_now  ! Meridional ice internal stress convergence [R Z L T-2 ~> kg m-1 s-2].
   real :: drag_u, drag_v ! Drag rates with the ocean at u & v points [R Z T-1 ~> kg m-2 s-1].
@@ -652,7 +652,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
   real :: sum_area   ! The sum of ocean areas around a vorticity point [L2 ~> m2].
 
   type(time_type) :: &
-    time_it_start, &  ! The starting time of the iteratve steps.
+    time_it_start, &  ! The starting time of the iterative steps.
     time_step_end, &  ! The end time of an iterative step.
     time_end_in       ! The end time for diagnostics when this routine started.
   real :: time_int_in ! The diagnostics' time interval when this routine started.
@@ -921,7 +921,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     call pass_vector(ui, vi, G%Domain, stagger=CGRID_NE)
 
     !    Calculate the strain tensor for viscosities and forcing elastic eqn.
-    !  The following are the forms of the horizontal tension and hori-
+    !  The following are the forms of the horizontal tension and horizontal
     !  shearing strain advocated by Smagorinsky (1993) and discussed in
     !  Griffies and Hallberg (MWR, 2000).  Similar forms are used in the sea
     !  ice model of Bouillon et al. (Ocean Modelling, 2009).
@@ -1867,14 +1867,14 @@ subroutine write_u_trunc(I, j, ui, u_IC, uo, mis, fxoc, fxic, Cor_u, PFu, fxat, 
   integer,                           intent(in) :: I    !< The i-index of the column to report on
   integer,                           intent(in) :: j    !< The j-index of the column to report on
   type(SIS_hor_grid_type),           intent(in) :: G    !< The horizontal grid type
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: ui   !< The zonal ice velicity [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: u_IC !< The initial zonal ice velicity [L T-1 ~> m s-1].
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: uo   !< The zonal ocean velicity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: ui   !< The zonal ice velocity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: u_IC !< The initial zonal ice velocity [L T-1 ~> m s-1].
+  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: uo   !< The zonal ocean velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G)),  intent(in) :: mis  !< The mass of ice and snow per unit ocean area [R Z ~> kg m-2]
   real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: fxoc !< The zonal ocean-to-ice force [R Z L T-2 ~> Pa].
   real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: fxic !< The ice internal force [R Z L T-2 ~> Pa].
   real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: Cor_u !< The zonal Coriolis acceleration [L T-2 ~> m s-2].
-  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: PFu  !< The zonal Pressure force accleration [L T-2 ~> m s-2].
+  real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: PFu  !< The zonal Pressure force acceleration [L T-2 ~> m s-2].
   real, dimension(SZIB_(G),SZJ_(G)), intent(in) :: fxat !< The zonal wind stress [R Z L T-2 ~> Pa].
   real,                              intent(in) :: dt_slow !< The slow ice dynamics timestep [T ~> s].
   type(unit_scale_type),             intent(in) :: US   !< A structure with unit conversion factors
@@ -1943,14 +1943,14 @@ subroutine write_v_trunc(i, J, vi, v_IC, vo, mis, fyoc, fyic, Cor_v, PFv, fyat, 
   integer,                           intent(in) :: i    !< The i-index of the column to report on
   integer,                           intent(in) :: J    !< The j-index of the column to report on
   type(SIS_hor_grid_type),           intent(in) :: G    !< The horizontal grid type
-  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: vi   !< The meridional ice velicity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: v_IC !< The initial meridional ice velicity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: vo   !< The meridional ocean velicity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: vi   !< The meridional ice velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: v_IC !< The initial meridional ice velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: vo   !< The meridional ocean velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G)),  intent(in) :: mis  !< The mass of ice and snow per unit ocean area [R Z ~> kg m-2]
   real, dimension(SZI_(G),SZJB_(G)), intent(in) :: fyoc !< The meridional ocean-to-ice force [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G)), intent(in) :: fyic !< The ice internal force [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G)), intent(in) :: Cor_v !< The meridional Coriolis acceleration [L T-2 ~> m s-2].
-  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: PFv  !< The meridional pressure force accleration [L T-2 ~> m s-2].
+  real, dimension(SZI_(G),SZJB_(G)), intent(in) :: PFv  !< The meridional pressure force acceleration [L T-2 ~> m s-2].
   real, dimension(SZI_(G),SZJB_(G)), intent(in) :: fyat !< The meridional wind stress [R Z L T-2 ~> Pa].
   real,                              intent(in) :: dt_slow !< The slow ice dynamics timestep [T ~> s].
   type(unit_scale_type),             intent(in) :: US   !< A structure with unit conversion factors

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -53,8 +53,8 @@ type, public :: SIS_C_dyn_CS ; private
   real :: p0                  !< Pressure constant in the Hibler rheology [R L2 T-2 ~> Pa]
   real :: p0_rho              !< The pressure constant divided by ice density [L2 T-2 ~> N m kg-1].
   real :: c0                  !< another pressure constant, c* in Hunke & Dukowicz 1997 [nondim]
-  real :: cdw                 !< "The drag coefficient between the sea ice and water. [nondim]
-  real :: EC = 2.0            !< yield curve axis ratio
+  real :: cdw                 !< The drag coefficient between the sea ice and water. [nondim]
+  real :: EC = 2.0            !< yield curve axis ratio [nondim]
   real :: Rho_ocean           !< The nominal density of sea water [R ~> kg m-3].
   real :: Rho_ice             !< The nominal density of sea ice [R ~> kg m-3].
   real :: drag_bg_vel2 = 0.0  !< A background (subgridscale) velocity for drag with the ocean
@@ -479,7 +479,7 @@ subroutine find_ice_strength(mi, ci, ice_strength, G, US, CS, halo_sz) ! ??? may
   type(SIS_hor_grid_type),          intent(in)  :: G   !< The horizontal grid type
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: mi  !< Mass per unit ocean area of sea ice [R Z ~> kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), intent(in)  :: ci  !< Sea ice concentration [nondim]
-  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: ice_strength !< The ice strength [R Z L2 T-2 ~> N m-1].
+  real, dimension(SZI_(G),SZJ_(G)), intent(out) :: ice_strength !< The ice strength [R Z L2 T-2 ~> Pa m].
   type(SIS_C_dyn_CS),               pointer     :: CS  !< The control structure for this module
   type(unit_scale_type),            intent(in)  :: US  !< A structure with unit conversion factors
   integer,                optional, intent(in)  :: halo_sz !< The halo size to work on
@@ -597,8 +597,8 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
                   ! directions.
 
   real :: Cor       ! A Coriolis acceleration [L T-2 ~> m s-2].
-  real :: fxic_now  ! Zonal ice internal stress convergence [R Z L T-2 ~> kg m-1 s-2].
-  real :: fyic_now  ! Meridional ice internal stress convergence [R Z L T-2 ~> kg m-1 s-2].
+  real :: fxic_now  ! Zonal ice internal stress convergence [R Z L T-2 ~> Pa].
+  real :: fyic_now  ! Meridional ice internal stress convergence [R Z L T-2 ~> Pa].
   real :: drag_u, drag_v ! Drag rates with the ocean at u & v points [R Z T-1 ~> kg m-2 s-1].
   real :: drag_LFu  ! Drag rates to the land for landfast ice at u points [R Z T-1 ~> kg m-2 s-1].
   real :: drag_LFv  ! Drag rates to the land for landfast ice at v points [R Z T-1 ~> kg m-2 s-1].
@@ -1475,7 +1475,8 @@ subroutine limit_stresses(pres_mice, mice, str_d, str_t, str_s, G, US, CS, limit
                                                              !! [R Z L2 T-2 ~> Pa m].
   type(unit_scale_type),              intent(in)    :: US    !< A structure with unit conversion factors
   type(SIS_C_dyn_CS),                 pointer       :: CS    !< The control structure for this module
-  real, optional,                     intent(in)    :: limit !< A factor by which the strength limits are changed.
+  real, optional,                     intent(in)    :: limit !< A factor by which the strength limits
+                                                             !! are changed [nondim]
 
 !   This subroutine ensures that the input stresses are not larger than could
 ! be justified by the ice pressure now, as the ice might have melted or been
@@ -1486,12 +1487,12 @@ subroutine limit_stresses(pres_mice, mice, str_d, str_t, str_s, G, US, CS, limit
   real :: pressure  ! The integrated internal ice pressure at a point [R Z L2 T-2 ~> Pa m].
   real :: pres_avg  ! The average of the internal ice pressures around a point [R Z L2 T-2 ~> Pa m].
   real :: sum_area  ! The sum of ocean areas around a vorticity point [L2 ~> m2].
-  real :: I_2EC     ! 1/(2*EC), where EC is the yield curve axis ratio.
-  real :: lim       ! A local copy of the factor by which the limits are changed.
-  real :: lim_2     ! The limit divided by 2.
-!  real :: EC2       ! EC^2, where EC is the yield curve axis ratio.
+  real :: I_2EC     ! 1/(2*EC), where EC is the yield curve axis ratio [nondim].
+  real :: lim       ! A local copy of the factor by which the limits are changed [nondim].
+  real :: lim_2     ! The limit divided by 2 [nondim].
+!  real :: EC2       ! EC^2, where EC is the yield curve axis ratio [nondim].
 !  real :: rescale_str ! A factor by which to rescale the internal stresses [nondim].
-!  real :: stress_mag  ! The magnitude of the stress at a point [kg m-2 L2 T-2 ~> Pa m].
+!  real :: stress_mag  ! The magnitude of the stress at a point [R Z L2 T-2 ~> Pa m].
 !  real :: str_d_q     ! CS%str_d interpolated to a vorticity point [R Z L2 T-2 ~> Pa m].
 !  real :: str_t_q     ! CS%str_t interpolated to a vorticity point [R Z L2 T-2 ~> Pa m].
 
@@ -1597,7 +1598,7 @@ subroutine find_sigI(mi, ci, str_d, sigI, G, US, CS)
   type(SIS_C_dyn_CS),               pointer     :: CS    !< The control structure for this module
 
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    strength ! The ice strength [kg m-2 L2 T-2 ~> Pa m = N m-1].
+    strength ! The ice strength [R Z L2 T-2 ~> Pa m].
   integer :: i, j, isc, iec, jsc, jec
   isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1,4 +1,4 @@
-!> Handles the main updates of the ice states at the slower time-scales of the couplng or
+!> Handles the main updates of the ice states at the slower time-scales of the coupling or
 !! the interactions with the ocean due to ice dynamics and lateral transport.
 module SIS_dyn_trans
 
@@ -12,7 +12,7 @@ module SIS_dyn_trans
 ! with the Modular Ocean Model, version 6 (MOM6), and to permit might tighter  !
 ! dynamical coupling between the ocean and sea-ice.                            !
 !   This module handles the main updates of the ice states at the slower time- !
-! scales of the couplng or the interactions with the ocean due to ice dynamics !
+! scales of the coupling or the interactions with the ocean due to ice dynamics !
 ! and lateral transport.                                                       !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
@@ -96,7 +96,7 @@ type dyn_trans_CS ; private
                           !! current air-ice stress.  This option is here for
                           !! backward compatibility, but should be avoided.
   logical :: Warsaw_sum_order !< If true, use the order of sums in the Warsaw version
-                          !! of SIS2.  This option exists for backward compatibilty
+                          !! of SIS2.  This option exists for backward compatibility
                           !! but may eventually be obsoleted.
   real :: complete_ice_cover !< The fractional ice coverage that is close enough to 1 to be
                           !! complete for the purpose of calculating wind stresses [nondim].
@@ -121,7 +121,7 @@ type dyn_trans_CS ; private
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(SIS_diag_ctrl), pointer :: diag => NULL() !< A structure that is used to regulate the
                                    !! timing of diagnostic output.
-  logical :: lemieux_landfast !< If true, use the lemieux landfast ice parameterization.
+  logical :: lemieux_landfast !< If true, use the Lemieux landfast ice parameterization.
 
   !>@{ Diagnostic IDs
   integer :: id_fax=-1, id_fay=-1
@@ -343,17 +343,17 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
     str_x_ice_ocn_B, &  ! Zonal ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
     str_y_ice_ocn_B     ! Meridional ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
   real, dimension(SZIB_(G),SZJ_(G))  :: &
-    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categores on C-grid u-points [R Z L T-2 ~> Pa].
+    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categories on C-grid u-points [R Z L T-2 ~> Pa].
     WindStr_x_ocn_Cu, & ! Zonal wind stress on the ice-free ocean on C-grid u-points [R Z L T-2 ~> Pa].
     str_x_ice_ocn_Cu   ! Zonal ice-ocean stress on C-grid u-points [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G))  :: &
-    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categores on C-grid v-points [R Z L T-2 ~> Pa].
+    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categories on C-grid v-points [R Z L T-2 ~> Pa].
     WindStr_y_ocn_Cv, & ! Meridional wind stress on the ice-free ocean on C-grid v-points [R Z L T-2 ~> Pa].
     str_y_ice_ocn_Cv  ! Meridional ice-ocean stress on C-grid v-points [R Z L T-2 ~> Pa].
 
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBx ! A temporary array for diagnostics.
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBy ! A temporary array for diagnostics.
-  real :: ps_vel   ! The fractional thickness catetory coverage at a velocity point.
+  real :: ps_vel   ! The fractional thickness category coverage at a velocity point.
 
   type(time_type) :: Time_cycle_start ! The model's time at the start of an advective cycle.
   real :: dt_slow_dyn  ! The slow dynamics timestep [T ~> s].
@@ -923,18 +923,18 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, dt_cycle, Time_start, G, US,
     str_x_ice_ocn_B, &  ! Zonal ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
     str_y_ice_ocn_B     ! Meridional ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
   real, dimension(SZIB_(G),SZJ_(G))  :: &
-    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categores on C-grid u-points [R Z L T-2 ~> Pa].
+    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categories on C-grid u-points [R Z L T-2 ~> Pa].
     WindStr_x_ocn_Cu, & ! Zonal wind stress on the ice-free ocean on C-grid u-points [R Z L T-2 ~> Pa].
     str_x_ice_ocn_Cu   ! Zonal ice-ocean stress on C-grid u-points [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G))  :: &
-    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categores on C-grid v-points [R Z L T-2 ~> Pa].
+    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categories on C-grid v-points [R Z L T-2 ~> Pa].
     WindStr_y_ocn_Cv, & ! Meridional wind stress on the ice-free ocean on C-grid v-points [R Z L T-2 ~> Pa].
     str_y_ice_ocn_Cv  ! Meridional ice-ocean stress on C-grid v-points [R Z L T-2 ~> Pa].
 
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBx ! A temporary array for diagnostics.
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBy ! A temporary array for diagnostics.
 
-  real :: ps_vel   ! The fractional thickness catetory coverage at a velocity point.
+  real :: ps_vel   ! The fractional thickness category coverage at a velocity point.
   real :: wt_new, wt_prev ! Weights in an average.
   real :: dt_slow_dyn  ! The slow dynamics timestep [T ~> s].
   real :: dt_slow_dyn_sec ! The slow dynamics timestep [s].
@@ -1159,17 +1159,17 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
     str_x_ice_ocn_B, &  ! Zonal ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
     str_y_ice_ocn_B     ! Meridional ice-ocean stress on a B-grid [R Z L T-2 ~> Pa].
   real, dimension(SZIB_(G),SZJ_(G))  :: &
-    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categores on C-grid u-points [R Z L T-2 ~> Pa].
+    WindStr_x_Cu, &   ! Zonal wind stress averaged over the ice categories on C-grid u-points [R Z L T-2 ~> Pa].
     WindStr_x_ocn_Cu, & ! Zonal wind stress on the ice-free ocean on C-grid u-points [R Z L T-2 ~> Pa].
     str_x_ice_ocn_Cu   ! Zonal ice-ocean stress on C-grid u-points [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G))  :: &
-    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categores on C-grid v-points [R Z L T-2 ~> Pa].
+    WindStr_y_Cv, &   ! Meridional wind stress averaged over the ice categories on C-grid v-points [R Z L T-2 ~> Pa].
     WindStr_y_ocn_Cv, & ! Meridional wind stress on the ice-free ocean on C-grid v-points [R Z L T-2 ~> Pa].
     str_y_ice_ocn_Cv  ! Meridional ice-ocean stress on C-grid v-points [R Z L T-2 ~> Pa].
 
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBx ! A temporary array for diagnostics.
   real, dimension(SZIB_(G),SZJB_(G)) :: diagVarBy ! A temporary array for diagnostics.
-  real :: ps_vel   ! The fractional thickness catetory coverage at a velocity point.
+  real :: ps_vel   ! The fractional thickness category coverage at a velocity point.
   real :: dt_slow_dyn  ! The slow dynamics timestep [T ~> s].
   real :: dt_slow_dyn_sec ! The slow dynamics timestep [s].
   integer :: i, j, k, n, isc, iec, jsc, jec, ncat
@@ -1424,7 +1424,7 @@ subroutine stresses_to_stress_mag(G, str_x, str_y, stagger, stress_mag)
                                                   !! two wind stress components. Valid entries include AGRID,
                                                   !! BGRID_NE, and CGRID_NE, following the Arakawa
                                                   !! grid-staggering  notation.  BGRID_SW and CGRID_SW are
-                                                  !! possibilties that have not been implemented yet.
+                                                  !! possibilities that have not been implemented yet.
   real, dimension(SZI_(G),SZJ_(G)), &
                              intent(inout) :: stress_mag !< The magnitude of the stress at tracer points
                                                   !! in the same units as str_x and str_y [R Z L T-2 ~> Pa].
@@ -1891,11 +1891,11 @@ subroutine set_wind_stresses_C(FIA, ice_cover, ice_free, WindStr_x_Cu, WindStr_y
                         !! thickness categories [nondim], between 0 & 1.
     ice_free            !< The fractional open water [nondim], between 0 & 1.
   real, dimension(SZIB_(G),SZJ_(G)), intent(out)  :: &
-    WindStr_x_Cu, &     !< Zonal wind stress averaged over the ice categores on C-grid u-points
+    WindStr_x_Cu, &     !< Zonal wind stress averaged over the ice categories on C-grid u-points
                         !! [R Z L T-2 ~> Pa].
     WindStr_x_ocn_Cu    !< Zonal wind stress on the ice-free ocean on C-grid u-points [R Z L T-2 ~> Pa].
   real, dimension(SZI_(G),SZJB_(G)), intent(out)  :: &
-    WindStr_y_Cv, &     !< Meridional wind stress averaged over the ice categores on C-grid v-points
+    WindStr_y_Cv, &     !< Meridional wind stress averaged over the ice categories on C-grid v-points
                         !! [R Z L T-2 ~> Pa].
     WindStr_y_ocn_Cv    !< Meridional wind stress on the ice-free ocean on C-grid v-points [R Z L T-2 ~> Pa].
   type(unit_scale_type),             intent(in)   :: US    !< A structure with unit conversion factors
@@ -2322,7 +2322,7 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
   CS%write_ice_stats_time = Time_Init + CS%ice_stats_interval * &
       (1 + (Time - Time_init) / CS%ice_stats_interval)
 
-  ! Stress dagnostics that are specific to the C-grid or B-grid dynamics of the ice model
+  ! Stress diagnostics that are specific to the C-grid or B-grid dynamics of the ice model
   if (CS%Cgrid_dyn) then
     CS%id_fax = register_diag_field('ice_model', 'FA_X', diag%axesCu1, Time, &
                'Air stress on ice on C-grid - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
@@ -2440,7 +2440,7 @@ end function SIS_dyn_trans_sum_output_CS
 !! and calls similar routines for subsidiary modules.
 subroutine SIS_dyn_trans_end(CS)
   type(dyn_trans_CS), pointer :: CS  !< The control structure for the SIS_dyn_trans module that
-                                     !! is dellocated here
+                                     !! is deallocated here
 
   if (associated(CS%DS2d)) then
     if (allocated(CS%DS2d%mi_sum)) deallocate(CS%DS2d%mi_sum)

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -888,7 +888,7 @@ subroutine redo_update_ice_model_fast(IST, sOSS, Rad, FIA, TSF, optics_CSp, &
   real    :: flux_sw_prev  ! The previous value of flux_sw_top [Q R Z T-1 ~> W m-2].
   real    :: rescale    ! A rescaling factor between 0 and 1 [nondim].
   real    :: bmelt_tmp, tmelt_tmp ! Temporary arrays [Q R Z ~> J m-2].
-  real    :: dSWt_dt    ! The derivative of SW_tot with skin temperature [Q R Z T-1 ~> W m-2 degC-1].
+  real    :: dSWt_dt    ! The derivative of SW_tot with skin temperature [Q R Z T-1 degC-1 ~> W m-2 degC-1].
   real    :: Tskin_prev ! The previous value of Tskin [degC]
   real    :: T_bright   ! A skin temperature below which the snow and ice attain
                         ! their greatest brightness and albedo no longer varies [degC].

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -431,7 +431,7 @@ subroutine find_excess_fluxes(FIA, TSF, XSF, part_size, G, US, IG)
   ! already being taken into account.
 
   ! This could be done more succinctly by initializing XSF = -TSF, but the
-  ! answers would then be more accutely impacted by roundoff.
+  ! answers would then be more acutely impacted by roundoff.
   XSF%flux_sh(:,:) = 0.0 ; XSF%flux_lw(:,:) = 0.0 ; XSF%flux_lh(:,:) = 0.0
   XSF%flux_sw(:,:,:) = 0.0
   XSF%evap(:,:) = 0.0 ; XSF%fprec(:,:) = 0.0 ; XSF%lprec(:,:) = 0.0
@@ -513,7 +513,7 @@ subroutine infill_array(IST, ta_ocn, ta, G, IG)
         mH_thin(i) = IST%mH_ice(i,j,k)
       endif ; enddo ; enddo
 
-      ! The logic for the k=1 (thinest) category is particularly simple.
+      ! The logic for the k=1 (thinnest) category is particularly simple.
       do i=isc,iec ; if (IST%part_size(i,j,1) <= 0.0) then
         ta(i,j,1) = G%mask2dT(i,j)*ta_ocn(i,j)
       endif ; enddo
@@ -739,7 +739,7 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
 
       dhf_dt = (dshdt(i,j,k) + devapdt(i,j,k)*latent) - dlwdt(i,j,k)
       if (CS%Reorder_0C_heatflux) then
-        ! This form seperately projects each contribution to the surface heat
+        ! This form separately projects each contribution to the surface heat
         ! flux back to its value when T=0, so that a bitwise identical result
         ! can be obtained if the heating is redone.  The two forms are
         ! mathematically equivalent.

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -95,9 +95,9 @@ subroutine sum_top_quantities (FIA, ABT, flux_u, flux_v, flux_sh, evap, &
   type(SIS_hor_grid_type),       intent(in)    :: G   !< The horizontal grid type
   type(ice_grid_type),           intent(in)    :: IG  !< The sea-ice specific grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed,0:IG%CatIce), &
-    intent(in) :: flux_u   !< The grid-wise quasi-zonal wind stress on the ice [R L Z T-2 ~> Pa].
+    intent(in) :: flux_u   !< The grid-wise quasi-zonal wind stress on the ice [R Z L T-2 ~> Pa].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,0:IG%CatIce), &
-    intent(in) :: flux_v   !< The grid-wise quasi-meridional wind stress on the ice [R L Z T-2 ~> Pa].
+    intent(in) :: flux_v   !< The grid-wise quasi-meridional wind stress on the ice [R Z L T-2 ~> Pa].
   real, dimension(G%isd:G%ied,G%jsd:G%jed,0:IG%CatIce), &
     intent(in) :: flux_sh  !< The upward sensible heat flux from the top of the ice into
                            !! the atmosphere [Q R Z T-1 ~> W m-2].
@@ -587,8 +587,8 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
     flux_lh, &  ! The upward latent heat flux associated with sublimation or
                 ! evaporation [Q R Z T-1 ~> W m-2].
     flux_lw, &  ! The net downward longwave heat flux into the ice [Q R Z T-1 ~> W m-2].
-    flux_u, &   ! The grid-aligned quasi-zonal wind stress on the ice [R L Z T-2 ~> Pa].
-    flux_v, &   ! The grid-aligned quasi-meridional wind stress on the ice [R L Z T-2 ~> Pa].
+    flux_u, &   ! The grid-aligned quasi-zonal wind stress on the ice [R Z L T-2 ~> Pa].
+    flux_v, &   ! The grid-aligned quasi-meridional wind stress on the ice [R Z L T-2 ~> Pa].
     lprec, &    ! The liquid precipitation onto the ice [R Z T-1 ~> kg m-2 s-1].
     fprec, &    ! The frozen precipitation onto the ice [R Z T-1 ~> kg m-2 s-1].
     sh_T0, &    ! The upward sensible heat flux from the top of the ice into

--- a/src/SIS_hor_grid.F90
+++ b/src/SIS_hor_grid.F90
@@ -57,8 +57,8 @@ type, public :: SIS_hor_grid_type
   integer :: JsgB !< The start j-index of cell vertices within the global domain
   integer :: JegB !< The end j-index of cell vertices within the global domain
 
-  integer :: isd_global !< The value of isd in the global index space (decompoistion invariant).
-  integer :: jsd_global !< The value of isd in the global index space (decompoistion invariant).
+  integer :: isd_global !< The value of isd in the global index space (decomposition invariant).
+  integer :: jsd_global !< The value of isd in the global index space (decomposition invariant).
   integer :: idg_offset !< The offset between the corresponding global and local i-indices.
   integer :: jdg_offset !< The offset between the corresponding global and local j-indices.
   logical :: symmetric  !< True if symmetric memory is used.
@@ -417,7 +417,7 @@ end function isPointInCell
 !> Specify which direction to work on first in directionally split algorithms.
 subroutine set_first_direction(G, y_first)
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
-  integer, intent(in) :: y_first !< A flag indicating which diretion to work on first
+  integer, intent(in) :: y_first !< A flag indicating which direction to work on first
                                  !! in split algorithms. Even for x, odd for y.
 
   G%first_direction = y_first

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -244,7 +244,7 @@ subroutine post_ice_state_diagnostics(IDs, IST, OSS, IOF, dt_slow, Time, G, US, 
     call post_data(IDs%id_e2m, tmp2d, diag)
   endif
 
-  ! Dermine the fraction of ridged ice rdg_frac = (ridged ice volume) / (total ice volume)
+  ! Determine the fraction of ridged ice rdg_frac = (ridged ice volume) / (total ice volume)
   ! in each category; IST%rdg_mice is ridged ice mass per unit total area throughout the code.
   if (IDs%id_rdgf>0) then
     !$OMP parallel do default(shared)
@@ -258,7 +258,7 @@ subroutine post_ice_state_diagnostics(IDs, IST, OSS, IOF, dt_slow, Time, G, US, 
     call post_data(IDs%id_rdgf, rdg_frac, diag)
   endif
 
-  ! Dermine the height of ridged ice rdg_height in each category.
+  ! Determine the height of ridged ice rdg_height in each category.
   if (IDs%id_rdg_h>0) then
     call post_data(IDs%id_rdg_h, IST%rdg_height, diag)
   endif

--- a/src/SIS_optics.F90
+++ b/src/SIS_optics.F90
@@ -28,7 +28,7 @@ integer, parameter :: NIR_DIF=4 !< Indicates the near-infrared diffuse band
 !> This type contains the parameters regulating sea-ice optics.
 type, public :: SIS_optics_CS ; private
 
-  ! albedos are from CSIM4 assumming 0.53 visible and 0.47 near-ir insolation
+  ! albedos are from CSIM4 assuming 0.53 visible and 0.47 near-ir insolation
   real :: alb_snow        !< albedo of snow (not melting) [nondim]
   real :: alb_ice         !< albedo of ice (not melting) [nondim]
   real :: pen_ice         !< ice surface penetrating solar fraction [nondim]
@@ -46,7 +46,7 @@ type, public :: SIS_optics_CS ; private
   logical :: slab_optics = .false. !< If true use the very old slab ice optics
                                    !! from the supersource model.
   real :: slab_crit_thick !< The thickness beyond which the slab ice optics no
-                          !! longer exhibits a thickness dependencs on albedo [Z ~> m].
+                          !! longer exhibits a thickness dependence on albedo [Z ~> m].
   real :: slab_alb_ocean  !< The ocean albedo as used in the slab ice optics [nondim].
   real :: slab_min_ice_alb !< The minimum thick ice albedo with the slab ice optics [nondim].
 

--- a/src/SIS_restart.F90
+++ b/src/SIS_restart.F90
@@ -404,7 +404,7 @@ subroutine SIS_restart_init(CS, filename, domain, param_file)
   endif
   allocate(CS)
 
-  ! Determine whether all paramters are set to their default values.
+  ! Determine whether all parameters are set to their default values.
   call get_param(param_file, mdl, "PARALLEL_RESTARTFILES", CS%parallel_restartfiles, &
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "MAX_FIELDS", CS%max_fields, default=100, do_not_log=.true.)

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -1,11 +1,11 @@
-!> This module is used to initalize the sea ice state for SIS2
+!> This module is used to initialize the sea ice state for SIS2
 module SIS_state_initialization
 
 ! This file is a part of SIS2. See LICENSE.md for the license.
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !   This module has code that initializes the sea ice state at the start of a  !
-! run.  If a run segment is initialzed from a restart file, some of these      !
+! run.  If a run segment is initialized from a restart file, some of these     !
 ! routines have options that just read and log their input parameters.         !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
@@ -494,7 +494,7 @@ subroutine initialize_concentration_from_latitudes(part_size, G, IG, US, PF, jus
 
   ! Local variables
   real :: Arctic_ice_edge    ! The southern latitude of Arctic ice in an initial condition [degrees of latitude]
-  real :: Antarctic_ice_edge ! The nouthern latitude of Antarctic ice in an initial condition [degrees of latitude]
+  real :: Antarctic_ice_edge ! The northern latitude of Antarctic ice in an initial condition [degrees of latitude]
   logical :: just_read    ! If true, just read parameters but set nothing.
   character(len=40)  :: mdl = "initialize_concentration_from_latitudes" ! This subroutine's name.
   integer :: i, j, k, is, ie, js, je, CatIce
@@ -638,7 +638,7 @@ subroutine initialize_salinity_from_file(salin, G, IG, US, PF, just_read_params)
   type(param_file_type),   intent(in)  :: PF   !< A structure indicating the open file
                                                !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
-                                               !! only read parameters without changing salinty.
+                                               !! only read parameters without changing salinity.
 
   ! Local variables
   logical :: just_read    ! If true, just read parameters but set nothing.
@@ -705,7 +705,7 @@ subroutine initialize_ice_enthalpy_from_file(enth_ice, sal_ice, G, IG, US, ITV, 
                            intent(out) :: enth_ice !< The ice enthalpy that is being initialized [Q ~> J kg-1]
   real, dimension(SZI_(G),SZJ_(G),IG%CatIce,IG%NkIce), &
                            intent(in)  :: sal_ice !< The ice salinity [gSalt kg-1]
-  type(ice_thermo_type),   intent(in)  :: ITV  !< The ice themodynamics parameter structure.
+  type(ice_thermo_type),   intent(in)  :: ITV  !< The ice thermodynamics parameter structure.
   type(param_file_type),   intent(in)  :: PF   !< A structure indicating the open file
                                                !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will
@@ -824,7 +824,7 @@ subroutine initialize_snow_enthalpy_from_file(enth_snow, G, IG, US, ITV, PF, jus
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),IG%CatIce,1), &
                            intent(out) :: enth_snow !< The snow enthalpy that is being initialized [Q ~> J kg-1]
-  type(ice_thermo_type),   intent(in)  :: ITV  !< The ice themodynamics parameter structure.
+  type(ice_thermo_type),   intent(in)  :: ITV  !< The ice thermodynamics parameter structure.
   type(param_file_type),   intent(in)  :: PF   !< A structure indicating the open file
                                                !! to parse for model parameter values.
   logical,       optional, intent(in)  :: just_read_params !< If present and true, this call will

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -66,7 +66,7 @@ type, public :: SIS_sum_out_CS ; private
                                 !! time that write_ice_statistics was called [gSalt], in EFP form.
   type(EFP_type) :: mass_prev_EFP !<   The total sea ice mass the last time that
                                 !! write_ice_statistics was called [kg], in EFP form.
-  real    :: dt                 !< The baroclinic dynamics time step [T ~> s].
+  real    :: dt                 !< The dynamics time step [T ~> s].
   real    :: timeunit           !<   The length of the units for the time axis [s].
   type(time_type) :: Start_time !< The start time of the simulation.
                                 !< Start_time is set in SIS_initialization.F90
@@ -246,7 +246,7 @@ subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_colum
   real :: mass_imb     ! The column integrated mass imbalance [kg].
   real :: enth_liq_0   ! The enthalpy of liquid water at the freezing point [Q ~> J kg-1].
   real :: kg_H_nlay    ! A mass unit conversion factor divided by the number of layers [kg m-2 H-1 ~> 1]
-  real :: area_pt      ! The area of a thickness catagory in a cell [m2].
+  real :: area_pt      ! The area of a thickness category in a cell [m2].
   real :: area_h       ! The masked area of a column [m2].
   type(EFP_type) :: &
     fresh_water_in_EFP, & ! The total mass of fresh water added by surface fluxes

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -47,18 +47,21 @@ public accumulate_input_1, accumulate_input_2
 type, public :: SIS_sum_out_CS ; private
   real, dimension(:,:), allocatable :: &
     water_in_col, &             !< The water that has been input to the ice and snow in a column since
-                                !! the last time that write_ice_statistics was called [R Z ~> kg m-2].
+                                !! the last time that write_ice_statistics was called [R Z ~> kg m-2]
+                                !! or its area integral in mks units [kg]
     heat_in_col, &              !< The heat that has been input to the ice and snow in a column since
                                 !! the last time that write_ice_statistics was called [Q R Z ~> J m-2].
+                                !! or its area integral in mks units [J]
     salt_in_col, &              !< The salt that has been input to the ice and snow in a column since
                                 !! the last time that write_ice_statistics was called [R Z kgSalt kg-1 ~> kgSalt m-2].
+                                !! or its area integral in mks units [kgSalt]
     ! These three arrays are only allocated and used for monitoring column-wise conservation.
     water_col_prev, &           !< The column integrated water that was in the ice and snow the last
-                                !! time that write_ice_statistics was called [kg m-2].
+                                !! time that write_ice_statistics was called [kg].
     heat_col_prev, &            !< The column integrated heat that was in the ice and snow the last
-                                !! time that write_ice_statistics was called [J m-2].
+                                !! time that write_ice_statistics was called [J].
     salt_col_prev               !< The column integrated salt that was in the ice and snow the last
-                                !! time that write_ice_statistics was called [kg m-2].
+                                !! time that write_ice_statistics was called [kgSalt].
 
   type(EFP_type) :: heat_prev_EFP !<   The total amount of heat in the sea ice the last
                                 !! time that write_ice_statistics was called [J], in EFP form.
@@ -242,10 +245,10 @@ subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_colum
   real :: Heat_chg     ! The change in total sea ice heat since the last call to this subroutine [J].
   real :: Heat_anom    ! The change in heat that cannot be accounted for bythe surface fluxes [J].
   real :: Heat_anom_norm ! The heat anomaly normalized by heat (if it is nonzero) [nondim].
-  real :: heat_imb     ! The column integrated heat imbalance [Q kg m-2 ~> J m-2].
+  real :: heat_imb     ! The column integrated heat imbalance [J].
   real :: mass_imb     ! The column integrated mass imbalance [kg].
   real :: enth_liq_0   ! The enthalpy of liquid water at the freezing point [Q ~> J kg-1].
-  real :: kg_H_nlay    ! A mass unit conversion factor divided by the number of layers [kg m-2 H-1 ~> 1]
+  real :: kg_H_nlay    ! A mass unit conversion factor divided by the number of layers [kg m-2 R-1 Z-1 ~> 1]
   real :: area_pt      ! The area of a thickness category in a cell [m2].
   real :: area_h       ! The masked area of a column [m2].
   type(EFP_type) :: &
@@ -536,7 +539,7 @@ subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_colum
     mass_anom_EFP = mass_chg_EFP - fresh_water_in_EFP
     mass_chg = EFP_to_real(mass_chg_EFP) ; mass_anom = EFP_to_real(mass_anom_EFP)
 
-    ! net_salt_input needs to be converted from gSalt kg-1 m s-1 to kg m-2 s-1 if mass includes salt.
+    ! net_salt_input needs to be accounted for if mass includes salt.
     ! mass_anom = mass_anom - 0.001*EFP_to_real(CS%net_salt_in_EFP)
   endif
 

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -965,7 +965,7 @@ subroutine kernel_uhh_CFL_x(G, is, ie, j, hprev, uhr, uhh, CFL, domore_u, h_negl
   real,                      intent(in)    :: mass_neglect ! A cell mass that is so small it is usually
                                                   !! lost in roundoff and can be neglected, or 0 to use
                                                   !! h_neglect times area [R Z L2 ~> kg].  If this is
-                                                 !! negative use an Adcroft-rule reciprocal in CFL.
+                                                  !! negative use an Adcroft-rule reciprocal in CFL.
   ! Local
   integer :: i
   real :: hup, hlos ! Upwind cell mass and an outward transport [R Z L2 ~> kg]
@@ -1297,7 +1297,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, domore_v, ntr, nL_max, Idt, is, 
                            intent(inout) :: Tr  !< The tracers being advected
   real, dimension(SZI_(G),SZJ_(G),SZCAT_(IG)), &
                            intent(inout) :: hprev !< Category thickness times fractional coverage
-                                                !! before this step of advection [R Z ~> kg m-2].
+                                                !! before this step of advection [R Z L2 ~> kg].
   real, dimension(SZI_(G),SZJB_(G),SZCAT_(IG)), &
                            intent(inout) :: vhr !< Remaining volume or mass fluxes through
                                                 !! meridional faces [R Z L2 ~> kg].
@@ -1495,7 +1495,7 @@ subroutine kernel_vhh_CFL_y(G, is, ie, J, hprev, vhr, vhh, CFL, domore_v, h_negl
   integer,                  intent(in)    :: J   !< The j-index to work on
   real, dimension(SZI_(G),SZJ_(G)), &
                             intent(in)    :: hprev !< Category thickness times fractional coverage
-                                                 !! before this step of advection [R Z L2 ~> kg m-2].
+                                                 !! before this step of advection [R Z L2 ~> kg].
   real, dimension(SZI_(G),SZJB_(G)), &
                             intent(in)    :: vhr !< Remaining volume or mass fluxes through
                                                  !! meridional faces [R Z L2 ~> kg].
@@ -1506,7 +1506,7 @@ subroutine kernel_vhh_CFL_y(G, is, ie, J, hprev, vhr, vhh, CFL, domore_v, h_negl
   logical, dimension(SZJB_(G)), &
                             intent(inout) :: domore_v !< True in rows with more advection to be done
   real,                     intent(in)    :: h_neglect !< A thickness that is so small it is usually lost
-                                                 !! in roundoff and can be neglected [R Z L2 ~> kg m-2].
+                                                 !! in roundoff and can be neglected [R Z ~> kg m-2].
   real,                     intent(in)    :: mass_neglect ! A cell mass that is so small it is usually
                                                  !! lost in roundoff and can be neglected, or 0 to use
                                                  !! h_neglect times area [R Z L2 ~> kg].  If this is

--- a/src/SIS_tracer_registry.F90
+++ b/src/SIS_tracer_registry.F90
@@ -60,10 +60,10 @@ type, public :: SIS_tracer_type
     pointer :: ad3d_y => NULL() !< The vertically summed y-direction advective flux [Conc R Z L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
     pointer :: ad4d_x => NULL() !< The x-direction advective flux by ice category and layer in
-                                !! units of [Conc R Z L2 T-1 ~> CONC kg s-1].
+                                !! units of [Conc R Z L2 T-1 ~> Conc kg s-1].
   real, dimension(:,:,:,:), &
     pointer :: ad4d_y => NULL() !< The y-direction advective flux by ice category and layer in
-                                !! units of [Conc R Z L2 T-1 ~> CONC kg s-1].
+                                !! units of [Conc R Z L2 T-1 ~> Conc kg s-1].
 !  real, dimension(:,:), &
 !    pointer :: snow_flux_tr => NULL() !< Concentration of the tracer in snow (for salinity = 0.0)
   real, dimension(:,:,:), &

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -559,7 +559,7 @@ subroutine adjust_ice_categories(mH_ice, mH_snow, mH_pond, part_sz, TrReg, G, IG
   real, dimension(SZI_(G),SZJ_(G),0:SZCAT_(IG)), &
                            intent(inout) :: part_sz !< The fractional ice concentration
                                                 !! within a cell in each thickness
-                                                !! camcategory [nondim], 0-1.
+                                                !! category [nondim], 0-1.
   type(SIS_tracer_registry_type), &
                            pointer       :: TrReg !< The registry of SIS ice and snow tracers.
   type(SIS_transport_CS),  pointer       :: CS  !< A pointer to the control structure for this module
@@ -579,7 +579,7 @@ subroutine adjust_ice_categories(mH_ice, mH_snow, mH_pond, part_sz, TrReg, G, IG
     mca_ice, mca_snow, mca_pond, &
     ! Initial ice, snow and pond masses per unit cell area [R Z ~> kg m-2].
     mca0_ice, mca0_snow, mca0_pond, &
-    ! Cross-catagory transfers of ice, snow and pond mass [R Z ~> kg m-2].
+    ! Cross-category transfers of ice, snow and pond mass [R Z ~> kg m-2].
     trans_ice, trans_snow, trans_pond
   real, dimension(SZI_(G)) :: ice_cover ! The summed fractional ice coverage [nondim].
   logical :: do_any, do_j(SZJ_(G)), resum_cat(SZI_(G), SZJ_(G))

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -212,14 +212,14 @@ type fast_ice_avg_type
     WindStr_ocn_x, & !< The zonal wind stress on open water on an A-grid [R L Z T-2 ~> Pa].
     WindStr_ocn_y, & !< The meridional wind stress on open water on an A-grid [R L Z T-2 ~> Pa].
     p_atm_surf , &  !< The atmospheric pressure at the top of the ice [R L Z T-2 ~> Pa].
-    runoff, &       !< Liquid runoff into the ocean [R Z T-1 ~> kg m-2].
-    calving         !< Calving of ice or runoff of frozen fresh  water into the ocean [R Z T-1 ~> kg m-2].
+    runoff, &       !< Liquid runoff into the ocean [R Z T-1 ~> kg m-2 s-1].
+    calving         !< Calving of ice or runoff of frozen fresh  water into the ocean [R Z T-1 ~> kg m-2 s-1].
   real, allocatable, dimension(:,:) :: runoff_hflx !< The heat flux associated with runoff, based
                     !! on the temperature difference relative to a reference temperature [Q R Z T-1 ~> W m-2]
   real, allocatable, dimension(:,:) :: calving_hflx !< The heat flux associated with calving, based
                     !! on the temperature difference relative to a reference temperature [Q R Z T-1 ~> W m-2]
   real, allocatable, dimension(:,:) :: calving_preberg !< Calving of ice or runoff of frozen fresh
-                    !! water into the ocean, exclusive of any iceberg contributions [R Z T-1 ~> kg m-2].
+                    !! water into the ocean, exclusive of any iceberg contributions [R Z T-1 ~> kg m-2 s-1].
   real, allocatable, dimension(:,:) :: calving_hflx_preberg !< The heat flux associated with calving
                     !! exclusive of any iceberg contributions, based on the temperature difference
                     !! relative to a reference temperature [Q R Z T-1 ~> W m-2]
@@ -855,7 +855,7 @@ subroutine rescale_fast_to_slow_restart_fields(FIA, Rad, TSF, G, US, IG)
     FIA%evap0(i,j,k) = RZ_T_rescale * FIA%evap0(i,j,k) ! [R Z T-1 ~> kg m-2 s-1]
     FIA%dshdt(i,j,k) = QRZ_T_rescale * FIA%dshdt(i,j,k) ! [Q R Z T-1 degC-1 ~> W m-2 degC-1]
     FIA%dlwdt(i,j,k) = QRZ_T_rescale * FIA%dlwdt(i,j,k) ! [Q R Z T-1 degC-1 ~> W m-2 degC-1]
-    FIA%devapdt(i,j,k) = RZ_T_rescale * FIA%devapdt(i,j,k) ! [Q R Z T-1 degC-1 ~> kg m-2 s-1 degC-1]
+    FIA%devapdt(i,j,k) = RZ_T_rescale * FIA%devapdt(i,j,k) ! [R Z T-1 degC-1 ~> kg m-2 s-1 degC-1]
 !    ! Do not rescale FIA%Tskin_cat(i,j,k) =  FIA%Tskin_cat(i,j,k)  ! [degC]
   enddo ; enddo ; enddo ; endif
 

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -483,7 +483,7 @@ end subroutine alloc_IST_arrays
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> ice_state_register_restarts registers any variables in the ice state type
-!!     that need to be includedin the restart files.
+!!     that need to be included in the restart files.
 subroutine ice_state_register_restarts(IST, G, IG, Ice_restart)
   type(ice_state_type),    intent(inout) :: IST !< A type describing the state of the sea ice
   type(SIS_hor_grid_type), intent(in)    :: G   !< The horizontal grid type

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -207,11 +207,11 @@ type fast_ice_avg_type
   real, allocatable, dimension(:,:,:) :: flux_sw_dn !< The total downward shortwave flux
                     !! by wavelength band, averaged across all thickness categories [Q R Z T-1 ~> W m-2].
   real, allocatable, dimension(:,:) :: &
-    WindStr_x  , &  !< The zonal wind stress averaged over the ice categories on an A-grid [R L Z T-2 ~> Pa].
-    WindStr_y  , &  !< The meridional wind stress averaged over the ice categories on an A-grid [R L Z T-2 ~> Pa].
-    WindStr_ocn_x, & !< The zonal wind stress on open water on an A-grid [R L Z T-2 ~> Pa].
-    WindStr_ocn_y, & !< The meridional wind stress on open water on an A-grid [R L Z T-2 ~> Pa].
-    p_atm_surf , &  !< The atmospheric pressure at the top of the ice [R L Z T-2 ~> Pa].
+    WindStr_x  , &  !< The zonal wind stress averaged over the ice categories on an A-grid [R Z L T-2 ~> Pa].
+    WindStr_y  , &  !< The meridional wind stress averaged over the ice categories on an A-grid [R Z L T-2 ~> Pa].
+    WindStr_ocn_x, & !< The zonal wind stress on open water on an A-grid [R Z L T-2 ~> Pa].
+    WindStr_ocn_y, & !< The meridional wind stress on open water on an A-grid [R Z L T-2 ~> Pa].
+    p_atm_surf , &  !< The atmospheric pressure at the top of the ice [R Z L T-2 ~> Pa].
     runoff, &       !< Liquid runoff into the ocean [R Z T-1 ~> kg m-2 s-1].
     calving         !< Calving of ice or runoff of frozen fresh  water into the ocean [R Z T-1 ~> kg m-2 s-1].
   real, allocatable, dimension(:,:) :: runoff_hflx !< The heat flux associated with runoff, based
@@ -277,8 +277,8 @@ type total_sfc_flux_type
   ! These are the arrays that are averaged over the categories and in time over
   ! the fast thermodynamics.
   real, allocatable, dimension(:,:) :: &
-    flux_u  , & !< The downward flux of zonal momentum on an A-grid [R L Z T-2 ~> Pa].
-    flux_v  , & !< The downward flux of meridional momentum on an A-grid [R L Z T-2 ~> Pa].
+    flux_u  , & !< The downward flux of zonal momentum on an A-grid [R Z L T-2 ~> Pa].
+    flux_v  , & !< The downward flux of meridional momentum on an A-grid [R Z L T-2 ~> Pa].
     flux_sh , & !< The upward sensible heat flux at the ice top [Q R Z T-1 ~> W m-2].
     evap    , & !< The upward evaporative moisture flux at top of the ice [R Z T-1 ~> kg m-2 s-1].
     flux_lw , & !< The downward flux of longwave radiation at  the top of the ice [Q R Z T-1 ~> W m-2].
@@ -707,9 +707,9 @@ subroutine rescale_ice_state_restart_fields(IST, G, US, IG, H_to_kg_m2, Rho_ice,
   type(unit_scale_type),   intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),     intent(in)    :: IG  !< The sea-ice specific grid type
   real,                    intent(in)    :: H_to_kg_m2 !< The mass conversion_factor that will be
-                                                     !! used for the run [kg m-2 H-1 ~> 1].
-  real,                    intent(in)    :: Rho_ice  !< The nominal density of ice [R ~> kg m-2]
-  real,                    intent(in)    :: Rho_snow !< The nominal density of snow [R ~> kg m-2]
+                                                     !! used for the run [kg m-2 R-1 Z-1 ~> 1].
+  real,                    intent(in)    :: Rho_ice  !< The nominal density of ice [R ~> kg m-3]
+  real,                    intent(in)    :: Rho_snow !< The nominal density of snow [R ~> kg m-3]
 
   ! Local variables
   real :: vel_rescale, Q_rescale, RZ_rescale, H_rescale_ice, H_rescale_snow
@@ -795,9 +795,11 @@ subroutine rescale_fast_to_slow_restart_fields(FIA, Rad, TSF, G, US, IG)
   type(total_sfc_flux_type), pointer     :: TSF     !< The fast ice model's total_sfc_flux_type
   type(SIS_hor_grid_type),   intent(in)  :: G       !< The horizontal grid type
   type(unit_scale_type),     intent(in)  :: US      !< A structure with unit conversion factors
-  type(ice_grid_type),       intent(in)  :: IG  !< The sea-ice specific grid type
+  type(ice_grid_type),       intent(in)  :: IG      !< The sea-ice specific grid type
 
-  real :: QRZ_T_rescale, RZ_T_rescale, RZL_T2_rescale ! Rescaling correction factors [all ~> 1.0]
+  real :: QRZ_T_rescale  ! Restart rescaling correction factor for heat fluxes [nondim]
+  real :: RZ_T_rescale   ! Restart rescaling correction factor for mass fluxes [nondim]
+  real :: RZL_T2_rescale ! Restart rescaling correction factor for stresses [nondim]
   integer :: i, j, k, b
 
   QRZ_T_rescale = 1.0 ; RZ_T_rescale = 1.0 ; RZL_T2_rescale = 1.0

--- a/src/SIS_utils.F90
+++ b/src/SIS_utils.F90
@@ -124,7 +124,7 @@ end subroutine ice_line
 subroutine post_avg_3d(id, val, part, diag, G, mask, scale, offset, wtd)
   integer,                 intent(in) :: id   !< The ID for this diagnostic
   real, dimension(:,:,:),  intent(in) :: val  !< The field to average
-  real, dimension(:,:,:),  intent(in) :: part !< The frational coverage of each cetegory
+  real, dimension(:,:,:),  intent(in) :: part !< The fractional coverage of each category
   type(SIS_diag_ctrl),     intent(in) :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_hor_grid_type), &
                  optional, intent(in) :: G   !< The horizontal grid type
@@ -208,7 +208,7 @@ end subroutine post_avg_3d
 subroutine post_avg_4d(id, val, part, diag, G, mask, scale, offset, wtd)
   integer,                  intent(in) :: id   !< The ID for this diagnostic
   real, dimension(:,:,:,:), intent(in) :: val  !< The field to average
-  real, dimension(:,:,:),   intent(in) :: part !< The frational coverage of each cetegory
+  real, dimension(:,:,:),   intent(in) :: part !< The fractional coverage of each category
   type(SIS_diag_ctrl),      intent(in) :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_hor_grid_type), &
                   optional, intent(in) :: G   !< The horizontal grid type

--- a/src/ice_boundary_types.F90
+++ b/src/ice_boundary_types.F90
@@ -6,7 +6,7 @@ module ice_boundary_types
 ! ice_exchange_types contains the types that are used for exchanging information
 !   with the atmosphere, land and ocean components via the FMS coupler.  These
 !   types should be altered only in close coordination with the entire FMS
-!   develoment effort.
+!   development effort.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
 use MOM_error_handler, only : stdout, is_root_pe
@@ -40,7 +40,7 @@ type ocean_ice_boundary_type
   real, dimension(:,:,:), pointer :: data =>NULL() !< S collective field for "named" fields above
   integer   :: stagger = BGRID_NE  !< A flag indicating how the velocities are staggered.
   integer   :: xtype     !< A flag indicating the exchange type, which may be set to
-                         !! REGRID, REDIST or DIRECT and isused by coupler
+                         !! REGRID, REDIST or DIRECT and is used by coupler
   type(coupler_2d_bc_type) :: fields !< An array of fields used for additional tracers
 end type ocean_ice_boundary_type
 
@@ -86,13 +86,13 @@ type atmos_ice_boundary_type
                          !! with the surface temperature [kg m-2 s-1 degC-1].
     drdt    => NULL(), & !< The derivative of the net UPWARD longwave radiative
                          !! heat flux (-lw_flux) with surface temperature [W m-2 degC-1].
-    coszen  => NULL(), & !< The cosine of the solar zenith angle averged over the
+    coszen  => NULL(), & !< The cosine of the solar zenith angle averaged over the
                          !! next radiation timestep (not the one that was used to
                          !! calculate the sw_flux fields), nondim and <=1.
     p       => NULL()    !< The atmospheric surface pressure [Pa], often ~1e5 Pa.
 !    data    => NULL() ! This can probably be removed.
   integer   :: xtype     !< A flag indicating the exchange type, which may be set to
-                         !! REGRID, REDIST or DIRECT and isused by coupler
+                         !! REGRID, REDIST or DIRECT and is used by coupler
   type(coupler_3d_bc_type)  :: fluxes !< An array of fluxes used for additional tracers
 end type atmos_ice_boundary_type
 
@@ -111,7 +111,7 @@ type land_ice_boundary_type
                          !! at 0 degC [W m-2].
   real, dimension(:,:,:), pointer :: data => NULL() !< A collective field for "named" fields above
   integer   :: xtype     !< A flag indicating the exchange type, which may be set to
-                         !! REGRID, REDIST or DIRECT and isused by coupler
+                         !! REGRID, REDIST or DIRECT and is used by coupler
 end type land_ice_boundary_type
 
 contains

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -566,7 +566,7 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, FIA, OSS, G, US, IG, sCS)
   endif
 
 !   It is possible that the ice mass and surface pressure will be needed after
-! the themodynamic step, in which case this should be uncommented.
+! the thermodynamic step, in which case this should be uncommented.
 !  ! Sum the concentration weighted mass.
 !  Ice%mi(:,:) = 0.0
 !  i_off = LBOUND(Ice%mi,1) - G%isc ; j_off = LBOUND(Ice%mi,2) - G%jsc
@@ -577,7 +577,7 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, FIA, OSS, G, US, IG, sCS)
 !        (G%US%RZ_to_kg_m2 * ((IST%mH_snow(i,j,k) + IST%mH_pond(i,j,k)) + IST%mH_ice(i,j,k)))
 !  enddo ; enddo ; enddo
 
-  ! This block of code is probably unneccessary.
+  ! This block of code is probably unnecessary.
   Ice%flux_t(:,:) = 0.0 ; Ice%flux_q(:,:) = 0.0
   Ice%flux_sw_nir_dir(:,:) = 0.0 ; Ice%flux_sw_nir_dif(:,:) = 0.0
   Ice%flux_sw_vis_dir(:,:) = 0.0 ; Ice%flux_sw_vis_dif(:,:) = 0.0
@@ -608,7 +608,7 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, FIA, OSS, G, US, IG, sCS)
     Ice%SST_C(i2,j2) = OSS%SST_C(i,j)
 
 !   It is possible that the ice mass and surface pressure will be needed after
-! the themodynamic step, in which case this should be uncommented.
+! the thermodynamic step, in which case this should be uncommented.
 !  if (IOF%slp2ocean) then
 !     Ice%p_surf(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*FIA%p_atm_surf(i,j) - 1e5 ! SLP - 1 std. atmosphere [Pa].
 !   else
@@ -829,10 +829,10 @@ end subroutine unpack_ocean_ice_boundary
 !! variable.
 subroutine unpack_ocn_ice_bdry(OIB, OSS, ITV, G, US, specified_ice, ocean_fields)
   type(ocean_ice_boundary_type), intent(in)    :: OIB !< A type containing ocean surface fields that
-                                                      !! aare used to drive the sea ice
+                                                      !! are used to drive the sea ice
   type(ocean_sfc_state_type),    intent(inout) :: OSS !< A structure containing the arrays that describe
                                                       !! the ocean's surface state for the ice model.
-  type(ice_thermo_type),         intent(in)    :: ITV !< The ice themodynamics parameter structure.
+  type(ice_thermo_type),         intent(in)    :: ITV !< The ice thermodynamics parameter structure.
   type(SIS_hor_grid_type),       intent(inout) :: G   !< The horizontal grid type
   type(unit_scale_type),         intent(in)    :: US  !< A structure with unit conversion factors
   logical,                       intent(in)    :: specified_ice !< If true, use specified ice properties.
@@ -996,7 +996,7 @@ subroutine set_ice_surface_state(Ice, IST, OSS, Rad, FIA, G, US, IG, fCS)
   real, dimension(IG%NkIce) :: sw_abs_lay ! The fraction of the absorbed shortwave that is
                                           ! absorbed in each of the ice layers, <=1, [nondim].
   real, dimension(size(FIA%flux_sw_top,4)) :: &
-    albedos        ! The albedos for the various wavelenth and direction bands
+    albedos        ! The albedos for the various wavelength and direction bands
                    ! for the current partition, non-dimensional and 0 to 1.
   real :: u, v     ! Ice velocity components [m s-1]
 
@@ -1160,7 +1160,7 @@ subroutine set_ice_surface_state(Ice, IST, OSS, Rad, FIA, G, US, IG, fCS)
     enddo
   endif
 
-  ! Copy over the additional tracer fields into the the open-ocean category of
+  ! Copy over the additional tracer fields into the open-ocean category of
   ! the Ice%ocean_fields structure.
   call coupler_type_copy_data(OSS%tr_fields, Ice%ocean_fields, ind3_start=1, ind3_end=1)
 
@@ -1194,7 +1194,7 @@ subroutine set_ice_optics(IST, OSS, Tskin_ice, coszen, Rad, G, US, IG, optics_CS
 
   real, dimension(IG%NkIce) :: sw_abs_lay ! The fraction of the absorbed shortwave that is
                                           ! absorbed in each of the ice layers, <=1, [nondim].
-  real :: albedos(4)  ! The albedos for the various wavelenth and direction bands
+  real :: albedos(4)  ! The albedos for the various wavelength and direction bands
                       ! for the current partition, non-dimensional and 0 to 1.
   integer :: i, j, k, m, isc, iec, jsc, jec, ncat
 
@@ -1279,7 +1279,7 @@ subroutine set_fast_ocean_sfc_properties( Atmos_boundary, Ice, IST, Rad, FIA, &
   type(unit_scale_type),         intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),           intent(inout) :: IG  !< The sea-ice specific grid type
   type(time_type),               intent(in)    :: Time_start !< The start of the time covered by this call
-  type(time_type),               intent(in)    :: Time_end   !< The end of the timee covered by this call
+  type(time_type),               intent(in)    :: Time_end   !< The end of the time covered by this call
 
   real, parameter :: T_0degC = 273.15 ! 0 degrees C in Kelvin
   logical :: coszen_changed
@@ -1329,7 +1329,7 @@ subroutine set_ocean_albedo_from_astronomy(Ice, G, Time_start, Time_end)
   type(ice_data_type),     intent(inout) :: Ice !< The publicly visible ice data type.
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type
   type(time_type),         intent(in)    :: Time_start !< The start of the time covered by this call
-  type(time_type),         intent(in)    :: Time_end   !< The end of the timee covered by this call
+  type(time_type),         intent(in)    :: Time_end   !< The end of the time covered by this call
 
   real, dimension(G%isc:G%iec,G%jsc:G%jec) :: &
     dummy, &  ! A dummy array that is not used again.
@@ -1760,7 +1760,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                               ! after a restart. However this may cause answers to diverge
                               ! after a restart.Provide a switch to turn this option off.
   logical :: recategorize_ice ! If true, adjust the distribution of the ice among thickness
-                              ! categories after initialiation.
+                              ! categories after initialization.
   logical :: Verona
   logical :: Concurrent
   logical :: read_aux_restart

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -81,7 +81,7 @@ subroutine ice_ridging_init(G, IG, PF, CS, US)
   nfsd=0 ! The number of floe size distribution layers
   n_iso=0 ! The number of isotopes in use
   n_aero=0 ! The number of aerosols in use
-  nt_Tsfc=1 ! Tracer index for ice/snow surface temperatore
+  nt_Tsfc=1 ! Tracer index for ice/snow surface temperature
   nt_qice=2 ! Starting index for ice enthalpy in layers
   nt_qsno=2+nilyr ! Starting index for snow enthalpy
   nt_sice=2+nilyr+nslyr ! Index for ice salinity

--- a/src/ice_shortwave_dEdd.F90
+++ b/src/ice_shortwave_dEdd.F90
@@ -674,7 +674,7 @@ subroutine compute_dEdd0(nx_block, ny_block, &
 ! Basically, vertical profiles of the layer extinction optical depth (tau),
 ! single scattering albedo (w0) and asymmetry parameter (g) are required over
 ! the klev+1 layers, where klev+1 = 2 + nslyr + nilyr. All of the surface type
-! information and snow/ice iop properties are evaulated in this routine, so
+! information and snow/ice iop properties are evaluated in this routine, so
 ! the tau,w0,g profiles can be passed to solution_dEdd for multiple scattering
 ! evaluation. Snow, bare ice and ponded ice iops are contained in data arrays
 ! in this routine.
@@ -771,7 +771,7 @@ subroutine compute_dEdd0(nx_block, ny_block, &
       real (kind=dbl_kind), dimension (nspint,nmbrad) :: &
          Qs_tab  , & ! extinction efficiency for each snow grain radius
          ws_tab  , & ! single scatter albedo for each snow grain radius
-         gs_tab      ! assymetry parameter   for each snow grain radius
+         gs_tab      ! asymmetry parameter   for each snow grain radius
       real (kind=dbl_kind) :: &
          delr    , & ! snow grain radius interpolation parameter
          rhoi    , & ! pure ice density [kg m-3]
@@ -1607,7 +1607,7 @@ end subroutine compute_dEdd0
 !=======================================================================
 !BOP
 !
-! !IROUTINE: solution_dEdd0 - evaluate solution for Delta-Edddington solar
+! !IROUTINE: solution_dEdd0 - evaluate solution for Delta-Eddington solar
 !
 ! !INTERFACE:
 
@@ -1696,7 +1696,7 @@ subroutine solution_dEdd0(nx_block, ny_block, &
 ! lowest interface (underlying ocean) up to the top of the column.
 !
 ! Note that layer diffuse reflectivity and transmissivity are computed
-! by integrating the direct over several gaussian angles. This is
+! by integrating the direct over several Gaussian angles. This is
 ! because the diffuse reflectivity expression sometimes is negative,
 ! but the direct reflectivity is always well-behaved. We assume isotropic
 ! radiation in the upward and downward hemispheres for this integration.
@@ -1717,7 +1717,7 @@ subroutine solution_dEdd0(nx_block, ny_block, &
 ! ocean from sea ice.
 !
 ! To handle refraction, we define a "fresnel" layer, which physically
-! is of neglible thickness and is non-absorbing, which can be combined to
+! is of negligible thickness and is non-absorbing, which can be combined to
 ! any sea ice layer or top of melt pond. The fresnel layer accounts for
 ! refraction of direct beam and associated reflection and transmission for
 ! solar radiation. A fresnel layer is combined with the top of a melt pond
@@ -1943,7 +1943,7 @@ subroutine solution_dEdd0(nx_block, ny_block, &
               trndif(k,ij) = trndif(k-1,ij)*refkm1*tdif_a(k-1,ij)
         endif       ! k > 0
 
-        ! compute next layer Delta-eddington solution only if total transmission
+        ! compute next layer Delta-Eddington solution only if total transmission
         ! of radiation to the interface just above the layer exceeds trmin.
           if (trntdr(k,ij) > trmin ) then
 
@@ -2127,7 +2127,7 @@ subroutine solution_dEdd0(nx_block, ny_block, &
         trndif(k,ij) = trndif(k-1,ij)*refkm1*tdif_a(k-1,ij)
 
       ! compute reflectivity to direct and diffuse radiation for layers
-      ! below by adding succesive layers starting from the underlying
+      ! below by adding successive layers starting from the underlying
       ! ocean and working upwards:
       !
       !              layers       interface

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -48,7 +48,7 @@ type ice_data_type !  ice_public_type
   logical  :: slow_ice_pe = .false. !< If true, this is a slow ice PE
   logical  :: fast_ice_pe = .false. !< If true, this is a fast ice PE
   logical  :: shared_slow_fast_PEs = .true. !< If true, the fast and slow ice use the same processors
-                                    !! and domain decomposiion
+                                    !! and domain decomposition
   integer  :: xtype          !< An integer specifying the type for the exchange
   integer, pointer, dimension(:)   :: slow_pelist =>NULL() !< Used for flux-exchange with slow processes.
   integer, pointer, dimension(:)   :: fast_pelist =>NULL() !< Used for flux-exchange with fast processes.
@@ -81,7 +81,7 @@ type ice_data_type !  ice_public_type
     t_surf      => NULL(), &  !< The surface temperature for the ocean or for
                               !! each ice-thickness category [Kelvin].
     u_surf      => NULL(), &  !< The eastward surface velocities of the ocean (:,:,1) or sea-ice [m s-1].
-    v_surf      => NULL()     !< The northward surface elocities of the ocean (:,:,1) or sea-ice [m s-1].
+    v_surf      => NULL()     !< The northward surface velocities of the ocean (:,:,1) or sea-ice [m s-1].
   real, pointer, dimension(:,:)   :: &
     s_surf         =>NULL()   !< The ocean's surface salinity [gSalt kg-1].
 
@@ -176,7 +176,7 @@ subroutine ice_type_slow_reg_restarts(domain, CatIce, param_file, Ice, &
                                               !! ocean, ice, and atmosphere.
 
   ! This subroutine allocates the externally visible ice_data_type's arrays and
-  ! registers the appopriate ones for inclusion in the restart file.
+  ! registers the appropriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
   call get_domain_extent(domain, isc, iec, jsc, jec )
@@ -268,7 +268,7 @@ subroutine ice_type_fast_reg_restarts(domain, CatIce, param_file, Ice, &
                                               !! tracer fluxes.
 
   ! This subroutine allocates the externally visible ice_data_type's arrays and
-  ! registers the appopriate ones for inclusion in the restart file.
+  ! registers the appropriate ones for inclusion in the restart file.
   integer :: isc, iec, jsc, jec, km, idr
 
   call get_domain_extent(domain, isc, iec, jsc, jec )
@@ -434,7 +434,7 @@ end subroutine Ice_public_type_chksum
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> Ice_public_type_bounds_check checks for unphysical values in a publicly
-!! visible ice data type, and writes out dianostics for any offending columns
+!! visible ice data type, and writes out diagnostics for any offending columns
 subroutine Ice_public_type_bounds_check(Ice, G, msg)
   type(ice_data_type),     intent(in)    :: Ice !< The publicly visible ice data type.
   type(SIS_hor_grid_type), intent(inout) :: G   !< The horizontal grid type

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -115,7 +115,7 @@ type ice_data_type !  ice_public_type
     calving_hflx => NULL(), & !< The heat flux associated with calving, based on
                               !! the temperature difference relative to a
                               !! reference temperature, in ???.
-    flux_salt  => NULL()  !< The flux of salt out of the ocean [kg m-2].
+    flux_salt  => NULL()  !< The flux of salt out of the ocean [kg m-2 s-1].
 
   real, pointer, dimension(:,:) :: &
     area => NULL() , &    !< The area of ocean cells [m2].  Land cells have

--- a/src/slab_ice.F90
+++ b/src/slab_ice.F90
@@ -101,10 +101,10 @@ subroutine slab_ice_dynamics(ui, vi, uo, vo, fxat, fyat, fxoc, fyoc)
   real, dimension(:,:), intent(inout) :: vi    !< Meridional ice velocity [L T-1 ~> m s-1]
   real, dimension(:,:), intent(in   ) :: uo    !< Zonal ocean velocity [L T-1 ~> m s-1]
   real, dimension(:,:), intent(in   ) :: vo    !< Meridional ocean velocity [L T-1 ~> m s-1]
-  real, dimension(:,:), intent(in   ) :: fxat  !< Zonal air stress on ice [kg m-2 L T-2 ~> Pa]
-  real, dimension(:,:), intent(in   ) :: fyat  !< Meridional air stress on ice [kg m-2 L T-2 ~> Pa]
-  real, dimension(:,:), intent(  out) :: fxoc  !< Zonal ice stress on ocean [kg m-2 L T-2 ~> Pa]
-  real, dimension(:,:), intent(  out) :: fyoc  !< Meridional ice stress on ocean [kg m-2 L T-2 ~> Pa]
+  real, dimension(:,:), intent(in   ) :: fxat  !< Zonal air stress on ice [R Z L T-2 ~> Pa]
+  real, dimension(:,:), intent(in   ) :: fyat  !< Meridional air stress on ice [R Z L T-2 ~> Pa]
+  real, dimension(:,:), intent(  out) :: fxoc  !< Zonal ice stress on ocean [R Z L T-2 ~> Pa]
+  real, dimension(:,:), intent(  out) :: fyoc  !< Meridional ice stress on ocean [R Z L T-2 ~> Pa]
 
   ui(:,:) = uo(:,:) ; vi(:,:) = vo(:,:)
   fxoc(:,:) = fxat(:,:) ; fyoc(:,:) = fyat(:,:)

--- a/src/specified_ice.F90
+++ b/src/specified_ice.F90
@@ -306,7 +306,7 @@ end function specified_ice_sum_output_CS
 !> specified_ice_end deallocates memory associated with the specified_ice_CS type.
 subroutine specified_ice_end(CS)
   type(specified_ice_CS), pointer :: CS  !< The control structure for the specified_ice module that
-                                         !! is dellocated here
+                                         !! is deallocated here
 
   deallocate(CS)
 


### PR DESCRIPTION
  This PR includes a series of commits that correct the unit documentation for
43 variables, correct numerous spelling errors in comments widely scattered
throught the SIS2 code, and revises the comments in SIS_tracer_advect.F90 to
reflect the fact that SIS2 never makes the Boussinesq approximation.  Only
comments are changed and all answers are bitwise identical.

  The SIS2 commits that are included in this update are:
- NOAA-GFDL/SIS2@d18605e Fixed 15 more variable unit descriptions
- NOAA-GFDL/SIS2@41c76d8 Corrected spelling errors in comments
- NOAA-GFDL/SIS2@98e926e Corrected comments in SIS_tracer_advect.F90
- NOAA-GFDL/SIS2@dde02fb Fixed 28 variable unit descriptions
