### PR TITLE
FMS2: Move FMS domain calls to MOM infra

### DIFF
--- a/src/SIS_framework.F90
+++ b/src/SIS_framework.F90
@@ -4,8 +4,6 @@ module SIS_framework
 
 ! This file is part of SIS2. See LICENSE.md for the license.
 
-use fms_io_mod,        only : set_domain, nullify_domain
-
 use MOM_coms_infra,    only : SIS_chksum=>field_chksum
 use MOM_coupler_types, only : coupler_1d_bc_type, coupler_2d_bc_type, coupler_3d_bc_type
 use MOM_coupler_types, only : coupler_type_spawn, coupler_type_initialized, coupler_type_send_data
@@ -15,6 +13,7 @@ use MOM_coupler_types, only : coupler_type_set_diags, coupler_type_write_chksums
 use MOM_domain_infra,  only : MOM_domain_type, domain2D, get_domain_extent
 use MOM_domain_infra,  only : global_field, redistribute_data=>redistribute_array, broadcast_domain
 use MOM_domain_infra,  only : CENTER, CORNER, EAST=>EAST_FACE, NORTH=>NORTH_FACE, EAST_FACE, NORTH_FACE
+use MOM_domain_infra,  only : set_domain, nullify_domain
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser,   only : get_param, read_param, log_param, log_version, param_file_type
 ! use MOM_io,            only : MULTIPLE, READONLY_FILE, SINGLE_FILE

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2031,7 +2031,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     call clone_MOM_domain(sGD, dG%Domain)
 
     ! Set up the restart file and determine whether this is a new simulation.
-    call set_domain(sGD%mpp_domain)
+    call set_domain(sGD)
     if (.not.associated(Ice%Ice_restart)) &
       call SIS_restart_init(Ice%Ice_restart, restart_file, sGD, param_file)
     new_sim = determine_is_new_run(dirs%input_filename, dirs%restart_input_dir, sG, Ice%Ice_restart)
@@ -2189,7 +2189,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
   ! Allocate and register fields for restarts.
 
-    if (.not.slow_ice_PE) call set_domain(fGD%mpp_domain)
+    if (.not.slow_ice_PE) call set_domain(fGD)
     if (split_restart_files) then
       if (.not.associated(Ice%Ice_fast_restart)) &
         call SIS_restart_init(Ice%Ice_fast_restart, fast_rest_file, fGD, param_file)
@@ -2515,7 +2515,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
 
 !  if (Ice%fCS%Rad%add_diurnal_sw .or. Ice%fCS%Rad%do_sun_angle_for_alb) then
-!    call set_domain(fGD%mpp_domain)
+!    call set_domain(fGD)
     call astronomy_init()
 !    call nullify_domain()
 !  endif

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -24,7 +24,6 @@ use MOM_file_parser,   only : get_param, log_param, read_param, log_version, par
 use MOM_unit_scaling,  only : unit_scale_type
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_types,         only : ice_state_type, ist_chksum
-use fms_io_mod,        only : register_restart_field, restart_file_type
 use SIS_tracer_registry, only : SIS_tracer_registry_type, SIS_tracer_type, get_SIS_tracer_pointer
 use SIS2_ice_thm,      only : get_SIS2_thermo_coefs
 use ice_grid,          only : ice_grid_type


### PR DESCRIPTION
The `set_domain` and `nullify_domain` calls used in FMS1 IO now pass through the MOM domain infra.  Explicit references to the internal `mpp_domain` have also been removed.