### PR TITLE
Fix for sigma_i going to zero in ITD landfast ice.

### DIFF
--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -1,9 +1,10 @@
 @article{dupont2021,
 	author = "F. Dupont and D. Dumont and J.-F. Lemieux and E. Dumas-Lefebvre and A. Caya",
-	year = 2021,
+	year = 2022,
 	title = "A probabilistic seabed-ice keel interaction model",
 	journal = "The Cryosphere",
-	note = "in review"
+	volume = "16",
+	pages = "1963--1977"
 }
 
 @article{lemieux2015,

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1975,6 +1975,7 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
         enddo
         x_kmax = min(cut, x_kmax)
 
+        sigma_i = max(sigma_i, CS%puny)
         g_k(:) = exp(-(log(x_k(:)/CS%onemeter) - mu_i) ** 2 / (2.0 * sigma_i ** 2)) / &
                  (x_k(:) * sigma_i * sqrt(2.0 * pi))
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1952,16 +1952,11 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
         do n =1, ncat
           v_i = v_i + vcat(n)**2 / (max(acat(n), CS%puny))
         enddo
-        v_i = v_i - m_i**2
+        v_i = max( (v_i - m_i**2), CS%puny )
 
         ! parameters for the log-normal
         mu_i    = log(m_i/(CS%onemeter * sqrt(1.0 + v_i/m_i**2)))
-        sigma_i = 0.0
-        if (v_i > 0.0) then
-          sigma_i = max(sqrt(log(1.0 + v_i/m_i**2)), CS%puny)
-        else
-          sigma_i = CS%puny
-        endif
+        sigma_i = max(sqrt(log(1.0 + v_i/m_i**2)), CS%puny)
 
         ! max thickness associated with percentile of log-normal PDF
         ! x_kmax=x997 was obtained from an optimization procedure (Dupont et al.)

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1853,8 +1853,9 @@ end subroutine basal_stress_coeff_C
 !! a normal distribution with sigma_b = 2.5d0. An improvement would
 !! be to provide the distribution based on high resolution data.
 !!
-!! Dupont, F. Dumont, D., Lemieux, J.F., Dumas-Lefebvre, E., Caya, A.
-!! in prep.
+!! Dupont, F., D. Dumont, J.F. Lemieux, E. Dumas-Lefebvre, A. Caya (2022).
+!! A probabilistic seabed-ice keel interaction model, The Cryosphere, 16,
+!! 1963-1977.
 !!
 !! authors: D. Dumont, J.F. Lemieux, E. Dumas-Lefebvre, F. Dupont
 !!
@@ -1959,7 +1960,7 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
         sigma_i = max(sqrt(log(1.0 + v_i/m_i**2)), CS%puny)
 
         ! max thickness associated with percentile of log-normal PDF
-        ! x_kmax=x997 was obtained from an optimization procedure (Dupont et al.)
+        ! x_kmax=x997 was obtained from an optimization procedure (Dupont et al. 2022)
 
         x_kmax = CS%onemeter * exp(mu_i + sqrt(2.0*sigma_i)*CS%basal_stress_cutoff)
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1956,7 +1956,12 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
 
         ! parameters for the log-normal
         mu_i    = log(m_i/(CS%onemeter * sqrt(1.0 + v_i/m_i**2)))
-        sigma_i = max(sqrt(log(1.0 + v_i/m_i**2)), CS%puny)
+        sigma_i = 0.0
+        if (v_i > 0.0) then
+          sigma_i = max(sqrt(log(1.0 + v_i/m_i**2)), CS%puny)
+        else
+          sigma_i = CS%puny
+        endif
 
         ! max thickness associated with percentile of log-normal PDF
         ! x_kmax=x997 was obtained from an optimization procedure (Dupont et al.)
@@ -1975,7 +1980,6 @@ subroutine basal_stress_coeff_itd(G, IG, IST, sea_lev, CS)
         enddo
         x_kmax = min(cut, x_kmax)
 
-        sigma_i = max(sigma_i, CS%puny)
         g_k(:) = exp(-(log(x_k(:)/CS%onemeter) - mu_i) ** 2 / (2.0 * sigma_i ** 2)) / &
                  (x_k(:) * sigma_i * sqrt(2.0 * pi))
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1173,46 +1173,6 @@ subroutine set_ice_surface_state(Ice, IST, OSS, Rad, FIA, G, US, IG, fCS)
 end subroutine set_ice_surface_state
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
-!### set_ice_optics might not be used.
-!> Determine the sea ice shortwave optical properties
-subroutine set_ice_optics(IST, OSS, Tskin_ice, coszen, Rad, G, US, IG, optics_CSp)
-  type(ice_state_type),    intent(in)    :: IST !< A type describing the state of the sea ice
-  type(simple_OSS_type),   intent(in)    :: OSS !< A structure containing the arrays that describe
-                                                !! the ocean's surface state for the ice model.
-  type(SIS_hor_grid_type), intent(in)    :: G   !< The horizontal grid type
-  type(unit_scale_type),   intent(in)    :: US  !< A structure with unit conversion factors
-  type(ice_grid_type),     intent(in)    :: IG  !< The sea-ice specific grid type
-  real, dimension(G%isd:G%ied, G%jsd:G%jed, IG%CatIce), &
-                           intent(in)    :: Tskin_ice !< The sea ice skin temperature [C ~> degC].
-  real, dimension(G%isd:G%ied, G%jsd:G%jed), &
-                           intent(in)    :: coszen  !< Cosine of the solar zenith angle for this step
-  type(ice_rad_type),      intent(inout) :: Rad !< A structure with fields related to the absorption,
-                                                !! reflection and transmission of shortwave radiation.
-  type(SIS_optics_CS),     intent(in)    :: optics_CSp !< The control structure for optics calculations
-
-  real, dimension(IG%NkIce) :: sw_abs_lay ! The fraction of the absorbed shortwave that is
-                                          ! absorbed in each of the ice layers, <=1, [nondim].
-  real :: albedos(4)  ! The albedos for the various wavelength and direction bands
-                      ! for the current partition, non-dimensional and 0 to 1.
-  integer :: i, j, k, m, isc, iec, jsc, jec, ncat
-
-  isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec ; ncat = IG%CatIce
-
-  !$OMP parallel do default(shared) private(albedos, sw_abs_lay)
-  do j=jsc,jec ; do k=1,ncat ; do i=isc,iec ; if (IST%part_size(i,j,k) > 0.0) then
-    call ice_optics_SIS2(IST%mH_pond(i,j,k), IST%mH_snow(i,j,k), IST%mH_ice(i,j,k), &
-             Tskin_ice(i,j,k), OSS%T_fr_ocn(i,j), IG%NkIce, &
-             albedos, Rad%sw_abs_sfc(i,j,k),  Rad%sw_abs_snow(i,j,k), &
-             sw_abs_lay, Rad%sw_abs_ocn(i,j,k), Rad%sw_abs_int(i,j,k), &
-             US, optics_CSp, IST%ITV, coszen_in=coszen(i,j))
-
-    do m=1,IG%NkIce ; Rad%sw_abs_ice(i,j,k,m) = sw_abs_lay(m) ; enddo
-
-  endif ; enddo ; enddo ; enddo
-
-end subroutine set_ice_optics
-
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> update_ice_model_fast records fluxes (in Ice) and calculates ice temperature
 !!    on the (fast) atmospheric timestep
 subroutine update_ice_model_fast( Atmos_boundary, Ice )


### PR DESCRIPTION
- We can't divide by zero, so don't let sigma_i be zero.