### PR TITLE
Add CI pipelines for SIS2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,170 @@
+stages:
+  - builds
+  - run
+  - tests
+  - cleanup
+
+variables:
+  CACHE_DIR: "/lustre/f2/scratch/oar.gfdl.ogrp-account/runner/cache/"
+
+
+# Merges SIS2 with dev/gfdl. Changes directory to test directory, if it exists.
+# - set cache location
+# - get MOM6-examples/tools/MRS scripts by cloning Gaea-stats and then MOM6-examples
+# - set working directory to MOM6-examples
+# - pull down latest of dev/gfdl (MOM6-examples might be ahead of Gaea-stats)
+before_script:
+  - echo Cache directory set to $CACHE_DIR
+  - echo -e "\e[0Ksection_start:`date +%s`:before[collapsed=true]\r\e[0KPre-script"
+  - git clone https://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git tests
+  - cd tests && git submodule init && git submodule update
+  - cd MOM6-examples && git checkout dev/gfdl && git pull
+  - echo -e "\e[0Ksection_end:`date +%s`:before\r\e[0K"
+
+# Tests that merge with dev/gfdl works.
+merge:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - cd $CI_PROJECT_DIR
+    - git pull --no-edit https://github.com/NOAA-GFDL/SIS2.git dev/gfdl
+
+# Compiles
+gnu:repro:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time make -f tools/MRS/Makefile SIS2_SRC=../.. pipeline-build-repro-gnu -s -j
+
+#gnu:ice-ocean-nolibs:
+#  stage: builds
+#  tags:
+#    - ncrc4
+#  script:
+#    - make -f tools/MRS/Makefile SIS2_SRC=../.. pipeline-build-gnu-iceocean-nolibs
+
+intel:repro:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time make -f tools/MRS/Makefile SIS2_SRC=../.. pipeline-build-repro-intel -s -j
+
+pgi:repro:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time make -f tools/MRS/Makefile SIS2_SRC=../.. pipeline-build-repro-pgi -s -j
+
+gnu:debug:
+  stage: builds
+  tags:
+    - ncrc4
+  script:
+    - time make -f tools/MRS/Makefile SIS2_SRC=../.. pipeline-build-debug-gnu -s -j
+
+# Runs
+run:
+  stage: run
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-run
+
+# Tests
+gnu:non-symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-gnu_non_symmetric
+
+gnu:symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-gnu_symmetric
+
+gnu:memory:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-gnu_memory
+
+#gnu:static:
+#  stage: tests
+#  tags:
+#    - ncrc4
+#  script:
+#    - make -f tools/MRS/Makefile sis2-pipeline-test-gnu_static
+
+gnu:restart:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-gnu_restarts
+
+gnu:params:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-params_gnu_symmetric
+  allow_failure: true
+
+intel:symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-intel_symmetric
+
+intel:non-symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-intel_non_symmetric
+
+intel:memory:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-intel_memory
+
+pgi:symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-pgi_symmetric
+
+pgi:non-symmetric:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-pgi_non_symmetric
+
+pgi:memory:
+  stage: tests
+  tags:
+    - ncrc4
+  script:
+    - make -f tools/MRS/Makefile sis2-pipeline-test-pgi_memory
+
+cleanup:
+  stage: cleanup
+  tags:
+    - ncrc4
+  before_script:
+    - echo Skipping submodule update
+  script:
+    - rm $CACHE_DIR/*$CI_PIPELINE_ID.tgz


### PR DESCRIPTION
Turns on gitlab pipeline (on gaea) modeled on the MOM6 CI pipeline:
- Compiles with gnu, intel and pgi compilers
- Compiles both non-symmetric and symmetric executables
- Runs 6 executables for all *SIS2 configurations for which regression stats files are recorded
- Does restart tests for ice-ocean configurations
- Checks strings in parameter doc files (using gnu)

Pipeline took ~43 mins, dominated by the 15min for the PGI compile and 18min to run tests. Example of succesful test at https://gitlab.gfdl.noaa.gov/ogrp/SIS2/-/pipelines/14957

Todo:
  [ ] currently skips static builds and runs
  [ ] currently also builds MOM6 solo executable (which is a small overhead relative to coupled executables)
  [ ] turn on nolibs build (currently fails in CI, unable to find gsw/TEOS10)