### PR TITLE
Standardize syntax in mask2d logical tests

### DIFF
--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -365,7 +365,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
 
   !TOM> check where ice is present
   do j=jsc,jec ; do i=isc,iec
-    ice_present(i,j) = ( (G%mask2dT(i,j)>0.5) .and. (misp(i,j) > CS%MIV_MIN) )
+    ice_present(i,j) = ( (G%mask2dT(i,j)>0.0) .and. (misp(i,j) > CS%MIV_MIN) )
   enddo ; enddo
 
   ! sea level slope force
@@ -377,7 +377,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
   enddo ; enddo
 
   ! put ice/snow mass and concentration on v-grid, first finding mass on t-grid.
-  do J=jsc-1,jec ; do I=isc-1,iec ; if (G%mask2dBu(i,j) > 0.5 ) then
+  do J=jsc-1,jec ; do I=isc-1,iec ; if (G%mask2dBu(i,j)>0.0) then
     miv(I,J) = 0.25*( (misp(i+1,j+1) + misp(i,j)) + (misp(i+1,j) + misp(i,j+1)) )
     civ(I,J) = 0.25*( (ci(i+1,j+1) + ci(i,j)) + (ci(i+1,j) + ci(i,j+1)) )
   else
@@ -407,7 +407,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
   endif
 
   do J=jsc-1,jec ; do I=isc-1,iec
-    if ((G%mask2dBu(I,J)>0.5) .and. (miv(I,J) > CS%MIV_MIN) ) then ! values for velocity calculation (on v-grid)
+    if ((G%mask2dBu(I,J)>0.0) .and. (miv(I,J) > CS%MIV_MIN) ) then ! values for velocity calculation (on v-grid)
       dtmiv(I,J) = dt_Rheo/miv(I,J)
     else
       ui(I,J) = 0.0 ; vi(I,J) = 0.0
@@ -483,7 +483,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
 
     ! timestep stress tensor (H&D eqn 21)
     do j=jsc,jec ; do i=isc,iec
-      if( (G%mask2dT(i,j)>0.5) .and. (misp(i,j) > CS%MIV_MIN) ) then
+      if( (G%mask2dT(i,j)>0.0) .and. (misp(i,j) > CS%MIV_MIN) ) then
         f11   = mp4z(i,j) + CS%sig11(i,j)/edt(i,j) + strn11(i,j)
         f22   = mp4z(i,j) + CS%sig22(i,j)/edt(i,j) + strn22(i,j)
         CS%sig11(i,j) = (t1(i,j)*f22 + f11) * It2(i,j)
@@ -520,7 +520,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
     call pass_var(CS%sig12, G%Domain, complete=.true.)
 
     do J=jsc-1,jec ; do I=isc-1,iec
-      if( (G%mask2dBu(i,j)>0.5).and.(miv(i,j)>CS%MIV_MIN)) then ! timestep ice velocity (H&D eqn 22)
+      if( (G%mask2dBu(i,j)>0.0) .and. (miv(i,j)>CS%MIV_MIN)) then ! timestep ice velocity (H&D eqn 22)
         rr = CS%cdw*US%L_to_Z*CS%Rho_ocean * abs(cmplx(ui(i,j)-uo(i,j),vi(i,j)-vo(i,j))) * &
              exp(sign(CS%blturn*pi/180, G%CoriolisBu(i,j)) * (0.0,1.0))
         !
@@ -599,7 +599,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
   ! make averages
   I_sub_steps = 1.0/EVP_steps
   do J=jsc-1,jec ; do I=isc-1,iec
-    if ( (G%mask2dBu(i,j)>0.5) .and. miv(i,j)>CS%MIV_MIN ) then
+    if ( (G%mask2dBu(i,j)>0.0) .and. miv(i,j)>CS%MIV_MIN ) then
       fxoc(i,j) = fxoc(i,j)*I_sub_steps ; fyoc(i,j) = fyoc(i,j)*I_sub_steps
       fxic(i,j) = fxic(i,j)*I_sub_steps ; fyic(i,j) = fyic(i,j)*I_sub_steps
       fxco(i,j) = fxco(i,j)*I_sub_steps ; fyco(i,j) = fyco(i,j)*I_sub_steps

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -887,7 +887,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     if (sum_area <= 0.0) then
       ! This is a land point.
       mi_ratio_A_q(I,J) = 0.0
