### PR TITLE
Correct interspersed option in the CIOD

### DIFF
--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1007,6 +1007,9 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
+      if (nds>1) &
+        call pass_var(DS2d%mca_step(:,:,DS2d%nts), G%Domain, complete=.true.)
+
       call cpu_clock_begin(iceClocka)
       !### Ridging needs to be added with C-grid dynamics.
       if (CS%do_ridging) rdg_rate(:,:) = 0.0

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -128,7 +128,7 @@ public :: ice_model_restart  ! for intermediate restarts
 public :: ocn_ice_bnd_type_chksum, atm_ice_bnd_type_chksum
 public :: lnd_ice_bnd_type_chksum, ice_data_type_chksum
 public :: update_ice_atm_deposition_flux
-public :: unpack_ocean_ice_boundary, exchange_slow_to_fast_ice, set_ice_surface_fields
+public :: unpack_ocean_ice_boundary, unpack_ocn_ice_bdry, exchange_slow_to_fast_ice, set_ice_surface_fields
 public :: ice_model_fast_cleanup, unpack_land_ice_boundary
 public :: exchange_fast_to_slow_ice, update_ice_model_slow
 public :: update_ice_slow_thermo, update_ice_dynamics_trans
@@ -1719,7 +1719,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   logical :: recategorize_ice ! If true, adjust the distribution of the ice among thickness
                               ! categories after initialization.
   logical :: Verona
-  logical :: Concurrent
+  logical :: split_fast_slow_flag
   logical :: read_aux_restart
   logical :: split_restart_files
   logical :: is_restart = .false.
@@ -1737,7 +1737,8 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   Verona = .false. ; if (present(Verona_coupler)) Verona = Verona_coupler
   if (Verona) call SIS_error(FATAL, "SIS2 no longer works with pre-Warsaw couplers.")
   fast_ice_PE = Ice%fast_ice_pe ; slow_ice_PE = Ice%slow_ice_pe
-  Concurrent = .false. ; if (present(Concurrent_ice)) Concurrent = Concurrent_ice
+  split_fast_slow_flag = .false. ;
+  if (present(Concurrent_ice)) split_fast_slow_flag = Concurrent_ice
 
   ! Open the parameter file.
   if (slow_ice_PE) then
