### PR TITLE
Correct interspersed option in the combined ice-ocean driver

### DIFF
--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -9,23 +9,26 @@ module combined_ice_ocean_driver
 ! This module provides a common interface for jointly stepping SIS2 and MOM6, and
 ! will evolve as a platform for tightly integrating the ocean and sea ice models.
 
-use MOM_coupler_types, only : coupler_type_copy_data, coupler_type_data_override
-use MOM_coupler_types, only : coupler_type_send_data
-use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_COMPONENT
-use MOM_data_override, only : data_override
-use MOM_domains,       only : domain2D, same_domain
-use MOM_error_handler, only : MOM_error, FATAL, WARNING, callTree_enter, callTree_leave
-use MOM_file_parser,   only : param_file_type, open_param_file, close_param_file
-use MOM_file_parser,   only : read_param, get_param, log_param, log_version
-use MOM_io,            only : file_exists, close_file, slasher, ensembler
-use MOM_io,            only : open_namelist_file, check_nml_error
-use MOM_time_manager,  only : time_type, time_type_to_real, real_to_time_type
-use MOM_time_manager,  only : operator(+), operator(-), operator(>)
+use MOM_coupler_types,  only : coupler_type_copy_data, coupler_type_data_override
+use MOM_coupler_types,  only : coupler_type_send_data
+use MOM_cpu_clock,      only : cpu_clock_id, cpu_clock_begin, cpu_clock_end, CLOCK_COMPONENT
+use MOM_data_override,  only : data_override
+use MOM_domains,        only : domain2D, same_domain
+use MOM_error_handler,  only : MOM_error, FATAL, WARNING, callTree_enter, callTree_leave
+use MOM_file_parser,    only : param_file_type, open_param_file, close_param_file
+use MOM_file_parser,    only : read_param, get_param, log_param, log_version
+use MOM_io,             only : file_exists, close_file, slasher, ensembler
+use MOM_io,             only : open_namelist_file, check_nml_error
+use MOM_time_manager,   only : time_type, time_type_to_real, real_to_time_type
+use MOM_time_manager,   only : operator(+), operator(-), operator(>) 
 
-use ice_model_mod,     only : ice_data_type, ice_model_end
-use ice_model_mod,     only : update_ice_slow_thermo, update_ice_dynamics_trans
-use ocean_model_mod,   only : update_ocean_model, ocean_model_end
-use ocean_model_mod,   only : ocean_public_type, ocean_state_type, ice_ocean_boundary_type
+use ice_model_mod,      only : ice_data_type, ice_model_end
+use ice_model_mod,      only : update_ice_slow_thermo, update_ice_dynamics_trans
+use ocean_model_mod,    only : update_ocean_model, ocean_model_end
+use ocean_model_mod,    only : ocean_public_type, ocean_state_type, ice_ocean_boundary_type
+use ice_boundary_types, only : ocean_ice_boundary_type
+
+use ice_model_mod,      only : unpack_ocn_ice_bdry
 
 implicit none ; private
 
@@ -48,6 +51,7 @@ end type ice_ocean_driver_type
 
 !>@{ CPU time clock IDs
 integer :: fluxIceOceanClock
+integer :: fluxOceanIceClock
 !!@}
 
 contains
@@ -139,7 +143,7 @@ end subroutine ice_ocean_driver_init
 !>   The subroutine update_slow_ice_and_ocean uses the forcing already stored in
 !! the ice_data_type to advance both the sea-ice (and icebergs) and ocean states
 !! for a time interval coupling_time_step.
-subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, &
+subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
                                      time_start_update, coupling_time_step)
   type(ice_ocean_driver_type), &
                            pointer       :: CS   !< The control structure for this driver
@@ -155,6 +159,10 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, &
   type(time_type),         intent(in)    :: coupling_time_step !< The amount of time over which to advance
                                                                !! the ocean and ice
 
+  type(ocean_ice_boundary_type), &
+       intent(inout) :: OIB !< A structure containing information about
+              !! the ocean that is being shared wth the sea-ice.
+              !! should probably be inout like IOB but this is fine for now
   ! Local variables
   type(time_type) :: time_start_step ! The start time within an iterative update cycle.
   real :: dt_coupling        ! The time step of the thermodynamic update calls [s].
@@ -189,10 +197,18 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, &
 
   if (CS%intersperse_ice_ocn) then
     ! First step the ice, then ocean thermodynamics.