-    elseif (G%mask2dBu(I,J)>0.5) then
+    elseif (G%mask2dBu(I,J)>0.0) then
       ! This is an interior ocean point.
       !   Determine an appropriately averaged mass on q-points. The following
       ! expression for mi_q is mi when the masses are all equal, and goes to 4
@@ -1610,7 +1610,7 @@ subroutine limit_stresses(pres_mice, mice, str_d, str_t, str_s, G, US, CS, limit
 !        ! The factor of 2 here arises because of the definitions of the str_#.
 !        stress_mag = 2.0 * sqrt(min(0.0, str_d_q + 0.5*pres_avg)**2 + &
 !                                EC2 * (str_s(I,J)**2 + str_t_q**2))
-!        if ((stress_mag > pres_avg) .and. (G%mask2dBu(I,j)>0.5)) &
+!        if ((stress_mag > pres_avg) .and. (G%mask2dBu(I,j)>0.0)) &
 !          str_s(I,J) = str_s(I,J) * (pres_avg / stress_mag)
 !      endif
 !    endif
@@ -1928,7 +1928,8 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
         enddo
         x_kmax = min(cut, x_kmax)
 
-        g_k(:) = exp(-(log(x_k(:)/CS%onemeter) - mu_i) ** 2 / (2.0 * sigma_i ** 2)) / (x_k(:) * sigma_i * sqrt(2.0 * pi))
+        g_k(:) = exp(-(log(x_k(:)/CS%onemeter) - mu_i) ** 2 / (2.0 * sigma_i ** 2)) / &
+                 (x_k(:) * sigma_i * sqrt(2.0 * pi))
 
         b_n(:)  = exp(-(y_n(:) - mu_b) ** 2 / (2.0 * CS%sigma_b(i,j) ** 2)) / (CS%sigma_b(i,j) * sqrt(2.0 * pi))
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -864,7 +864,7 @@ subroutine convert_IST_to_simple_state(IST, DS2d, CAS, G, US, IG, CS)
   enddo ; enddo ; enddo
   do j=jsd,jed ; do i=isd,ied
     DS2d%mca_step(i,j,0) = DS2d%mca_step(i,j,0) + DS2d%mi_sum(i,j)
-!    if ((abs(max(1.0-DS2d%ice_cover(i,j),0.0) - IST%part_size(i,j,0)) > 5.0e-15) .and. (G%mask2dT(i,j)>0.5)) then
+!    if ((abs(max(1.0-DS2d%ice_cover(i,j),0.0) - IST%part_size(i,j,0)) > 5.0e-15) .and. (G%mask2dT(i,j)>0.0)) then
 !      write(mesg, '(3(ES13.5))') max(1.0 - DS2d%ice_cover(i,j), 0.0) - IST%part_size(i,j,0), &
 !         max(1.0 - DS2d%ice_cover(i,j), 0.0), IST%part_size(i,j,0)
 !      call SIS_error(FATAL, "Mismatch in ice_free values exceeding roundoff: "//trim(mesg))
@@ -1525,7 +1525,7 @@ subroutine set_ocean_top_stress_Bgrid(IOF, windstr_x_water, windstr_y_water, &
             ((windstr_y_water(I,J) + windstr_y_water(I-1,J-1)) + &
              (windstr_y_water(I-1,J) + windstr_y_water(I,J-1)))
       enddo
-      do k=1,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+      do k=1,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
         IOF%flux_u_ocn(i,j) = IOF%flux_u_ocn(i,j) + part_size(i,j,k) * 0.25 * &
             ((str_ice_oce_x(I,J) + str_ice_oce_x(I-1,J-1)) + &
              (str_ice_oce_x(I-1,J) + str_ice_oce_x(I,J-1)))
@@ -1538,13 +1538,13 @@ subroutine set_ocean_top_stress_Bgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do J=jsc-1,jec
       do I=isc-1,iec
-        ps_vel = 1.0 ; if (G%mask2dBu(I,J)>0.5) ps_vel = &
-                           0.25*((part_size(i+1,j+1,0) + part_size(i,j,0)) + &
-                                 (part_size(i+1,j,0) + part_size(i,j+1,0)) )
+        ps_vel = 1.0
+        if (G%mask2dBu(I,J)>0.0) ps_vel = 0.25*((part_size(i+1,j+1,0) + part_size(i,j,0)) + &
+                                                (part_size(i+1,j,0) + part_size(i,j+1,0)) )
         IOF%flux_u_ocn(I,J) = IOF%flux_u_ocn(I,J) + windstr_x_water(I,J) * ps_vel
         IOF%flux_v_ocn(I,J) = IOF%flux_v_ocn(I,J) + windstr_y_water(I,J) * ps_vel
       enddo
-      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dBu(I,J)>0.5) then
+      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dBu(I,J)>0.0) then
         ps_vel = 0.25 * ((part_size(i+1,j+1,k) + part_size(i,j,k)) + &
                          (part_size(i+1,j,k) + part_size(i,j+1,k)) )
         IOF%flux_u_ocn(I,J) = IOF%flux_u_ocn(I,J) + str_ice_oce_x(I,J) * ps_vel
@@ -1555,12 +1555,11 @@ subroutine set_ocean_top_stress_Bgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do j=jsc,jec
       do I=isc-1,iec
-        ps_vel = 1.0 ; if (G%mask2dCu(I,j)>0.5) ps_vel = &
-                           0.5*(part_size(i+1,j,0) + part_size(i,j,0))
+        ps_vel = 1.0 ; if (G%mask2dCu(I,j)>0.0) ps_vel = 0.5*(part_size(i+1,j,0) + part_size(i,j,0))
         IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * &
                 0.5 * (windstr_x_water(I,J) + windstr_x_water(I,J-1))
       enddo
-      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dCu(I,j)>0.5) then
+      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dCu(I,j)>0.0) then
         ps_vel = 0.5 * (part_size(i+1,j,k) + part_size(i,j,k))
         IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * &
                 0.5 * (str_ice_oce_x(I,J) + str_ice_oce_x(I,J-1))
