### PR TITLE
+Changing the ice ridging calls to Icepack

### DIFF
--- a/config_src/external/Icepack_interfaces/icepack_mechred.F90
+++ b/config_src/external/Icepack_interfaces/icepack_mechred.F90
@@ -6,119 +6,114 @@
       implicit none
 
       private
-      public :: ridge_ice
+      public :: icepack_step_ridge
       contains
 
 !-----------------------------------------------------------------------
 !> Interface for updating the sea-ice state due to ice ridging processes
 !! using Icepack.
-      subroutine ridge_ice (dt,          ndtd,       &
-                            ncat,        n_aero,     &
-                            nilyr,       nslyr,      &
-                            ntrcr,       hin_max,    &
-                            rdg_conv,    rdg_shear,  &
-                            aicen,       trcrn,      &
-                            vicen,       vsnon,      &
-                            aice0,                   &
-                            trcr_depend, trcr_base,  &
-                            n_trcr_strata,           &
-                            nt_strata,               &
-                            krdg_partic, krdg_redist,&
-                            mu_rdg,      tr_brine,   &
-                            dardg1dt,    dardg2dt,   &
-                            dvirdgdt,    opening,    &
-                            fpond,                   &
-                            fresh,       fhocn,      &
-                            faero_ocn,   fiso_ocn,   &
-                            aparticn,    krdgn,      &
-                            aredistn,    vredistn,   &
-                            dardg1ndt,   dardg2ndt,  &
-                            dvirdgndt,               &
-                            araftn,      vraftn,     &
-                            closing_flag,closing )
-
-      integer (kind=int_kind), intent(in) :: &
-         ndtd       , & !< Thenumber of dynamics subcycles
-         ncat  , & !< The number of thickness categories
-         nilyr , & !< The number of ice layers
-         nslyr , & !< The number of snow layers
-         n_aero, & !< The number of aerosol tracers
-         ntrcr     !< The number of tracers in use
+      subroutine icepack_step_ridge(dt,           ndtd,          &
+                                    nilyr,        nslyr,         &
+                                    nblyr,                       &
+                                    ncat,         hin_max,       &
+                                    rdg_conv,     rdg_shear,     &
+                                    aicen,                       &
+                                    trcrn,                       &
+                                    vicen,        vsnon,         &
+                                    aice0,        trcr_depend,   &
+                                    trcr_base,    n_trcr_strata, &
+                                    nt_strata,                   &
+                                    dardg1dt,     dardg2dt,      &
+                                    dvirdgdt,     opening,       &
+                                    fpond,                       &
+                                    fresh,        fhocn,         &
+                                    n_aero,                      &
+                                    faero_ocn,    fiso_ocn,      &
+                                    aparticn,     krdgn,         &
+                                    aredistn,     vredistn,      &
+                                    dardg1ndt,    dardg2ndt,     &
+                                    dvirdgndt,                   &
+                                    araftn,       vraftn,        &
+                                    aice,         fsalt,         &
+                                    first_ice,    fzsal,         &
+                                    flux_bio,     closing )
 
       real (kind=dbl_kind), intent(in) :: &
-         mu_rdg , & !< The e-folding scale of ridged ice [m^0.5]
-         dt         !< The time step over which ridging occurs [s]
+         dt        !< The time step over which ridging occurs [s]
+
+      integer (kind=int_kind), intent(in) :: &
+         ncat  , & !< The number of thickness categories
+         ndtd  , & !< Thenumber of dynamics subcycles
+         nblyr , & !< The number of bio layers
+         nilyr , & !< The number of ice layers
+         nslyr , & !< The number of snow layers
+         n_aero    !< The number of aerosol tracers
 
       real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
          hin_max   !< category limits [m]
 