+    call direct_flux_ice_to_IOB(time_start_update, Ice,   IOB, do_thermo=.true.)
+    call direct_flux_ocn_to_OIB(time_start_update, Ocean_sfc, OIB, do_thermo=.true.)
+    call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
+                           Ice%sCS%specified_ice, Ice%ocean_fields)
+    
     call update_ice_slow_thermo(Ice)
 
-    call direct_flux_ice_to_IOB(time_start_update, Ice, IOB, do_thermo=.true.)
-
+    call direct_flux_ice_to_IOB(time_start_update, Ice,   IOB, do_thermo=.true.)
+    call direct_flux_ocn_to_OIB(time_start_update, Ocean_sfc, OIB, do_thermo=.true.)
+    call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
+                           Ice%sCS%specified_ice, Ice%ocean_fields)
+                           
     call update_ocean_model(IOB, Ocn, Ocean_sfc, time_start_update, coupling_time_step, &
                             update_dyn=.false., update_thermo=.true., &
                             start_cycle=.true., end_cycle=.false., cycle_length=dt_coupling)
@@ -217,6 +233,12 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, &
       call update_ocean_model(IOB, Ocn, Ocean_sfc, time_start_step, dyn_time_step, &
                               update_dyn=.true., update_thermo=.false., &
                               start_cycle=.false., end_cycle=(ns==nstep), cycle_length=dt_coupling)
+
+      call direct_flux_ocn_to_OIB(time_start_step, Ocean_sfc, OIB, do_thermo=.false.)
+      ! calling unpack OIB to transfer OIB info to Ice%sCS%OSS
+      call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
+                           Ice%sCS%specified_ice, Ice%ocean_fields)
+           
       time_start_step = time_start_step + dyn_time_step
     enddo
   else
@@ -332,6 +354,71 @@ subroutine direct_flux_ice_to_IOB(Time, Ice, IOB, do_thermo)
 
 end subroutine direct_flux_ice_to_IOB
 
+!> This subroutine does a direct copy of the fluxes from the ocean public type into
+!! a ocean-ice boundary type on the same grid.
+!! This is analogous to the flux_ocean_to_ice subroutine in ice_ocean_flux_exchange.F90
+!! but assumes the sea ice and ocean are on the same grid and does a direct copy as in
+!! direct_flux_ice_to_IOB above. The thermodynamic varibles are also seperated so only 
+!! the dynamics are updated.
+!! The data_override is similar to flux_ocean_to_ice_finish
+subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, do_thermo)
+  type(time_type),    intent(in)     :: Time  !< Current time
+  type(ocean_public_type),intent(in) :: Ocean !< A derived data type to specify ocean boundary data
+  type(ocean_ice_boundary_type), intent(in)    :: OIB !< A type containing ocean surface fields that
+                                                      !! are used to drive the sea ice
+  logical,  optional, intent(in)     :: do_thermo !< If present and false, do not update the
+                                              !! thermodynamic or tracer fluxes.
+  logical :: used, do_therm
+
+  call cpu_clock_begin(fluxOceanIceClock)
+
+  do_therm = .true. ; if (present(do_thermo)) do_therm = do_thermo                                              
+                                              
+  if( ASSOCIATED(OIB%u)     )OIB%u = Ocean%u_surf
+  if( ASSOCIATED(OIB%v)     )OIB%v = Ocean%v_surf
+  if( ASSOCIATED(OIB%u_sym) )OIB%u_sym = Ocean%u_surf_sym
+  if( ASSOCIATED(OIB%v_sym) )OIB%v_sym = Ocean%v_surf_sym
+  if( ASSOCIATED(OIB%sea_level) )OIB%sea_level = Ocean%sea_lev
+  
+  if (do_therm) then
+   if( ASSOCIATED(OIB%t)     )OIB%t = Ocean%t_surf
+   if( ASSOCIATED(OIB%s)     )OIB%s = Ocean%s_surf
+   if( ASSOCIATED(OIB%frazil) ) then
+   !if(do_area_weighted_flux) then
+   !  OIB%frazil = Ocean%frazil * Ocean%area
+   !  call divide_by_area(OIB%frazil, Ice%area)
+   !else
+     OIB%frazil = Ocean%frazil
+   !endif
+   endif                                              
+  endif           
+  
+  ! Extra fluxes
+  !call coupler_type_copy_data(Ocean%fields, OIB%fields)
+  
+  call data_override('ICE', 'u',         OIB%u,         Time)
+  call data_override('ICE', 'v',         OIB%v,         Time)
+  if (ASSOCIATED(OIB%u_sym)) &
+      call data_override('ICE', 'u_sym', OIB%u_sym, Time)
+  if (ASSOCIATED(OIB%v_sym)) &
+      call data_override('ICE', 'v_sym', OIB%v_sym, Time)
+  call data_override('ICE', 'sea_level', OIB%sea_level, Time)
+   
+  !call coupler_type_data_override('ICE', OIB%fields, Time)
+                                    
+  if (do_therm) then
+    call data_override('ICE', 't',         OIB%t,         Time)
+    call data_override('ICE', 's',         OIB%s,         Time)
+    call data_override('ICE', 'frazil',    OIB%frazil,    Time)
+  endif
+ 
+  !Perform diagnostic output for the ocean_ice_boundary fields
+  !call coupler_type_send_data( OIB%fields, Time)
+  
+                                              
+end subroutine direct_flux_ocn_to_OIB                                        
+                                            
+                                            
 !=======================================================================
 !>   The subroutine ice_ocean_driver_end terminates the model run, saving
 !! the ocean and slow ice states in restart files and deallocating any data

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -155,12 +155,12 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
                                                  !! fields going from the ice to the ocean
                                                  !! The arrays of this type are intent out; they are
                                                  !! used externally for stocks and other diagnostics.