@@ -1569,12 +1568,11 @@ subroutine set_ocean_top_stress_Bgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do J=jsc-1,jec
       do i=isc,iec
-        ps_vel = 1.0 ; if (G%mask2dCv(i,J)>0.5) ps_vel = &
-                           0.5*(part_size(i,j+1,0) + part_size(i,j,0))
+        ps_vel = 1.0 ; if (G%mask2dCv(i,J)>0.0) ps_vel = 0.5*(part_size(i,j+1,0) + part_size(i,j,0))
         IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * &
                 0.5 * (windstr_y_water(I,J) + windstr_y_water(I-1,J))
       enddo
-      do k=1,ncat ; do i=isc,iec ; if (G%mask2dCv(i,J)>0.5) then
+      do k=1,ncat ; do i=isc,iec ; if (G%mask2dCv(i,J)>0.0) then
         ps_vel = 0.5 * (part_size(i,j+1,k) + part_size(i,j,k))
         IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * &
                 0.5 * (str_ice_oce_y(I,J) + str_ice_oce_y(I-1,J))
@@ -1633,7 +1631,7 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
         IOF%flux_v_ocn(i,j) = IOF%flux_v_ocn(i,j) + ps_vel * 0.5 * &
                             (windstr_y_water(i,J) + windstr_y_water(i,J-1))
       enddo
-      do k=1,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+      do k=1,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
         IOF%flux_u_ocn(i,j) = IOF%flux_u_ocn(i,j) +  part_size(i,j,k) * 0.5 * &
                             (str_ice_oce_x(I,j) + str_ice_oce_x(I-1,j))
         IOF%flux_v_ocn(i,j) = IOF%flux_v_ocn(i,j) + part_size(i,j,k) * 0.5 * &
