### PR TITLE
Use open_ASCII_file for sum output

### DIFF
--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -21,7 +21,7 @@ use MOM_file_parser,   only : get_param, log_param, read_param, log_version, par
 use MOM_domains,       only : pass_var, pass_vector, CGRID_NE, CORNER, pe_here
 use MOM_domains,       only : MOM_domain_type, clone_MOM_domain
 use MOM_hor_index,     only : hor_index_type
-use MOM_io,            only : open_file, APPEND_FILE, ASCII_FILE, MULTIPLE, SINGLE_FILE
+use MOM_io,            only : open_ASCII_file, APPEND_FILE, ASCII_FILE, MULTIPLE, SINGLE_FILE
 use MOM_io,            only : MOM_read_data
 use MOM_time_manager,  only : time_type, real_to_time, operator(+), operator(-)
 use MOM_time_manager,  only : set_date, get_time, get_date
@@ -2171,8 +2171,8 @@ subroutine write_u_trunc(I, j, ui, u_IC, uo, mis, fxoc, fxic, Cor_u, PFu, fxat, 
   ! Open up the file for output if this is the first call.
     if (CS%u_file < 0) then
       if (len_trim(CS%u_trunc_file) < 1) return
-      call open_file(CS%u_file, trim(CS%u_trunc_file), action=APPEND_FILE, &
-                     form=ASCII_FILE, threading=MULTIPLE, fileset=SINGLE_FILE)
+      call open_ASCII_file(CS%u_file, trim(CS%u_trunc_file), &
+          action=APPEND_FILE)
       if (CS%u_file < 0) then
         call SIS_error(NOTE, 'Unable to open file '//trim(CS%u_trunc_file)//'.')
         return
@@ -2247,8 +2247,8 @@ subroutine write_v_trunc(i, J, vi, v_IC, vo, mis, fyoc, fyic, Cor_v, PFv, fyat, 
   ! Open up the file for output if this is the first call.
     if (CS%v_file < 0) then
       if (len_trim(CS%v_trunc_file) < 1) return
-      call open_file(CS%v_file, trim(CS%v_trunc_file), action=APPEND_FILE, &
-                     form=ASCII_FILE, threading=MULTIPLE, fileset=SINGLE_FILE)
+      call open_ASCII_file(CS%v_file, trim(CS%v_trunc_file), &
+          action=APPEND_FILE)
       if (CS%v_file < 0) then
         call SIS_error(NOTE, 'Unable to open file '//trim(CS%v_trunc_file)//'.')
         return

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -19,7 +19,7 @@ use MOM_coms,          only : EFP_sum_across_PEs, max_across_PEs
 use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 ! use MOM_io,          only : create_file, fieldtype, flush_file, reopen_file, vardesc, write_field
-use MOM_io,            only : open_file, APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
+use MOM_io,            only : open_ASCII_file, APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_string_functions, only : slasher
 use MOM_time_manager,  only : time_type, get_time, operator(>), operator(-)
 use MOM_time_manager,  only : get_date, get_calendar_type, NO_CALENDAR
@@ -369,11 +369,11 @@ subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_colum
     !  Reopen or create a text output file, with an explanatory header line.
     if (is_root_pe()) then
       if (day > CS%Start_time) then
-        call open_file(CS%statsfile_ascii, trim(CS%statsfile), &
-                       action=APPEND_FILE, form=ASCII_FILE, nohdrs=.true.)
+        call open_ASCII_file(CS%statsfile_ascii, trim(CS%statsfile), &
+            action=APPEND_FILE)
       else
-        call open_file(CS%statsfile_ascii, trim(CS%statsfile), &
-                       action=WRITEONLY_FILE, form=ASCII_FILE, nohdrs=.true.)
+        call open_ASCII_file(CS%statsfile_ascii, trim(CS%statsfile), &
+            action=WRITEONLY_FILE)
         if (abs(CS%timeunit - 86400.0) < 1.0) then
           write(CS%statsfile_ascii,'("  Step,",7x,"Day,",28x,"Area(N/S),",22x,"Extent(N/S),",27x,&
               &"Mass(N/S),",22x,"Heat(N/S),",14x,"Salinty(N/S),   Frac Mass Err,   Temp Err,   Salin Err")')


### PR DESCRIPTION
The generic `open_file` call was replaced with the targeted `open_ASCII_file` function, since the generic `open_file` no longer works with the updated FMS2 `open_file` interface in MOM6.