### PR TITLE
Fix Bad ice warnings over land

### DIFF
--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -455,25 +455,25 @@ subroutine Ice_public_type_bounds_check(Ice, G, msg)
   n_bad = 0 ; i_bad = 0 ; j_bad = 0 ; k_bad = 0
 
   t_min = T_0degC-100. ; t_max = T_0degC+60.
-  do k=0,ncat ; do j=jsc,jec ; do i=isc,iec
+  do k=0,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
     i2 = i+i_off ; j2 = j+j_off ; k2 = k+1
     if ((Ice%t_surf(i2,j2,k2) < t_min) .or. (Ice%t_surf(i2,j2,k2) > t_max)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; k_bad = k ; endif
     endif
-  enddo ; enddo ; enddo
-  do j=jsc,jec ; do i=isc,iec ; i2 = i+i_off ; j2 = j+j_off
+    endif ; enddo ; enddo ; enddo
+  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then ; i2 = i+i_off ; j2 = j+j_off
     if ((Ice%s_surf(i2,j2) < 0.0) .or. (Ice%s_surf(i2,j2) > 100.0)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; endif
     endif
-  enddo ; enddo
-  if (fluxes_avail) then ; do j=jsc,jec ; do i=isc,iec ; i2 = i+i_off ; j2 = j+j_off
+    endif ; enddo ; enddo
+  if (fluxes_avail) then ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then ; i2 = i+i_off ; j2 = j+j_off
     if ((abs(Ice%flux_t(i2,j2)) > 1e4) .or. (abs(Ice%flux_lw(i2,j2)) > 1e4)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; endif
     endif
-  enddo ; enddo ; endif
+    endif ; enddo ; enddo ; endif
 
   if (n_bad > 0) then
     i2 = i_bad+i_off ; j2 = j_bad+j_off ; k2 = k_bad+1


### PR DESCRIPTION
- CM4/ESM4 coupled models get loads of warnings in stdout (causing 2G
fms.out files per year) like:
WARNING from PE   704: Bad ice data End set_ice_surface_state ;  at   20.2   6.5 or i,j,k =    5   5   0; nbad =    240 on pe  704 ; T_sfc =   0.0000E+00, ps =   1.0000E+00, S_sfc =   0.0000E+00
- This is because t_surf is set to 0 after allocation and then compared
with a minimum 273.15-100 (K) to catch bad surface values over sea ice
but the comparison is not restricted to ocean and is causing warnings
over land in fully coupled models.
- The fix is to restrinct the comparison over ocean mask just like is
done in SIS_types.F90