### PR TITLE
+Rescale SIS2 salinities

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -234,7 +234,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_evap     = register_SIS_diag_field('ice_model', 'EVAP',diag%axesT1, Time, &
                'evaporation', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   IOF%id_saltf    = register_SIS_diag_field('ice_model', 'SALTF', diag%axesT1, Time, &
-               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_tmelt    = register_SIS_diag_field('ice_model', 'TMELT', diag%axesT1, Time, &
                'upper surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
   FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT', diag%axesT1, Time, &
@@ -310,7 +310,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   OSS%id_sst   = register_SIS_diag_field('ice_model', 'SST', diag%axesT1, Time, &
              'sea surface temperature', 'deg-C', missing_value=missing)
   OSS%id_sss   = register_SIS_diag_field('ice_model', 'SSS', diag%axesT1, Time, &
-             'sea surface salinity', 'psu', missing_value=missing)
+             'sea surface salinity', 'psu', conversion=US%S_to_ppt, missing_value=missing)
   OSS%id_ssh   = register_SIS_diag_field('ice_model', 'SSH', diag%axesT1, Time, &
              'sea surface height', 'm', conversion=US%Z_to_m, missing_value=missing)
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -211,6 +211,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
   real, dimension(SZI_(G),SZJ_(G))   :: &
     hi_avg            ! The area-weighted average ice thickness in the units used for icebergs [m].
   real, dimension(G%isc:G%iec, G%jsc:G%jec)   :: &
+    Saln_sfc, &       ! A local copy of the surface salinity in the units used for icebergs [gSalt kg-1]
     calving, &        ! A local copy of the calving rate in the units used for icebergs [kg m-2 s-1]
     calving_hflx, &   ! A local copy of the calving heat flux in the units used for icebergs [W m-2]
     windstr_x, &      ! The area-weighted average ice thickness in the units used for icebergs [Pa].
@@ -265,6 +266,10 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
     stress_stagger = AGRID
   endif
 
+  do j=jsc,jec ; do i=isc,iec
+    Saln_sfc(i,j) = US%S_to_ppt*OSS%s_surf(i,j)
+  enddo ; enddo
+
   if (IST%Cgrid_dyn) then
     do j=jsc-1,jec+1 ; do I=isc-2,iec+1
       u_ice_C(I,j) = US%L_T_to_m_s*IST%u_ice_C(I,j) ; u_ocn_C(I,j) = US%L_T_to_m_s*OSS%u_ocn_C(I,j)
@@ -277,7 +282,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
             sea_lev, OSS%SST_C(isc:iec,jsc:jec), &
             calving_hflx, FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=CGRID_NE, &
-            stress_stagger=stress_stagger, sss=OSS%s_surf(isc:iec,jsc:jec), &
+            stress_stagger=stress_stagger, sss=Saln_sfc, &
             mass_berg=IOF%mass_berg, ustar_berg=IOF%ustar_berg, &
             area_berg=IOF%area_berg )
   else
@@ -290,7 +295,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
             sea_lev, OSS%SST_C(isc:iec,jsc:jec),  &
             calving_hflx, FIA%ice_cover(isc-1:iec+1,jsc-1:jec+1), &
             hi_avg(isc-1:iec+1,jsc-1:jec+1), stagger=BGRID_NE, &
-            stress_stagger=stress_stagger, sss=OSS%s_surf(isc:iec,jsc:jec), &
+            stress_stagger=stress_stagger, sss=Saln_sfc, &
             mass_berg=IOF%mass_berg, ustar_berg=IOF%ustar_berg, &
             area_berg=IOF%area_berg )
   endif

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -606,7 +606,7 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
     flux_sw     ! The downward shortwave heat fluxes [Q R Z T-1 ~> W m-2].  The fourth
                 ! dimension is a combination of angular orientation and frequency.
   real, dimension(0:IG%NkIce) :: T_col ! The temperature of a column of ice and snow [degC].
-  real, dimension(IG%NkIce)   :: S_col ! The thermodynamic salinity of a column of ice [gSalt kg-1].
+  real, dimension(IG%NkIce)   :: S_col ! The thermodynamic salinity of a column of ice [S ~> gSalt kg-1].
   real, dimension(0:IG%NkIce) :: enth_col   ! The enthalpy of a column of snow and ice [Q ~> J kg-1].
   real, dimension(0:IG%NkIce) :: SW_abs_col ! The shortwave absorption within a column of snow and
                   ! ice [Q R Z T-1 ~> W m-2].
