### PR TITLE
Replace MOM_memory.h with SIS2_memory.h

### DIFF
--- a/src/SIS_open_boundary.F90
+++ b/src/SIS_open_boundary.F90
@@ -19,7 +19,7 @@ use MOM_unit_scaling,         only : unit_scale_type
 
 implicit none ; private
 
-#include <MOM_memory.h>
+#include <SIS2_memory.h>
 
 public open_boundary_config
 !public open_boundary_init


### PR DESCRIPTION
The most recent PR to SIS2 includes MOM_memory.h in one of its files,
which breaks certain SIS2-only library builds.

This patch replaces it with SIS2_memory.h, which is functionally
identical but plays better with existing builds.