+  type(ocean_ice_boundary_type), optional, &
+                          intent(inout) :: OIB !< A structure containing information about
+                                                 !! the ocean that is being shared wth the sea-ice.
   type(time_type),         intent(in)    :: time_start_update  !< The time at the beginning of the update step
   type(time_type),         intent(in)    :: coupling_time_step !< The amount of time over which to advance
                                                                !! the ocean and ice
-
-  type(ocean_ice_boundary_type), intent(inout) :: OIB !< A structure containing information about
-                                                 !! the ocean that is being shared wth the sea-ice.
   ! Local variables
   type(time_type) :: time_start_step ! The start time within an iterative update cycle.
   real :: dt_coupling        ! The time step of the thermodynamic update calls [s].

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -184,6 +184,12 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
                     "ocean_state_type structure. ocean_model_init must be "//  &
                     "called first to allocate this structure.")
   endif
+  if (.not.associated(OIB)) then
+    call MOM_error(FATAL, "update_ocean_model called with an unassociated "// &
+                    "ocean_ice_boundary. This type is required to properly "//  &
+                    "couple the sea-ice and ocean. It should be added where "// &
+                    "this routine is called in coupler_main.")
+  endif
 
   if (.not.(Ocean_sfc%is_ocean_pe .and. Ice%slow_ice_pe)) call MOM_error(FATAL, &
         "update_slow_ice_and_ocean can only be called from PEs that handle both "//&

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -159,10 +159,8 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
   type(time_type),         intent(in)    :: coupling_time_step !< The amount of time over which to advance
                                                                !! the ocean and ice
 
-  type(ocean_ice_boundary_type), &
-       intent(inout) :: OIB !< A structure containing information about
-              !! the ocean that is being shared wth the sea-ice.
-              !! should probably be inout like IOB but this is fine for now
+  type(ocean_ice_boundary_type), intent(inout) :: OIB !< A structure containing information about
+                                                 !! the ocean that is being shared wth the sea-ice.
   ! Local variables
   type(time_type) :: time_start_step ! The start time within an iterative update cycle.
   real :: dt_coupling        ! The time step of the thermodynamic update calls [s].
@@ -197,17 +195,10 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
 
   if (CS%intersperse_ice_ocn) then
     ! First step the ice, then ocean thermodynamics.
-    call direct_flux_ice_to_IOB(time_start_update, Ice,   IOB, do_thermo=.true.)
-    call direct_flux_ocn_to_OIB(time_start_update, Ocean_sfc, OIB, do_thermo=.true.)
-    call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
-                           Ice%sCS%specified_ice, Ice%ocean_fields)
-    
-    call update_ice_slow_thermo(Ice)
+    call direct_flux_ocn_to_OIB(time_start_update, Ocean_sfc, OIB, Ice, do_thermo=.true.)
 
+    call update_ice_slow_thermo(Ice)
     call direct_flux_ice_to_IOB(time_start_update, Ice,   IOB, do_thermo=.true.)