-      real (kind=dbl_kind), intent(in) :: &
-         rdg_conv   , & !< Normalized energy dissipation due to convergence [s-1]
-         rdg_shear      !< Normalized energy dissipation due to shear [s-1]
-
-      real (kind=dbl_kind), dimension (:), intent(inout) :: &
-         aicen      , & !< The concentration of ice [nondim]
-         vicen      , & !< The volume per unit area of ice [m]
-         vsnon          !< The volume per unit area of snow [m]
-
-      real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
-         trcrn          !< Ice tracer concentrations [kg m-3]
-
-      real (kind=dbl_kind), intent(inout) :: &
-         aice0          !< The concentration of open water [nondim]
-
       integer (kind=int_kind), dimension (:), intent(in) :: &
-         trcr_depend, & !<  = 0 for aicen tracers, 1 for vicen, 2 for vsnon
+         trcr_depend, & !< = 0 for aicen tracers, 1 for vicen, 2 for vsnon
          n_trcr_strata  !< The number of underlying tracer layers
 
       real (kind=dbl_kind), dimension (:,:), intent(in) :: &
-         trcr_base      !< = 0 or 1 depending on tracer dependency [nondim]
+         trcr_base      !< = 0 or 1 depending on tracer dependency
                         !! argument 2:  (1) aice, (2) vice, (3) vsno [nondim]
 
       integer (kind=int_kind), dimension (:,:), intent(in) :: &
-         nt_strata      !< Tndices of underlying tracer layers
+         nt_strata      !< Indices of underlying tracer layers
 
-      integer (kind=int_kind), intent(in) :: &
-         krdg_partic, & !< Selects participation function
-         krdg_redist    !< Selects redistribution function
+      real (kind=dbl_kind), intent(inout) :: &
+         aice     , & !< sea ice concentration
+         aice0    , & !< The concentration of open water [nondim]
+         rdg_conv , & !< Normalized energy dissipation due to convergence [s-1]
+         rdg_shear, & !< Normalized energy dissipation due to shear [s-1]
+         dardg1dt , & !< rate of area loss by ridging ice [s-1]
+         dardg2dt , & !< rate of area gain by new ridges [s-1]
+         dvirdgdt , & !< rate of ice volume ridged [m s-1]
+         opening  , & !< rate of opening due to divergence/shear [s-1]
+         fpond    , & !< fresh water flux to ponds [kg m2 s-1]
+         fresh    , & !< fresh water flux to ocean [kg m2 s-1]
+         fsalt    , & !< salt flux to ocean [kg m2 s-1]
+         fhocn        !< net heat flux to ocean [W m-2]
 
-      logical (kind=log_kind), intent(in) :: &
-         closing_flag, &!< flag if closing is valid
-         tr_brine       !< if .true., brine height differs from ice thickness
-
-      ! optional history fields
       real (kind=dbl_kind), intent(inout), optional :: &
-         dardg1dt   , & !< The rate of fractional area loss by ridging ice [s-1]
-         dardg2dt   , & !< The rate of fractional area gain by new ridges [s-1]
-         dvirdgdt   , & !< The rate of ice volume ridged [m s-1]
-         opening    , & !< The rate of opening due to divergence/shear [s-1]
-         closing    , & !< The rate of closing due to divergence/shear [s-1]
-         fpond      , & !< The fresh water flux to ponds [kg m2 s-1]
-         fresh      , & !< The fresh water flux to ocean [kg m2 s-1]
-         fhocn          !< The net heat flux to ocean [W m-2]
+         fzsal        !< zsalinity flux to ocean [kg m2 s-1] (deprecated)
+
+      real (kind=dbl_kind), intent(inout), optional :: &
+         closing      !< rate of closing due to divergence/shear [s-1]
+
+      real (kind=dbl_kind), dimension(:), intent(inout) :: &
+         aicen    , & !< The concentration of ice [nondim]
+         vicen    , & !< The volume per unit area of ice [m]
+         vsnon    , & !< The volume per unit area of snow [m]
+         dardg1ndt, & !< The rate of area loss by ridging ice [s-1]
+         dardg2ndt, & !< The rate of area gain by new ridges [s-1]
+         dvirdgndt, & !< The rate of ice volume ridged [m s-1]
+         aparticn , & !< The participation function [nondim]
+         krdgn    , & !< The mean ridge thickness/thickness of ridging ice [m]
+         araftn   , & !< The rafting ice area [m2]
+         vraftn   , & !< The rafting ice volume [m3]
+         aredistn , & !< The redistribution function: fraction of new ridge area [nondim]
+         vredistn , & !< The redistribution function: fraction of new ridge volume [nondim]
+         faero_ocn, & !< The aerosol flux to ocean [kg m-2 s-1]
+         flux_bio     !< All bio fluxes to ocean
 
       real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         dardg1ndt  , & !< The rate of fractional area loss by ridging ice [s-1]
