### PR TITLE
Fix the result of a bad automated merge

### DIFF
--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -53,11 +53,11 @@ type, public :: SIS_sum_out_CS ; private
     salt_in_col, &              !< The salt that has been input to the ice and snow in a column since
                                 !! the last time that write_ice_statistics was called [R Z kgSalt kg-1 ~> kgSalt m-2]
     ! These three arrays are only allocated and used for monitoring column-wise conservation.
-    water_col_prev, &           !< The column integrated water that was in the ice and snow the last
+    water_cell_prev, &          !< The cell integrated water that was in the ice and snow the last
                                 !! time that write_ice_statistics was called [kg].
-    heat_col_prev, &            !< The column integrated heat that was in the ice and snow the last
+    heat_cell_prev, &           !< The cell integrated heat that was in the ice and snow the last
                                 !! time that write_ice_statistics was called [J].
-    salt_col_prev               !< The column integrated salt that was in the ice and snow the last
+    salt_cell_prev              !< The cell integrated salt that was in the ice and snow the last
                                 !! time that write_ice_statistics was called [kgSalt].
 
   type(EFP_type) :: heat_prev_EFP !<   The total amount of heat in the sea ice the last


### PR DESCRIPTION
  In merging in two separate pull requests that made corrections to similar
lines in the same file, three renamed variables retained their original names,
resulting in SIS2 code that does not compile.  Each of the PRs was fully tested
separately, but for whatever reason their combination was not, and the SIS2 git
repository does not seem to detect certain merge conflicts.  This PR updates
these variable names to their intended values, and the code is once more
compiling and is reproducing the intended outputs.

  This PR will address SIS2 issue #167, which can be closed once this PR is accepted.