-    call direct_flux_ocn_to_OIB(time_start_update, Ocean_sfc, OIB, do_thermo=.true.)
-    call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
-                           Ice%sCS%specified_ice, Ice%ocean_fields)
                            
     call update_ocean_model(IOB, Ocn, Ocean_sfc, time_start_update, coupling_time_step, &
                             update_dyn=.false., update_thermo=.true., &
@@ -218,12 +209,12 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
     nstep = 1
     if ((CS%dt_coupled_dyn > 0.0) .and. (CS%dt_coupled_dyn < dt_coupling))&
       nstep = max(CEILING(dt_coupling/CS%dt_coupled_dyn - 1e-6), 1)
-    dyn_time_step = real_to_time_type(dt_coupling / real(nstep))
-    time_start_step = time_start_update
+      dyn_time_step = real_to_time_type(dt_coupling / real(nstep))
+      time_start_step = time_start_update
     do ns=1,nstep
-      if (ns==nstep) then ! Adjust the dyn_time_step to cover uneven fractions of a tick or second.
-        dyn_time_step = coupling_time_step - (time_start_step - time_start_update)
-      endif
+    if (ns==nstep) then ! Adjust the dyn_time_step to cover uneven fractions of a tick or second.
+      dyn_time_step = coupling_time_step - (time_start_step - time_start_update)
+    endif
 
       call update_ice_dynamics_trans(Ice, time_step=dyn_time_step, &
                         start_cycle=(ns==1), end_cycle=(ns==nstep), cycle_length=dt_coupling)
@@ -234,10 +225,7 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
                               update_dyn=.true., update_thermo=.false., &
                               start_cycle=.false., end_cycle=(ns==nstep), cycle_length=dt_coupling)
 
-      call direct_flux_ocn_to_OIB(time_start_step, Ocean_sfc, OIB, do_thermo=.false.)
-      ! calling unpack OIB to transfer OIB info to Ice%sCS%OSS
-      call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
-                           Ice%sCS%specified_ice, Ice%ocean_fields)
+      call direct_flux_ocn_to_OIB(time_start_step, Ocean_sfc, OIB, Ice, do_thermo=.false.)
            
       time_start_step = time_start_step + dyn_time_step
     enddo
@@ -361,18 +349,22 @@ end subroutine direct_flux_ice_to_IOB
 !! direct_flux_ice_to_IOB above. The thermodynamic varibles are also seperated so only 
 !! the dynamics are updated.
 !! The data_override is similar to flux_ocean_to_ice_finish
-subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, do_thermo)
+subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, Ice, do_thermo)
   type(time_type),    intent(in)     :: Time  !< Current time
   type(ocean_public_type),intent(in) :: Ocean !< A derived data type to specify ocean boundary data
-  type(ocean_ice_boundary_type), intent(in)    :: OIB !< A type containing ocean surface fields that
+  type(ocean_ice_boundary_type), intent(inout)   :: OIB !< A type containing ocean surface fields that
                                                       !! are used to drive the sea ice
   logical,  optional, intent(in)     :: do_thermo !< If present and false, do not update the
                                               !! thermodynamic or tracer fluxes.
-  logical :: used, do_therm
+  type(ice_data_type), &
+    intent(inout) :: Ice            !< The publicly visible ice data type in the slow part
+                                    !! of which the ocean surface information is to be stored.                                            
+  logical :: used, do_therm, do_area_weighted_flux
 
   call cpu_clock_begin(fluxOceanIceClock)
 
   do_therm = .true. ; if (present(do_thermo)) do_therm = do_thermo                                              
+  do_area_weighted_flux = .false. !! Need to add option to account for area weighted fluxes                           
                                               
   if( ASSOCIATED(OIB%u)     )OIB%u = Ocean%u_surf
   if( ASSOCIATED(OIB%v)     )OIB%v = Ocean%v_surf
@@ -384,12 +376,12 @@ subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, do_thermo)
    if( ASSOCIATED(OIB%t)     )OIB%t = Ocean%t_surf
    if( ASSOCIATED(OIB%s)     )OIB%s = Ocean%s_surf
    if( ASSOCIATED(OIB%frazil) ) then
-   !if(do_area_weighted_flux) then
-   !  OIB%frazil = Ocean%frazil * Ocean%area
-   !  call divide_by_area(OIB%frazil, Ice%area)
-   !else
+   if(do_area_weighted_flux) then
+     OIB%frazil = Ocean%frazil * Ocean%area
+     call divide_by_area(OIB%frazil, Ice%area)
+   else
      OIB%frazil = Ocean%frazil