@@ -860,7 +860,7 @@ subroutine redo_update_ice_model_fast(IST, sOSS, Rad, FIA, TSF, optics_CSp, &
   type(ice_grid_type),       intent(in)    :: IG         !< The ice vertical grid type
 
   real, dimension(IG%NkIce)   :: &
-    S_col         ! The thermodynamic salinity of a column of ice [gSalt kg-1].
+    S_col         ! The thermodynamic salinity of a column of ice [S ~> gSalt kg-1].
   real, dimension(0:IG%NkIce) :: &
     T_col, &      ! The temperature of a column of ice and snow [degC].
     SW_abs_col, & ! The shortwave absorption within a column of snow and ice [Q R Z T-1 ~> W m-2].

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -88,7 +88,7 @@ subroutine post_ice_state_diagnostics(IDs, IST, OSS, IOF, dt_slow, Time, G, US, 
     rdg_frac    ! fraction of ridged ice per category [nondim]
   real, dimension(SZI_(G),SZJ_(G)) :: diagVar ! A temporary array for diagnostics.
   real, dimension(IG%NkIce) :: S_col ! Specified thermodynamic salinity of each
-                                     ! ice layer if spec_thermo_sal is true.
+                                     ! ice layer if spec_thermo_sal is true [S ~> gSalt kg-1]
   real :: rho_ice  ! The nominal density of sea ice [R ~> kg m-3].
   real :: rho_snow ! The nominal density of snow [R ~> kg m-3].
   real :: Spec_vol_ice ! The nominal sea ice specific volume [R-1 ~> m3 kg-1]
@@ -158,8 +158,7 @@ subroutine post_ice_state_diagnostics(IDs, IST, OSS, IOF, dt_slow, Time, G, US, 
         if (spec_thermo_sal) then ; do m=1,NkIce
           temp_ice(i,j,k,m) = temp_from_En_S(IST%enth_ice(i,j,k,m), S_col(m), IST%ITV)
         enddo ; else ; do m=1,NkIce
-          temp_ice(i,j,k,m) = temp_from_En_S(IST%enth_ice(i,j,k,m), &
-                                              IST%sal_ice(i,j,k,m), IST%ITV)
+          temp_ice(i,j,k,m) = temp_from_En_S(IST%enth_ice(i,j,k,m), IST%sal_ice(i,j,k,m), IST%ITV)
         enddo ; endif
       else
         do m=1,NkIce ; temp_ice(i,j,k,m) = 0.0 ; enddo
@@ -362,7 +361,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_t_iceav = register_diag_field('ice_model', 'T_bulkice', diag%axesT1, Time, &
                'Volume-averaged ice temperature', 'C', missing_value=missing)
   IDs%id_s_iceav = register_diag_field('ice_model', 'S_bulkice', diag%axesT1, Time, &
-               'Volume-averaged ice salinity', 'g/kg', missing_value=missing)
+               'Volume-averaged ice salinity', 'g/kg', conversion=US%S_to_ppt, missing_value=missing)
   call safe_alloc_ids_1d(IDs%id_t, nLay)
   call safe_alloc_ids_1d(IDs%id_sal, nLay)
   do n=1,nLay
@@ -372,7 +371,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
                  'C',  missing_value=missing)
     IDs%id_sal(n)   = register_diag_field('ice_model', 'Sal'//trim(nstr), &
                diag%axesT1, Time, 'ice layer '//trim(nstr)//' salinity', &
-               'g/kg',  missing_value=missing)
+               'g/kg', conversion=US%S_to_ppt, missing_value=missing)
   enddo
 
   IDs%id_mi   = register_diag_field('ice_model', 'MI', diag%axesT1, Time, &

--- a/src/SIS_tracer_registry.F90
+++ b/src/SIS_tracer_registry.F90
@@ -80,6 +80,8 @@ type, public :: SIS_tracer_type
     pointer :: OBC_in_v => NULL()  !< Structured values for flow into the domain through v-face open
                                    !! boundaries.
   character(len=32) :: name        !< A tracer name for error messages.
+  real :: conc_scale = 1.0         !< A scaling factor used to convert the concentrations
+                                   !! of this tracer to its desired units.
   logical :: nonnegative = .false. !< If true, this tracer can not be negative
   logical :: is_passive  = .false. !< True if this ice tracer is passive
 end type SIS_tracer_type
@@ -104,7 +106,7 @@ contains
 subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_tracer, &
                              massless_val, ad_2d_x, ad_2d_y, ad_3d_x, ad_3d_y, &
                              ad_4d_x, ad_4d_y, OBC_inflow, OBC_in_u, OBC_in_v, &
-                             nonnegative, ocean_BC, snow_BC, is_passive)
+                             nonnegative, ocean_BC, snow_BC, is_passive, conc_scale)
   integer,                 intent(in) :: nLtr !<  The number of vertical levels for this tracer
   type(SIS_hor_grid_type), intent(in) :: G   !< The horizontal grid type
   type(ice_grid_type),     intent(in) :: IG  !< The sea-ice specific grid type