-         dardg2ndt  , & !< The rate of fractional area gain by new ridges [s-1]
-         dvirdgndt  , & !< The rate of ice volume ridged [m s-1]
-         aparticn   , & !< The participation function [nondim]
-         krdgn      , & !< The mean ridge thickness/thickness of ridging ice [m]
-         araftn     , & !< The rafting ice area [m2]
-         vraftn     , & !< The rafting ice volume [m3]
-         aredistn   , & !< The redistribution function: fraction of new ridge area [nondim]
-         vredistn       !< The redistribution function: fraction of new ridge volume [nondim]
+         fiso_ocn     !< isotope flux to ocean [kg m-2 s-1]
 
-      real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         faero_ocn      !< The aerosol flux to ocean [kg m-2 s-1]
+      real (kind=dbl_kind), dimension(:,:), intent(inout) :: &
+         trcrn        !< Ice tracer concentrations [kg m-3]
 
-      real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         fiso_ocn       !< isotope flux to ocean [kg m-2 s-1]
+      !logical (kind=log_kind), intent(in) :: &
+         !tr_pond_topo,& ! If .true., use explicit topography-based ponds
+         !tr_aero     ,& ! If .true., use aerosol tracers
+         !tr_brine    ,& ! If .true., brine height differs from ice thickness
 
+      logical (kind=log_kind), dimension(:), intent(inout) :: &
+         first_ice    !< True until ice forms
 
-
-
-      end subroutine ridge_ice
-
+      end subroutine icepack_step_ridge
 
       end module icepack_mechred
 

--- a/config_src/external/Icepack_interfaces/icepack_mechred.F90
+++ b/config_src/external/Icepack_interfaces/icepack_mechred.F90
@@ -36,7 +36,8 @@
                                     araftn,       vraftn,        &
                                     aice,         fsalt,         &
                                     first_ice,    fzsal,         &
-                                    flux_bio,     closing )
+                                    flux_bio,     closing,       &
+                                    Tf)
 
       real (kind=dbl_kind), intent(in) :: &
          dt        !< The time step over which ridging occurs [s]
@@ -112,6 +113,8 @@
 
       logical (kind=log_kind), dimension(:), intent(inout) :: &
          first_ice    !< True until ice forms
+      real (kind=dbl_kind), intent(in) :: &
+         Tf           ! freezing temperature
 
       end subroutine icepack_step_ridge
 

--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -1504,7 +1504,7 @@ end subroutine SIS2_ice_thm_end
 !  Everything above this point pertains to the updating of the ice state due to
 !  thermodyanmic forcing.  Everything after this point relates to more basic
 !  calculations of sea ice thermodynamics.  They could be separated into two
-!  modules, but by keeping them together compliers stand a better chance of
+!  modules, but by keeping them together compilers stand a better chance of
 !  inlining various small subroutines and achieving better performance.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -131,14 +131,14 @@ type, public :: SIS_C_dyn_CS ; private
   real :: puny                !< small number [nondim]
   real :: onemeter            !< make the units work out (hopefully) [Z ~> m]
   real :: basal_stress_cutoff !< tunable parameter for the bottom drag [nondim]