-   !endif
+   endif
    endif                                              
   endif           
   
@@ -413,8 +405,10 @@ subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, do_thermo)
   endif
  
   !Perform diagnostic output for the ocean_ice_boundary fields
-  !call coupler_type_send_data( OIB%fields, Time)
-  
+  !call unpack_ocn_ice_bdry 
+  call unpack_ocn_ice_bdry(OIB, Ice%sCS%OSS, Ice%sCS%IST%ITV, Ice%sCS%G, Ice%sCS%US, &
+                                Ice%sCS%specified_ice, Ice%ocean_fields)
+    
                                               
 end subroutine direct_flux_ocn_to_OIB                                        
                                             

--- a/src/combined_ice_ocean_driver.F90
+++ b/src/combined_ice_ocean_driver.F90
@@ -184,7 +184,7 @@ subroutine update_slow_ice_and_ocean(CS, Ice, Ocn, Ocean_sfc, IOB, OIB,&
                     "ocean_state_type structure. ocean_model_init must be "//  &
                     "called first to allocate this structure.")
   endif
-  if (.not.associated(OIB)) then
+  if (.not.present(OIB)) then
     call MOM_error(FATAL, "update_ocean_model called with an unassociated "// &
                     "ocean_ice_boundary. This type is required to properly "//  &
                     "couple the sea-ice and ocean. It should be added where "// &
@@ -383,12 +383,12 @@ subroutine direct_flux_ocn_to_OIB(Time, Ocean, OIB, Ice, do_thermo)
    if( ASSOCIATED(OIB%t)     )OIB%t = Ocean%t_surf
    if( ASSOCIATED(OIB%s)     )OIB%s = Ocean%s_surf
    if( ASSOCIATED(OIB%frazil) ) then
-   if(do_area_weighted_flux) then
-     OIB%frazil = Ocean%frazil * Ocean%area
-     call divide_by_area(OIB%frazil, Ice%area)
-   else
+!   if(do_area_weighted_flux) then
+!     OIB%frazil = Ocean%frazil * Ocean%area
+!     call divide_by_area(OIB%frazil, Ice%area)
+!   else
      OIB%frazil = Ocean%frazil
-   endif
+!   endif
    endif                                              
   endif           
   

--- a/src/ice_boundary_types.F90
+++ b/src/ice_boundary_types.F90
@@ -32,6 +32,10 @@ type ocean_ice_boundary_type
                          !! determined by stagger [m s-1].
     v      => NULL(), &  !< The y-direction ocean velocity at a position
                          !! determined by stagger [m s-1].
+    u_sym  => NULL(), &  !< The x-direction ocean velocity at a position
+                         !! determined by stagger -symmetric [m s-1].
+    v_sym  => NULL(), &  !< The y-direction ocean velocity at a position
+                         !! determined by stagger -symmetric [m s-1].
     t      => NULL(), &  !< The ocean's surface temperature [Kelvin].
     s      => NULL(), &  !< The ocean's surface salinity [gSalt kg-1].
     frazil => NULL(), &  !< The frazil heat rejected by the ocean [J m-2].
@@ -39,6 +43,7 @@ type ocean_ice_boundary_type
                          !! pressure that the ocean allows to be expressed [m].
   real, dimension(:,:,:), pointer :: data =>NULL() !< S collective field for "named" fields above
   integer   :: stagger = BGRID_NE  !< A flag indicating how the velocities are staggered.
+  logical   :: use_oib_sym = .false.   !< A flag ti indicate whether to use [uv]_sym
   integer   :: xtype     !< A flag indicating the exchange type, which may be set to
                          !! REGRID, REDIST or DIRECT and is used by coupler
   type(coupler_2d_bc_type) :: fields !< An array of fields used for additional tracers

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1598,7 +1598,7 @@ end subroutine add_diurnal_sw
 !> ice_model_init - initializes ice model data, parameters and diagnostics. It
 !! might operate on the fast ice processors, the slow ice processors or both.
 subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, &
-                          Verona_coupler, Concurrent_ice_in, gas_fluxes, gas_fields_ocn )
+                          Verona_coupler, Concurrent_atm, Concurrent_ice_in, gas_fluxes, gas_fields_ocn )
 
   type(ice_data_type), intent(inout) :: Ice            !< The ice data type that is being initialized.
   type(time_type)    , intent(in)    :: Time_Init      !< The starting time of the model integration