@@ -1644,15 +1642,15 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do J=jsc-1,jec
       do I=isc-1,iec
-        ps_vel = 1.0 ; if (G%mask2dBu(I,J)>0.5) ps_vel = &
-                           0.25*((part_size(i+1,j+1,0) + part_size(i,j,0)) + &
-                                 (part_size(i+1,j,0) + part_size(i,j+1,0)) )
+        ps_vel = 1.0
+        if (G%mask2dBu(I,J)>0.0) ps_vel = 0.25*((part_size(i+1,j+1,0) + part_size(i,j,0)) + &
+                                                (part_size(i+1,j,0) + part_size(i,j+1,0)) )
         IOF%flux_u_ocn(I,J) = IOF%flux_u_ocn(I,J) + ps_vel * G%mask2dBu(I,J) * 0.5 * &
                 (windstr_x_water(I,j) + windstr_x_water(I,j+1))
         IOF%flux_v_ocn(I,J) = IOF%flux_v_ocn(I,J) + ps_vel * G%mask2dBu(I,J) * 0.5 * &
                 (windstr_y_water(i,J) + windstr_y_water(i+1,J))
       enddo
-      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dBu(I,J)>0.5) then
+      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dBu(I,J)>0.0) then
         ps_vel = 0.25 * ((part_size(i+1,j+1,k) + part_size(i,j,k)) + &
                          (part_size(i+1,j,k) + part_size(i,j+1,k)) )
         IOF%flux_u_ocn(I,J) = IOF%flux_u_ocn(I,J) + ps_vel * 0.5 * &
@@ -1665,11 +1663,10 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do j=jsc,jec
       do I=Isc-1,iec
-        ps_vel = 1.0 ; if (G%mask2dCu(I,j)>0.5) ps_vel = &
-                           0.5*(part_size(i+1,j,0) + part_size(i,j,0))
+        ps_vel = 1.0 ; if (G%mask2dCu(I,j)>0.0) ps_vel = 0.5*(part_size(i+1,j,0) + part_size(i,j,0))
         IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * windstr_x_water(I,j)
       enddo
-      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dCu(I,j)>0.5) then
+      do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dCu(I,j)>0.0) then
         ps_vel = 0.5 * (part_size(i+1,j,k) + part_size(i,j,k))
         IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * str_ice_oce_x(I,j)
       endif ; enddo ; enddo
@@ -1677,11 +1674,10 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_vel)
     do J=jsc-1,jec
       do i=isc,iec
-        ps_vel = 1.0 ; if (G%mask2dCv(i,J)>0.5) ps_vel = &
-                           0.5*(part_size(i,j+1,0) + part_size(i,j,0))
+        ps_vel = 1.0 ; if (G%mask2dCv(i,J)>0.0) ps_vel = 0.5*(part_size(i,j+1,0) + part_size(i,j,0))
         IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * windstr_y_water(i,J)
       enddo
-      do k=1,ncat ; do i=isc,iec ; if (G%mask2dCv(i,J)>0.5) then
+      do k=1,ncat ; do i=isc,iec ; if (G%mask2dCv(i,J)>0.0) then
         ps_vel = 0.5 * (part_size(i,j+1,k) + part_size(i,j,k))
         IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * str_ice_oce_y(i,J)
       endif ; enddo ; enddo
@@ -1751,7 +1747,7 @@ subroutine set_ocean_top_stress_B2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do I=isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dBu(I,J)>0.5) then
+      if (G%mask2dBu(I,J)>0.0) then
         ps_ocn = 0.25 * ((ice_free(i+1,j+1) + ice_free(i,j)) + &
                          (ice_free(i+1,j) + ice_free(i,j+1)) )
         ps_ice = 0.25 * ((ice_cover(i+1,j+1) + ice_cover(i,j)) + &
@@ -1764,7 +1760,7 @@ subroutine set_ocean_top_stress_B2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do j=jsc,jec ; do I=isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCu(I,j)>0.5) then
+      if (G%mask2dCu(I,j)>0.0) then
         ps_ocn = 0.5*(ice_free(i+1,j) + ice_free(i,j))
         ps_ice = 0.5*(ice_cover(i+1,j) + ice_cover(i,j))
       endif