-  integer :: ncat_b           ! number of bathymetry categories
-  integer :: ncat_i           ! number of ice thickness categories (log-normal)
+  integer :: ncat_b           !< number of bathymetry categories
+  integer :: ncat_i           !< number of ice thickness categories (log-normal)
 
   real, pointer, dimension(:,:) :: Tb_u=>NULL() !< Basal stress component at u-points
                                                 !! [R Z L T-2 -> kg m-1 s-2]
   real, pointer, dimension(:,:) :: Tb_v=>NULL() !< Basal stress component at v-points
                                                 !! [R Z L T-2 -> kg m-1 s-2]
-  real, pointer, dimension(:,:) :: sigma_b=>NULL()   !< !< Bottom depth variance [Z ~> m].
+  real, pointer, dimension(:,:) :: sigma_b=>NULL() !< Bottom depth variance [Z ~> m].
 
   logical :: FirstCall = .true. !< If true, this module has not been called before
   !>@{ Diagnostic IDs
@@ -356,9 +356,9 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
                    "Scale factor in ITD landfast ice.", &
                    units="nondim", default=1.9430)
     call get_param(param_file, mdl, "H2_FILE", h2_file, &
-                 "The path to the file containing the sub-grid-scale "//&
-                 "topographic roughness amplitude with ITD_LANDFAST.", &
-                 fail_if_missing=.true.)
+                   "The path to the file containing the sub-grid-scale "//&
+                   "topographic roughness amplitude with ITD_LANDFAST.", &
+                   fail_if_missing=.true.)
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     filename = trim(inputdir) // "/" // trim(h2_file)
     allocate(CS%sigma_b(G%isd:G%ied,G%jsd:G%jed), source=0.0)