@@ -1609,7 +1609,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                                               !! in Ice to determine whether this is a fast or slow
                                               !! ice processor or both.  SIS2 will now throw a fatal
                                               !! error if this is present and true.
-  logical,   optional, intent(in)    :: Concurrent_atm!< If present and true, use sea ice model
+  logical,   optional, intent(in)    :: Concurrent_atm !< If present and true, use sea ice model
                                               !! settings appropriate for running the atmosphere and
                                               !! slow ice simultaneously, including embedding the
                                               !! slow sea-ice time stepping in the ocean model.
@@ -1767,9 +1767,12 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   Concurrent_ice = .false. ;  if (present(Concurrent_ice_in)) Concurrent_ice = Concurrent_ice_in
 
   ! Open the parameter file.
-  if (slow_ice_PE) then
+  if (fast_ice_PE.eqv.slow_ice_PE) then
+    call Get_SIS_Input(param_file, dirs, check_params=.true., component='SIS')  
+    call Get_SIS_Input(param_file, dirs, check_params=.false., component='SIS_fast')
+  elseif (slow_ice_PE) then
     call Get_SIS_Input(param_file, dirs, check_params=.true., component='SIS')
-  else
+  elseif (fast_ice_PE) then
     call Get_SIS_Input(param_file, dirs, check_params=.false., component='SIS_fast')
   endif
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -128,7 +128,7 @@ public :: ice_model_restart  ! for intermediate restarts
 public :: ocn_ice_bnd_type_chksum, atm_ice_bnd_type_chksum
 public :: lnd_ice_bnd_type_chksum, ice_data_type_chksum
 public :: update_ice_atm_deposition_flux
-public :: unpack_ocean_ice_boundary, exchange_slow_to_fast_ice, set_ice_surface_fields
+public :: unpack_ocean_ice_boundary, unpack_ocn_ice_bdry, exchange_slow_to_fast_ice, set_ice_surface_fields
 public :: ice_model_fast_cleanup, unpack_land_ice_boundary
 public :: exchange_fast_to_slow_ice, update_ice_model_slow
 public :: update_ice_slow_thermo, update_ice_dynamics_trans

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -49,6 +49,7 @@ type ice_data_type !  ice_public_type
   logical  :: fast_ice_pe = .false. !< If true, this is a fast ice PE
   logical  :: shared_slow_fast_PEs = .true. !< If true, the fast and slow ice use the same processors
                                     !! and domain decomposition
+  logical  :: use_oib_sym = .false. !< If true, use symmetic velocities from the ocean surface
   integer  :: xtype          !< An integer specifying the type for the exchange
   integer, pointer, dimension(:)   :: slow_pelist =>NULL() !< Used for flux-exchange with slow processes.
   integer, pointer, dimension(:)   :: fast_pelist =>NULL() !< Used for flux-exchange with fast processes.


### PR DESCRIPTION
Changes are to the combined ice-ocean driver (CIOD) to pass the state of the ocean to the ice through the OIB  (ocean ice boundary type). A new subroutine has been added to combined_ice_ocean_driver.F90: direct_flux_ocn_to_OIB which is analogous to the existing direct_flux_ice_to_IOB subroutine. The new subroutine assumes the ocean and ice are on the same model grid and that the do_area_weighted_flux option is false for the frazil ice. 

This new version of the CIOD requires the OIB as an input when update_slow_ice_and_ocean is called. Currently it is an optional argument, but there is a fatal error if the CIOD is used without it. Therefore, to use the corrected version of the CIOD the call to update_slow_ice_and_ocean in coupler_main must be modified. 

The direct_flux_ocn_to_OIB subroutine uses the unpack_ocn_ice_bdry subroutine from the ice_model module. The routine is changed to public and the use statement is added to the CIOD.

In addition, an option to use symmetric surface velocities from MOM6 in the ocean_ice_boundary type has been added. This has been added to the ocean ice boundary type in ice_types and a flag to use this option has been added to the ice_public_type. This option has been added to the unpack_ocn_ice_bdry subroutine in order to copy the symmetric ocean surface velocity from the OIB to the ocean_sfc_state_type (OSS) embedded in the ice_data_type that is used by the ice dynamics. 

This PR will change answers for the coupled_AM2_LM3_SIS2/Intersperse_ice_1deg simulation, but should not change the solutions of any setup that does not use the interspersed option of the combined ice-ocean driver.