@@ -151,6 +153,8 @@ subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_t
   real, dimension(:,:,:), &
                  optional, pointer    :: snow_BC  !< Value of the tracer at the snow-ice boundary
   logical,       optional, intent(in) :: is_passive  !< True if this ice tracer is passive
+  real,          optional, intent(in) :: conc_scale  !< A scaling factor used to convert the concentration
+                                                     !! of this tracer to its desired units.
   ! This subroutine registers a tracer to be advected.
 
   ! Local variables
@@ -178,10 +182,14 @@ subroutine register_SIS_tracer(tr1, G, IG, nLtr, name, param_file, TrReg, snow_t
   Tr_here%name = trim(name)
   Tr_here%t => tr1(:,:,:,1:nLtr)
   Tr_here%nL = nLtr
-  if(present(ocean_BC)) then
+
+  Tr_here%conc_scale = 1.0
+  if (present(conc_scale)) Tr_here%conc_scale = conc_scale
+
+  if (present(ocean_BC)) then
     TrReg%Tr_ice(TrReg%ntr)%ocean_BC => ocean_BC
   endif
-  if(present(snow_BC)) then
+  if (present(snow_BC)) then
     TrReg%Tr_ice(TrReg%ntr)%snow_BC => snow_BC
   endif
 

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -607,7 +607,7 @@ subroutine ice_stock_pe(Ice, index, value)
       !There is no salt in the snow or in the ponds.
       do m=1,NkIce ; do k=1,ncat ; do j=jsc,jec ;  do i=isc,iec
         value = value + (IST%part_size(i,j,k) * (G%US%L_to_m**2*G%areaT(i,j)*G%mask2dT(i,j))) * &
-            (0.001*(kg_H_Nk*IST%mH_ice(i,j,k))) * IST%sal_ice(i,j,k,m)
+            (0.001*(kg_H_Nk*IST%mH_ice(i,j,k))) * G%US%S_to_ppt*IST%sal_ice(i,j,k,m)
       enddo ; enddo ; enddo ; enddo
 
   end select


### PR DESCRIPTION
  Applied dimensional rescaling to all SIS2 salinity variables.  All answers and
output are bitwise identical.  The specific changes with this commit include:

 - Changes to the unit descriptions in the comments for about 58 variables

 - Added the new optional argument conc_scale to register_SIS_tracer, mirroring
   the corresponding argument in the MOM6 version, to indicate how a tracer
   might be unscaled

 - Renamed a handful of internal variables or arguments from S to Saln to
   help ensure that these variables were being scaled properly

 - Added comments noting 4 subroutines that appear not to be used

 - Added scale arguments to 6 get_param calls for salinity parameters

 - Added scale arguments to 4 MOM_read_data calls for salinities

 - Added or modified scale arguments for 4 checksum calls

 - Added the (currently hard-coded) variable salin_max to the SIS_optics_CS

 - Added a rescaled salinity array to pass to update_icebergs

 - Modified a data_override call to use the interface that allows internal
   rescaling

 - Addition of the new elements ppt_to_S and S_to_ppt to the ice_thermo_type