@@ -1775,7 +1771,7 @@ subroutine set_ocean_top_stress_B2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do i=isc,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCv(i,J)>0.5) then
+      if (G%mask2dCv(i,J)>0.0) then
         ps_ocn = 0.5*(ice_free(i,j+1) + ice_free(i,j))
         ps_ice = 0.5*(ice_cover(i,j+1) + ice_cover(i,j))
       endif
@@ -1842,7 +1838,7 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do I=isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dBu(I,J)>0.5) then
+      if (G%mask2dBu(I,J)>0.0) then
         ps_ocn = 0.25 * ((ice_free(i+1,j+1) + ice_free(i,j)) + &
                          (ice_free(i+1,j) + ice_free(i,j+1)) )
         ps_ice = 0.25 * ((ice_cover(i+1,j+1) + ice_cover(i,j)) + &
@@ -1859,7 +1855,7 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do j=jsc,jec ; do I=Isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCu(I,j)>0.5) then
+      if (G%mask2dCu(I,j)>0.0) then
         ps_ocn = 0.5*(ice_free(i+1,j) + ice_free(i,j))
         ps_ice = 0.5*(ice_cover(i+1,j) + ice_cover(i,j))
       endif
@@ -1869,7 +1865,7 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do i=isc,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCv(i,J)>0.5) then
+      if (G%mask2dCv(i,J)>0.0) then
         ps_ocn = 0.5*(ice_free(i,j+1) + ice_free(i,j))
         ps_ice = 0.5*(ice_cover(i,j+1) + ice_cover(i,j))
       endif

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -1344,7 +1344,7 @@ subroutine translate_OSS_to_sOSS(OSS, IST, sOSS, G, US)
     sOSS%SST_C(i,j) = OSS%SST_C(i,j)
     sOSS%T_fr_ocn(i,j) = OSS%T_fr_ocn(i,j)
 
-    if (G%mask2dT(i,j) > 0.5) then
+    if (G%mask2dT(i,j)>0.0) then
       sOSS%bheat(i,j) = OSS%bheat(i,j)
       ! Interpolate the ocean and ice velocities onto tracer cells.
       if (OSS%Cgrid_dyn) then
@@ -2596,7 +2596,7 @@ subroutine IST_bounds_check(IST, G, US, IG, msg, OSS, Rad)
 
   tOcn_min = -100. ; tOcn_max = 60.
   if (present(OSS)) then
-    do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+    do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
       if ((OSS%s_surf(i,j) < 0.0) .or. (OSS%s_surf(i,j) > 100.0) .or. &
           (OSS%SST_C(i,j) < tOcn_min) .or. (OSS%SST_C(i,j) > tOcn_max)) then
         n_bad = n_bad + 1
@@ -2604,7 +2604,7 @@ subroutine IST_bounds_check(IST, G, US, IG, msg, OSS, Rad)
       endif
     endif ; enddo ; enddo
   endif
-  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     if (abs(sum_part_sz(i,j) - 1.0) > 2.0*(ncat+1)*epsilon(sum_part_sz(i,j))) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; err = "sum_part_sz" ; endif
@@ -2616,7 +2616,7 @@ subroutine IST_bounds_check(IST, G, US, IG, msg, OSS, Rad)
   enth_min = enth_from_TS(tice_min, 0., IST%ITV)
   enth_max = enth_from_TS(tice_max, 0., IST%ITV)
   if (present(Rad)) then
-    do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+    do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
       if ((Rad%t_skin(i,j,k) < tsurf_min) .or. (Rad%t_skin(i,j,k) > tsurf_max)) then
         n_bad = n_bad + 1
         if (n_bad == 1) then ; i_bad = i ; j_bad = j ; k_bad = k ; err = "tsurf" ; endif