@@ -1938,7 +1939,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   call get_param(param_file, "MOM", "REDO_FAST_ICE_UPDATE", redo_fast_update, &
                  "If true, recalculate the thermal updates from the fast "//&
                  "dynamics on the slowly evolving ice state, rather than "//&
-                 "copying over the slow ice state to the fast ice state.", default=Concurrent)
+                 "copying over the slow ice state to the fast ice state.", default=split_fast_slow_flag)
 
   call get_param(param_file, mdl, "NUDGE_SEA_ICE", nudge_sea_ice, &
                  "If true, constrain the sea ice concentrations using observations.", &
@@ -1974,7 +1975,6 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   elseif (uppercase(stagger(1:1)) == 'C') then ; Ice%flux_uv_stagger = CGRID_NE
   else ; call SIS_error(FATAL,"ice_model_init: ICE_OCEAN_STRESS_STAGGER = "//&
                         trim(stagger)//" is invalid.") ; endif
-
   Ice%Time = Time
 
   !   Now that all top-level sea-ice parameters have been read, allocate the
@@ -2221,7 +2221,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     Ice%fCS%Rad%do_sun_angle_for_alb = do_sun_angle_for_alb
     Ice%fCS%Rad%add_diurnal_sw = add_diurnal_sw
 
-    if (Concurrent) then
+    if (split_fast_slow_flag) then
       call register_fast_to_slow_restarts(Ice%fCS%FIA, Ice%fCS%Rad, Ice%fCS%TSF, &
                        fGD%mpp_domain, US, Ice%Ice_fast_restart, fast_rest_file)
     endif
@@ -2497,7 +2497,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       ! Read the fast restart file, if it exists and this is indicated by the value of dirs%input_filename.
       new_sim = determine_is_new_run(dirs%input_filename, dirs%restart_input_dir, fG, Ice%Ice_fast_restart)
       if (.not.new_sim) then
-        call restore_SIS_state(Ice%Ice_restart, dirs%restart_input_dir, dirs%input_filename, fG)
+        call restore_SIS_state(Ice%Ice_fast_restart, dirs%restart_input_dir, dirs%input_filename, fG)
         init_coszen = .not.query_initialized(Ice%Ice_fast_restart, 'coszen')
         init_Tskin  = .not.query_initialized(Ice%Ice_fast_restart, 'T_skin')
         init_rough  = .not.(query_initialized(Ice%Ice_fast_restart, 'rough_mom') .and. &
@@ -2508,7 +2508,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       endif
     endif
 
-    if (Concurrent) then
+    if (split_fast_slow_flag) then
       call rescale_fast_to_slow_restart_fields(Ice%fCS%FIA, Ice%fCS%Rad, Ice%fCS%TSF, &
                                                Ice%fCS%G, US, Ice%fCS%IG)
     endif
@@ -2588,6 +2588,11 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
   else
     Ice%xtype = REDIST
   endif
+
+!  if (fast_ice_PE .and. slow_ice_PE) then
+!  if (split_fast_slow_flag) then
+!    call exchange_fast_to_slow_ice(Ice)
+!  endif
 
   if (Ice%shared_slow_fast_PEs) then
     iceClock = cpu_clock_id( 'Ice', grain=CLOCK_COMPONENT )

--- a/src/ice_type.F90
+++ b/src/ice_type.F90
@@ -506,7 +506,7 @@ subroutine ice_model_restart(Ice, time_stamp)
   type(ice_data_type),        intent(inout) :: Ice !< The publicly visible ice data type.
   character(len=*), optional, intent(in)    :: time_stamp !< A date stamp to include in the restart file name
 
-  if (associated(Ice%Ice_restart)) then
+  if (associated(Ice%Ice_restart) .and. associated(Ice%sCS)) then
     call save_restart(Ice%restart_output_dir, Ice%Time, Ice%sCS%G, Ice%Ice_restart, IG=Ice%sCS%IG, &
                       time_stamp=time_stamp)
     if (associated(Ice%Ice_fast_restart)) then


### PR DESCRIPTION
Changes to the combined ice-ocean driver (CIOD) to fix a bug. The state of the ocean is now passed to the ice through the OIB (ocean ice boundary type). A new subroutine has been added to combined_ice_ocean_driver.F90: direct_flux_ocn_to_OIB which is analogous to the existing direct_flux_ice_to_IOB subroutine. The new subroutine assumes the ocean and ice are on the same model grid and that the do_area_weighted_flux option is false for the frazil ice.

This new version of the CIOD requires the OIB as an input when update_slow_ice_and_ocean is called. Currently it is an optional argument, but there is a fatal error if the CIOD is used without it. Therefore, to use the corrected version of the CIOD the call to update_slow_ice_and_ocean in coupler_main must be modified.

The ice_model_init routine is changed in two ways. First, the concurrent atmosphere and concurrent ice options are now both inputs so they are no longer assumed to be the same. Second, there are minor changes to the slow and fast processor calls so the slow/fast processors can be shared. 

The direct_flux_ocn_to_OIB subroutine uses the unpack_ocn_ice_bdry subroutine from the ice_model module. The routine is changed to public and the use statement is added to the CIOD.

This PR will change answers for the coupled_AM2_LM3_SIS2/Intersperse_ice_1deg simulation, but should not change the solutions of any setup that does not use the interspersed option of the combined ice-ocean driver. The coupled_AM2_LM3_SIS2/Intersperse_ice_1deg simulation was run with a slightly modified version of the Xanadu coupler. Note that answers will only change when DT_COUPLED_ICE_OCEAN_DYN is less than dt_cpld. The USE_INTERSPERSE_BUG flag can be used to recover the old version.  

