### PR TITLE
Icepack area underflow patch 

### DIFF
--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -50,7 +50,7 @@ type, public :: ice_ridging_CS ; private
   real :: mu_rdg = 3.0 !< e-folding scale of ridged ice, new_rdg_partic (m^0.5)
   real :: area_underflow = 0.0 ! a non-dimesional fractional area underflow limit for the sea-ice
                       ! ridging scheme. This is defaulted to zero, but a reasonable value might be
-                      ! 10^-24 which for a km square grid cell would equate to an Angstrom scale ice patch.
+                      ! 10^-26 which for a km square grid cell would equate to an Angstrom scale ice patch.
 end type ice_ridging_CS
 
 contains
@@ -79,7 +79,7 @@ subroutine ice_ridging_init(G, IG, PF, CS, US)
                    units="m^0.5", default=3.0)
     call get_param(PF, mdl, "RIDGE_AREA_UNDERFLOW", CS%area_underflow, &
                    "A fractional area limit below which ice fraction is set to zero "//&
-                   "A reasonable default value for a km scale grid cell is 10^-32.",&
+                   "A reasonable default value for a km scale grid cell is 10^-24.",&
                    units="none", default=0.0)
   endif
 

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -48,9 +48,10 @@ type, public :: ice_ridging_CS ; private
   new_rdg_partic = .false., & !< .true. = new participation, .false. = Thorndike et al 75
   new_rdg_redist = .false.    !< .true. = new redistribution, .false. = Hibler 80
   real :: mu_rdg = 3.0 !< e-folding scale of ridged ice, new_rdg_partic (m^0.5)
-  real :: area_underflow = 0.0 ! a non-dimesional fractional area underflow limit for the sea-ice
-                      ! ridging scheme. This is defaulted to zero, but a reasonable value might be
-                      ! 10^-26 which for a km square grid cell would equate to an Angstrom scale ice patch.
+  real :: area_underflow = 0.0 !< a non-dimesional fractional area underflow limit for the sea-ice
+                               !! ridging scheme. This is defaulted to zero, but a reasonable
+                               !! value might be 10^-26 which for a km square grid cell
+                               !! would equate to an Angstrom scale ice patch.
 end type ice_ridging_CS
 
 contains
@@ -249,10 +250,10 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
   call icepack_query_tracer_sizes(ncat_out=ncat_out,ntrcr_out=ntrcr_out, nilyr_out=nilyr_out, nslyr_out=nslyr_out)
 
   if (nIlyr .ne. nilyr_out .or. nSlyr .ne. nslyr_out ) &
-   call SIS_error(FATAL,"Oops!! It looks like you are trying to use sea-ice ridging "//&
-   "but did not include the Icepack (https://github.com/CICE-Consortium/Icepack)"//&
-   "source code repository in your compilation procedure, and are instead using the default "//&
-   "stub routine contained in config_src/external. Adjust your compilation accordingly." )
+    call SIS_error(FATAL,"Oops!! It looks like you are trying to use sea-ice ridging "//&
+                         "but did not include the Icepack (https://github.com/CICE-Consortium/Icepack)"//&
+                         "source code repository in your compilation procedure, and are instead using the default "//&
+                         "stub routine contained in config_src/external. Adjust your compilation accordingly." )
 
   ! copy strain calculation code from SIS_C_dynamics; might be a more elegant way ...
   !

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -239,7 +239,11 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
 
   call icepack_query_tracer_sizes(ncat_out=ncat_out,ntrcr_out=ntrcr_out, nilyr_out=nilyr_out, nslyr_out=nslyr_out)
 
-  if (nIlyr .ne. nilyr_out .or. nSlyr .ne. nslyr_out ) call SIS_error(FATAL,'nilyr or nslyr mismatch with Icepack')
+  if (nIlyr .ne. nilyr_out .or. nSlyr .ne. nslyr_out ) &
+   call SIS_error(FATAL,"Oops!! It looks like you are trying to use sea-ice ridging "//&
+   "but did not include the Icepack (https://github.com/CICE-Consortium/Icepack)"//&
+   "source code repository in your compilation procedure, and are instead using the default "//&
+   "stub routine contained in config_src/external. Adjust your compilation accordingly." )
 
   ! copy strain calculation code from SIS_C_dynamics; might be a more elegant way ...
   !

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -490,7 +490,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
       ! ! output: snow/ice masses/thicknesses
       do k=1,nCat
         if (aicen(k) < CS%area_underflow) then
-           aicek(k)=0.0
+           aicen(k)=0.0
            vicen(k)=0.0
         endif
         if (aicen(k) > 0.0) then

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -49,9 +49,8 @@ type, public :: ice_ridging_CS ; private
   new_rdg_redist = .false.    !< .true. = new redistribution, .false. = Hibler 80
   real :: mu_rdg = 3.0 !< e-folding scale of ridged ice, new_rdg_partic (m^0.5)
   real :: area_underflow = 0.0 ! a non-dimesional fractional area underflow limit for the sea-ice
-                      ! ridging scheme. This is defaulted to zero, but a reasonable value
-                      !  might be 10^-32 which for a km square grid cell would equate to an Angstrom scale
-                      ! ice patch.
+                      ! ridging scheme. This is defaulted to zero, but a reasonable value might be
+                      ! 10^-24 which for a km square grid cell would equate to an Angstrom scale ice patch.
 end type ice_ridging_CS
 
 contains


### PR DESCRIPTION
New parameter RIDGE_AREA_UNDERFLOW is introduced in order to avoid the occurrence of undetectably small fractional area and negative ice volume following ridging adjustments from Icepack. The default is 0.0, which does not introduce changes in existing runs.  A reasonable value would be 10^-26 which would correspond to an Angstrom-scale ice patch within a km-scale grid cell.  This addresses #178 and #183