@@ -2624,7 +2624,7 @@ subroutine IST_bounds_check(IST, G, US, IG, msg, OSS, Rad)
     endif ; enddo ; enddo ; enddo
   endif
 
-  do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     if ((IST%mH_ice(i,j,k) > m_max) .or. (IST%mH_snow(i,j,k) > m_max)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; k_bad = k ; err = "large mass" ; endif
@@ -2635,7 +2635,7 @@ subroutine IST_bounds_check(IST, G, US, IG, msg, OSS, Rad)
     endif
   endif ; enddo ; enddo ; enddo
 
-  do m=1,NkIce ; do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do m=1,NkIce ; do k=1,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     if ((IST%enth_ice(i,j,k,m) < enth_min) .or. (IST%enth_ice(i,j,k,m) > enth_max)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; k_bad = k ; err = "enth_ice" ; endif

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1458,7 +1458,7 @@ subroutine fast_radiation_diagnostics(ABT, Ice, IST, Rad, FIA, G, US, IG, CS, &
   if (Rad%id_lwdn > 0) then
     tmp_diag(:,:) = 0.0
     Stefan = 5.6734e-8  ! Set the Stefan-Bolzmann constant [W m-2 degK-4].
-    do k=0,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+    do k=0,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
       i3 = i+io_A ; j3 = j+jo_A ; k2 = k+1
       tmp_diag(i,j) = tmp_diag(i,j) + IST%part_size(i,j,k) * &
                            (ABT%lw_flux(i3,j3,k2) + Stefan*(Rad%t_skin(i,j,k)+T_0degC)**4)
@@ -1468,7 +1468,7 @@ subroutine fast_radiation_diagnostics(ABT, Ice, IST, Rad, FIA, G, US, IG, CS, &
 
   sw_dn(:,:) = 0.0 ; net_sw(:,:) = 0.0 ; avg_alb(:,:) = 0.0 ; sw_dn_bnd(:,:,:) = 0.0
   !$OMP parallel do default(shared) private(i2,j2,k2,i3,j3)
-  do j=jsc,jec ; do k=0,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do j=jsc,jec ; do k=0,ncat ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     i2 = i+io_I ; j2 = j+jo_I ; i3 = i+io_A ; j3 = j+jo_A ; k2 = k+1
     if (associated(ABT%sw_down_vis_dir)) then
       sw_dn(i,j) = sw_dn(i,j) + IST%part_size(i,j,k) * ( &
@@ -1525,7 +1525,7 @@ subroutine fast_radiation_diagnostics(ABT, Ice, IST, Rad, FIA, G, US, IG, CS, &
   if (Rad%id_swdn > 0) call post_data(Rad%id_swdn, sw_dn, CS%diag)
 
   if (Rad%id_alb > 0) then
-    do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+    do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
       if (sw_dn(i,j) > 0.0) &
         avg_alb(i,j) = (sw_dn(i,j) - net_sw(i,j)) / sw_dn(i,j)
       ! Otherwise keep the simple average that was set above.
@@ -1533,7 +1533,7 @@ subroutine fast_radiation_diagnostics(ABT, Ice, IST, Rad, FIA, G, US, IG, CS, &
     call post_data(Rad%id_alb, avg_alb, CS%diag)
   endif
 
-  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     do b=1,size(FIA%flux_sw_dn,3)
       FIA%flux_sw_dn(i,j,b) = FIA%flux_sw_dn(i,j,b) + US%W_m2_to_QRZ_T*sw_dn_bnd(i,j,b)
     enddo
@@ -2598,7 +2598,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     isc = fHI%isc ; iec = fHI%iec ; jsc = fHI%jsc ; jec = fHI%jec
     i_off = LBOUND(Ice%ocean_pt,1) - fHI%isc ; j_off = LBOUND(Ice%ocean_pt,2) - fHI%jsc
     do j=jsc,jec ; do i=isc,iec ; i2 = i+i_off ; j2 = j+j_off
-      Ice%ocean_pt(i2,j2) = ( fG%mask2dT(i,j) > 0.5 )
+      Ice%ocean_pt(i2,j2) = ( fG%mask2dT(i,j) > 0.0 )
     enddo ; enddo
     if (.not.slow_ice_PE) then
       Ice%axes(1:3) = Ice%fCS%diag%axesTc0%handles(1:3)

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -455,20 +455,20 @@ subroutine Ice_public_type_bounds_check(Ice, G, msg)
   n_bad = 0 ; i_bad = 0 ; j_bad = 0 ; k_bad = 0
 
   t_min = T_0degC-100. ; t_max = T_0degC+60.
-  do k=0,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then
+  do k=0,ncat ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then
     i2 = i+i_off ; j2 = j+j_off ; k2 = k+1
     if ((Ice%t_surf(i2,j2,k2) < t_min) .or. (Ice%t_surf(i2,j2,k2) > t_max)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; k_bad = k ; endif
     endif
     endif ; enddo ; enddo ; enddo
-  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then ; i2 = i+i_off ; j2 = j+j_off
+  do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then ; i2 = i+i_off ; j2 = j+j_off
     if ((Ice%s_surf(i2,j2) < 0.0) .or. (Ice%s_surf(i2,j2) > 100.0)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; endif
     endif
     endif ; enddo ; enddo
-  if (fluxes_avail) then ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.5) then ; i2 = i+i_off ; j2 = j+j_off
+  if (fluxes_avail) then ; do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j)>0.0) then ; i2 = i+i_off ; j2 = j+j_off
     if ((abs(Ice%flux_t(i2,j2)) > 1e4) .or. (abs(Ice%flux_lw(i2,j2)) > 1e4)) then
       n_bad = n_bad + 1
       if (n_bad == 1) then ; i_bad = i ; j_bad = j ; endif

--- a/src/specified_ice.F90
+++ b/src/specified_ice.F90
@@ -152,7 +152,7 @@ subroutine set_ocean_top_stress_FIA(FIA, IOF, G, US)
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do I=isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dBu(I,J)>0.5) then
+      if (G%mask2dBu(I,J)>0.0) then
         ps_ocn = 0.25 * ((FIA%ice_free(i+1,j+1) + FIA%ice_free(i,j)) + &
                          (FIA%ice_free(i+1,j) + FIA%ice_free(i,j+1)) )
         ps_ice = 0.25 * ((FIA%ice_cover(i+1,j+1) + FIA%ice_cover(i,j)) + &
@@ -186,7 +186,7 @@ subroutine set_ocean_top_stress_FIA(FIA, IOF, G, US)
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do j=jsc,jec ; do I=Isc-1,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCu(I,j)>0.5) then
+      if (G%mask2dCu(I,j)>0.0) then
         ps_ocn = 0.5*(FIA%ice_free(i+1,j) + FIA%ice_free(i,j))
         ps_ice = 0.5*(FIA%ice_cover(i+1,j) + FIA%ice_cover(i,j))
       endif
@@ -197,7 +197,7 @@ subroutine set_ocean_top_stress_FIA(FIA, IOF, G, US)
     !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
     do J=jsc-1,jec ; do i=isc,iec
       ps_ocn = 1.0 ; ps_ice = 0.0
-      if (G%mask2dCv(i,J)>0.5) then
+      if (G%mask2dCv(i,J)>0.0) then
         ps_ocn = 0.5*(FIA%ice_free(i,j+1) + FIA%ice_free(i,j))
         ps_ice = 0.5*(FIA%ice_cover(i,j+1) + FIA%ice_cover(i,j))
       endif


### PR DESCRIPTION
  Modified the syntax of the logical comparisons with the various mask2d
variables to always check whether they are larger than 0.0, not 0.5 and use
similar syntax throughout the SIS2 code.  Because these arrays are always either
0.0 or 1.0, the answers are bitwise identical.