### PR TITLE
Fix specified ice restart issue AND add flux_u,flux_v optional args to compute_ocean_albedo

### DIFF
--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -365,7 +365,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, US, IG)
   !
   if (CS%specified_ice) then   ! over-write changes with specifications.
     h_ice_input(:,:) = 0.0
-    call get_sea_surface(CS%Time, G%HI, SST=OSS%SST_C, ice_conc=IST%part_size, ice_thick=h_ice_input)
+    call get_sea_surface(CS%Time, G%HI, SST=OSS%SST_C, ice_conc=IST%part_size(:,:,1), ice_thick=h_ice_input)
     call get_SIS2_thermo_coefs(IST%ITV, rho_ice=rho_ice)
 
     do j=jsc,jec ; do i=isc,iec

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1351,7 +1351,7 @@ subroutine set_ocean_albedo_from_astronomy(Ice, G, Time_start, Time_end)
 
   call compute_ocean_albedo(Ice%ocean_pt, cosz_alb(:,:), Ice%albedo_vis_dir(:,:,1),&
                             Ice%albedo_vis_dif(:,:,1), Ice%albedo_nir_dir(:,:,1),&
-                            Ice%albedo_nir_dif(:,:,1), rad*G%geoLatT(isc:iec,jsc:jec) )
+                            Ice%albedo_nir_dif(:,:,1), rad*G%geoLatT(isc:iec,jsc:jec), Ice%flux_u(:,:), Ice%flux_v(:,:) )
 
 end subroutine set_ocean_albedo_from_astronomy
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1373,7 +1373,7 @@ subroutine set_ocean_albedo_from_coszen(Ice, G, coszen)
 
   call compute_ocean_albedo(Ice%ocean_pt, coszen(isc:iec,jsc:jec), Ice%albedo_vis_dir(:,:,1),&
                             Ice%albedo_vis_dif(:,:,1), Ice%albedo_nir_dir(:,:,1),&
-                            Ice%albedo_nir_dif(:,:,1), rad*G%geoLatT(isc:iec,jsc:jec) )
+                            Ice%albedo_nir_dif(:,:,1), rad*G%geoLatT(isc:iec,jsc:jec), Ice%flux_u(:,:), Ice%flux_v(:,:))
 
 end subroutine set_ocean_albedo_from_coszen
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2400,15 +2400,15 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       ! and needs to be updated for each run segment, regardless of whether a restart file is used.
       call get_sea_surface(Ice%sCS%Time, sG%HI, SST=Ice%sCS%OSS%SST_C, ice_domain=Ice%slow_domain_NH)
       if (.not.is_restart) then
-      !### Perhaps ice_conc and h_ice_input should also be read with the get_sea_surface limits.
-      allocate(h_ice_input(sG%isd:sG%ied,sG%jsd:sG%jed)) ; h_ice_input(:,:) = 0.0
-      call get_sea_surface(Ice%sCS%Time, sG%HI, SST=Ice%sCS%OSS%SST_C, ice_conc=sIST%part_size(:,:,1), &
-                            ice_thick=h_ice_input, ice_domain=Ice%slow_domain_NH)
-      do j=jsc,jec ; do i=isc,iec
-         sIST%part_size(i,j,0) = 1.0 - sIST%part_size(i,j,1)
-         sIST%mH_ice(i,j,1) = h_ice_input(i,j)*US%m_to_Z * Rho_ice
-      enddo ; enddo
-      deallocate(h_ice_input)
+        ! Perhaps ice_conc and h_ice_input should also be read with the get_sea_surface limits.
+        allocate(h_ice_input(sG%isd:sG%ied,sG%jsd:sG%jed)) ; h_ice_input(:,:) = 0.0
+        call get_sea_surface(Ice%sCS%Time, sG%HI, SST=Ice%sCS%OSS%SST_C, ice_conc=sIST%part_size(:,:,1), &
+                             ice_thick=h_ice_input, ice_domain=Ice%slow_domain_NH)
+        do j=jsc,jec ; do i=isc,iec
+          sIST%part_size(i,j,0) = 1.0 - sIST%part_size(i,j,1)
+          sIST%mH_ice(i,j,1) = h_ice_input(i,j)*US%m_to_Z * Rho_ice
+        enddo ; enddo
+        deallocate(h_ice_input)
       endif
     else
       call SIS_dyn_trans_init(Ice%sCS%Time, sG, US, sIG, param_file, Ice%sCS%diag, &

--- a/src/ice_spec.F90
+++ b/src/ice_spec.F90
@@ -69,13 +69,7 @@ subroutine get_sea_surface(Time, HI, SST, ice_conc, ice_thick, ice_domain, ice_d
   integer :: tod(3), dum1, dum2, dum3
 
   if (.not.module_is_initialized) then
-#ifdef INTERNAL_FILE_NML
-    read (input_nml_file, nml=ice_spec_nml, iostat=io)
-#else
-    unit = open_namelist_file()
-    read  (unit, ice_spec_nml,iostat=io)
-    call close_file (unit)
-#endif
+  read (input_nml_file, nml=ice_spec_nml, iostat=io)
     ierr = check_nml_error(io,'ice_spec_nml')
     write (stdout(),'(/)')
     write (stdout(), ice_spec_nml)


### PR DESCRIPTION
This PR addresses two different unrelated issues (my apologies for combining them, but they are in use together in ESM4.5):
- 1. The new whitecaps albedo scheme of Dunne et.al. needs the u,v fluxes be passed to ice_param/compute_ocean_albedo. It is now possible to request SIS2 doing that since ice_param is already updated to accept those optional arguments.
- 2. There is a restart issue (1x2days .ne. 2x1days) for the specified-ice option of SIS2. With this fix, it is possible to use SIS2 in AM4/AM5 experiments (which till now have been using SIS1) and hence the same executable for running AM and CM models. The fix is basically to un-comment what @Hallberg-NOAA has already put in line 2408 of ice_model.F90 plus an addition to bypass recategorize_ice for specified-ice.