--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -758,10 +758,12 @@ subroutine advect_scalar_x(scalar, hprev, uhr, uh_neglect, domore_u, Idt, is, ie
         do_i(i) = .false.
       endif
     enddo
-    do i=is,ie ; if ((do_i(i)) .and. (Ihnew(i) > 0.0)) then
-      scalar(i,j,k) = (scalar(i,j,k) * hlst(i) - &
-                       ((uhh(I)-haddE(i))*Tr_x(I) - &
-                        (uhh(I-1)+haddW(i))*Tr_x(I-1))) * Ihnew(i)
+    do i=is,ie ; if (do_i(i)) then
+      if (Ihnew(i) > 0.0) then
+        scalar(i,j,k) = (scalar(i,j,k) * hlst(i) - &
+                         ((uhh(I)-haddE(i))*Tr_x(I) - &
+                          (uhh(I-1)+haddW(i))*Tr_x(I-1))) * Ihnew(i)
+      endif
     endif ; enddo
 
   endif ; enddo ! End of j-loop.
@@ -928,10 +930,12 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, domore_u, ntr, nL_max, Idt, is, 
       endif
     enddo
     do m=1,ntr ; do l=1,Tr(m)%nL
-      do i=is,ie ; if ((do_i(i)) .and. (Ihnew(i) > 0.0)) then
-        Tr(m)%t(i,j,k,l) = (Tr(m)%t(i,j,k,l) * hlst(i) - &
-                            ((uhh(I)-haddE(i))*Tr_x(I,l,m) - &
-                             (uhh(I-1)+haddW(i))*Tr_x(I-1,l,m))) * Ihnew(i)
+      do i=is,ie ; if (do_i(i)) then
+        if (Ihnew(i) > 0.0) then
+          Tr(m)%t(i,j,k,l) = (Tr(m)%t(i,j,k,l) * hlst(i) - &
+                              ((uhh(I)-haddE(i))*Tr_x(I,l,m) - &
+                               (uhh(I-1)+haddW(i))*Tr_x(I-1,l,m))) * Ihnew(i)
+        endif
       endif ; enddo
       ! Diagnostics
       if (associated(Tr(m)%ad4d_x)) then ; do i=is,ie ; if (do_i(i)) then

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -2019,7 +2019,9 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
       call get_param(param_file, mdl, "HLIM_VALS", hlim_string, &
                    "This sets the list of lower limits on the ice thickness "//&
                    "categories.", default="1.0e-10, 0.1, 0.3, 0.7, 1.1, 1.5, 2.0, 2.5")
-      hlim_vals = extract_real(hlim_string, ',', CatIce) * US%m_to_L
+      do k=1,CatIce
+        hlim_vals(k) = extract_real(hlim_string, ', ', k) * US%m_to_L
+      enddo
       call initialize_ice_categories(sIG, Rho_ice, US, param_file, hLim_vals=hlim_vals)
     else
       call initialize_ice_categories(sIG, Rho_ice, US, param_file)

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -392,10 +392,12 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
       dardg1dt = 0.0
       dardg2dt = 0.0
       opening = 0.0
+      closing = 0.0
       fpond = 0.0
       fresh = 0.0
       fhocn = 0.0
       fsalt = 0.0
+      fzsal = 0.0
       faero_ocn(:) = 0.0
       fiso_ocn = 0.0
       aparticn = 0.0

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -355,13 +355,13 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
         trcr_base(ntrcr,:) = 0.0; trcr_base(ntrcr,1) = 1.0; ! 1st index for area
         do k=1,nL_ice
           ntrcr=ntrcr+1
-          trcrn(ntrcr,1:ncat) = Tr_ice_enth_ptr(i,j,1:nCat,k)
+          trcrn(ntrcr,1:ncat) = Tr_ice_enth_ptr(i,j,1:nCat,k) * rho_ice
           trcr_depend(ntrcr) = 1; ! 1 means ice-based tracer
           trcr_base(ntrcr,:) = 0.0; trcr_base(ntrcr,2) = 1.0; ! 2nd index for ice
         enddo
         do k=1,nL_snow
           ntrcr=ntrcr+1
-          trcrn(ntrcr,1:nCat) = Tr_snow_enth_ptr(i,j,1:nCat,k)
+          trcrn(ntrcr,1:nCat) = Tr_snow_enth_ptr(i,j,1:nCat,k) * rho_snow
           trcr_depend(ntrcr) = 2; ! 2 means snow-based tracer
           trcr_base(ntrcr,:) = 0.0; trcr_base(ntrcr,3) = 1.0; ! 3rd index for snow
         enddo
@@ -480,12 +480,12 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
 
          do k=1,nL_ice
            tr_tmp(1:nCat)=trcrn(1+k,1:nCat)
-           Tr_ice_enth_ptr(i,j,1:nCat,k) = tr_tmp(1:nCat)
+           Tr_ice_enth_ptr(i,j,1:nCat,k) = tr_tmp(1:nCat) / rho_ice
          enddo
 
          do k=1,nL_snow
            tr_tmp(1:nCat)=trcrn(1+nl_ice+k,1:ncat)
-           Tr_snow_enth_ptr(i,j,1:nCat,k) = tr_tmp(1:nCat)
+           Tr_snow_enth_ptr(i,j,1:nCat,k) = tr_tmp(1:nCat) / rho_snow
          enddo
 
          do k=1,nL_ice

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -73,10 +73,10 @@ subroutine ice_ridging_init(G, IG, PF, CS, US)
   if (.not.associated(CS)) allocate(CS)
   call get_param(PF, mdl, "NEW_RIDGE_PARTICIPATION", CS%new_rdg_partic, &
                  "Participation function used in ridging, .false. for Thorndike et al. 1975 "//&
-                 ".true. for Lipscomb et al. 2007", default=.false.)
+                 ".true. for Lipscomb et al. 2007", default=.true.)
   call get_param(PF, mdl, "NEW_RIDGE_REDISTRIBUTION", CS%new_rdg_redist, &
                  "Redistribution function used in ridging, .false. for Hibler 1980 "//&
-                 ".true. for Lipscomb et al. 2007", default=.false.)
+                 ".true. for Lipscomb et al. 2007", default=.true.)
   if (CS%new_rdg_partic) then
     call get_param(PF, mdl, "RIDGE_MU", CS%mu_rdg, &
                    "E-folding scale of ridge ice from Lipscomb et al. 2007", &
@@ -458,22 +458,6 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
         IST%mH_pond(i,j,k) = tr_tmp(k)
         mca_pond(i,j,k) = IST%mH_pond(i,j,k)*aicen(k)
       enddo
-      if (any(vicen < 0)) then
-!       print *, "Negative ice volume after ridging: ", i+G%idg_offset, j+G%jdg_offset, vicen
-!       print *, "Before ridging: ", mca_ice(i,j,1:nCat) /Rho_ice
-!       print *, "Ice concentration before/after ridging: ", IST%part_size(i,j,1:nCat), aicen
-        do k=1,nCat
-          if (vicen(k) < 0.0 .and. aicen(k) > 0.0) then
-            write(mesg,'("Negative ice volume after ridging: ", i6, i6, 2x, 1pe12.4, 1pe12.4)')  &
-                          i+G%idg_offset, j+G%jdg_offset, aicen(k), vicen(k)
-            call SIS_error(WARNING, mesg, all_print=.true.)
-          endif
-          vicen(k) = max(vicen(k),0.0)
-        enddo
-!       write(mesg,'("Negative ice volume after ridging: ", 2i6, 2x, (1pe12.4))') &
-!                     i+G%jdg_offset, j+G%jdg_offset, aicen, vicen
-!       call SIS_error(WARNING, mesg, all_print=.true.)
-      endif
 
       if (TrReg%ntr>0) then
         ! unload tracer array reversing order of load -- stack-like fashion

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -241,7 +241,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
   real, dimension(:,:,:),         pointer    :: Tr_ice_alvl_ptr=>NULL()  !< A pointer to the named tracer
   real, dimension(:,:,:),         pointer    :: Tr_ice_mlvl_ptr=>NULL()  !< A pointer to the named tracer
 
-  real :: rho_ice, rho_snow ! Density of ice and snow [R ~> kg m-3]
+  real :: rho_ice, rho_snow, rho_water ! Density of ice, snow and water [R ~> kg m-3]
   real :: Cp_water    ! The heat capacity of sea water [Q C-1 ~> J kg-1 degC-1]
   real :: divu_adv
   integer :: m, n ! loop vars for tracer; n is tracer #; m is tracer layer
@@ -257,6 +257,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
 
   call get_SIS2_thermo_coefs(IST%ITV, rho_ice=rho_ice)
   call get_SIS2_thermo_coefs(IST%ITV, rho_snow=rho_snow)
+  call get_SIS2_thermo_coefs(IST%ITV, rho_water=rho_water)
   call get_SIS2_thermo_coefs(IST%ITV, Cp_Water=Cp_water)
   dt_sec = dt*US%T_to_s
 
@@ -352,7 +353,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
       if (TrReg%ntr>0) then ! load tracer array
         ntrcr=ntrcr+1
         do k=1,ncat
-          trcrn(ntrcr,k) = Cp_water * OSS%SST_C(i,j) ! surface ocean enthalpy
+          trcrn(ntrcr,k) = Cp_water * OSS%SST_C(i,j) * rho_water ! surface ocean enthalpy
                                                      ! copying across all categories.
         enddo
         trcr_depend(ntrcr) = 0; ! ice/snow surface temperature


### PR DESCRIPTION
 - Icepack has made the call we were using private. The public interface we should have been using all along is the one here.
 - Because icepack_step_ridge calls not just ridge_ice, but also cleanup_itd, answers change.
 - cleanup_itd is called such that limit_aice is true. This will cause it to zap ice categories with very small areas. Will this clean up our ridging when using the new ridging schemes?
 - Addresses issue #201, should be applied before updating Icepack.