### PR TITLE
Add diag send complete calls

### DIFF
--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -8,6 +8,7 @@ use MOM_coms,               only : PE_here
 use MOM_diag_manager_infra, only : diag_manager_init=>MOM_diag_manager_init
 use MOM_diag_manager_infra, only : register_diag_field_infra, register_static_field_infra
 use MOM_diag_manager_infra, only : send_data_infra, diag_axis_init=>MOM_diag_axis_init, EAST, NORTH
+use MOM_diag_manager_infra, only : diag_send_complete_infra
 use MOM_error_handler,      only : SIS_error=>MOM_error, FATAL, is_root_pe
 use MOM_file_parser,        only : get_param, log_param, log_version, param_file_type
 use MOM_safe_alloc,         only : safe_alloc_ptr, safe_alloc_alloc
@@ -22,7 +23,7 @@ public safe_alloc_ptr, safe_alloc_alloc
 public enable_SIS_averaging, disable_SIS_averaging, query_SIS_averaging_enabled
 public SIS_diag_mediator_init, SIS_diag_mediator_end, set_SIS_diag_mediator_grid
 public SIS_diag_mediator_close_registration, get_SIS_diag_time_end
-public diag_axis_init, register_static_field
+public diag_axis_init, register_static_field, SIS_diag_send_complete
 
 !> Make a diagnostic available for averaging or output.
 interface post_SIS_data
@@ -974,5 +975,9 @@ subroutine assert(logical_arg, msg)
   endif
 
 end subroutine assert
+
+subroutine SIS_diag_send_complete()
+  call diag_send_complete_infra()
+end subroutine SIS_diag_send_complete
 
 end module SIS_diag_mediator

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -29,6 +29,7 @@ use MOM_unit_scaling,  only : unit_scale_type
 
 use SIS_diag_mediator, only : post_SIS_data, SIS_diag_ctrl
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, enable_SIS_averaging
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
 use SIS_debugging,     only : chksum, Bchksum, hchksum, uvchksum
 use SIS_debugging,     only : check_redundant_B, check_redundant_C
@@ -1372,7 +1373,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
       call uvchksum("Cor_[uv] in SIS_C_dynamics", Cor_u, Cor_v, G, scale=US%L_T_to_m_s*US%s_to_T)
       call uvchksum("[uv]i in SIS_C_dynamics", ui, vi, G, scale=US%L_T_to_m_s)
     endif
-
+    call SIS_diag_send_complete()
   enddo ! l=1,EVP_steps
 
   if (CS%debug .or. CS%debug_redundant) &
@@ -1578,6 +1579,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     endif
 
   endif
+  call SIS_diag_send_complete()
 
 end subroutine SIS_C_dynamics
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -39,6 +39,7 @@ use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
 use SIS_diag_mediator, only : post_SIS_data, post_data=>post_SIS_data
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_dyn_bgrid,     only : SIS_B_dyn_CS, SIS_B_dynamics, SIS_B_dyn_init
 use SIS_dyn_bgrid,     only : SIS_B_dyn_register_restarts, SIS_B_dyn_end
 use SIS_dyn_cgrid,     only : SIS_C_dyn_CS, SIS_C_dynamics, SIS_C_dyn_init
@@ -311,6 +312,7 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
   if (IOF%id_mass_berg>0 .and. associated(IOF%mass_berg)) then
     call post_data(IOF%id_mass_berg, IOF%mass_berg, CS%diag)
   endif
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
 end subroutine update_icebergs
@@ -606,7 +608,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
             DS2d%avg_ridge_rate(i,j) = wt_new * rdg_rate(i,j) + wt_prev * DS2d%avg_ridge_rate(i,j)
           enddo ; enddo
         endif
-
+        call SIS_diag_send_complete()
         call cpu_clock_end(iceClock4)
 
       enddo ! nds=1,ndyn_steps
@@ -818,6 +820,7 @@ subroutine ice_state_cleanup(IST, OSS, IOF, dt_slow, G, US, IG, CS, tracer_CSp)
 
   call enable_SIS_averaging(US%T_to_s*dt_slow, CS%Time, CS%diag)
   call post_ice_state_diagnostics(CS%IDs, IST, OSS, IOF, dt_slow, CS%Time, G, US, IG, CS%diag)
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
   if (CS%verbose) call ice_line(CS%Time, IST%part_size(:,:,0), OSS%SST_C(:,:), G)
@@ -1140,7 +1143,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
     enddo
     DS2d%nts = DS2d%nts + CS%adv_substeps
     call cpu_clock_end(iceClock4)
-
+    call SIS_diag_send_complete()
   enddo ! nds=1,ndyn_steps
 
 end subroutine SIS_merged_dyn_cont
@@ -1360,6 +1363,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
       call write_ice_statistics(IST, CS%Time, CS%n_calls, G, US, IG, CS%sum_output_CSp, &
                                 message="      Post_transport")! , check_column=.true.)
 
+    call SIS_diag_send_complete()
   enddo ! nds=1,ndyn_steps
   call finish_ocean_top_stresses(IOF, G)
 

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -41,6 +41,7 @@ use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
 use SIS_diag_mediator, only : post_SIS_data, post_data=>post_SIS_data
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_framework,     only : coupler_type_spawn, coupler_type_initialized
 use SIS_framework,     only : coupler_type_increment_data, coupler_type_rescale_data
 use SIS_framework,     only : coupler_type_send_data
@@ -415,6 +416,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, US, IG)
   ! Save out diagnostics of fluxes.  This must go before SIS2_thermodynamics.
   call post_flux_diagnostics(IST, FIA, IOF, CS, G, US, IG, Idt_slow)
 
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
   call accumulate_input_2(IST, FIA, IOF, OSS, IST%part_size, dt_slow, G, US, IG, CS%sum_output_CSp)
@@ -446,6 +448,7 @@ subroutine slow_thermodynamics(IST, dt_slow, CS, OSS, FIA, XSF, IOF, G, US, IG)
   ! Do tracer column physics
   call enable_SIS_averaging(US%T_to_s*dt_slow, CS%Time, CS%diag)
   call SIS_call_tracer_column_fns(dt_slow, G, IG, CS%tracer_flow_CSp, IST%mH_ice, mi_old)
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
   call accumulate_bottom_input(IST, OSS, FIA, IOF, dt_slow, G, US, IG, CS%sum_output_CSp)
@@ -1367,6 +1370,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
   if (coupler_type_initialized(IOF%tr_flux_ocn_top)) &
     call coupler_type_send_data(IOF%tr_flux_ocn_top, CS%Time)
 
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
   ! Combine the liquid precipitation with the net melt of ice and snow for

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -15,6 +15,7 @@ use SIS_continuity,    only : continuity=>ice_continuity, SIS_continuity_CS
 use SIS_continuity,    only : summed_continuity, proportionate_continuity
 use SIS_diag_mediator, only : post_SIS_data, query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_diag_mediator, only : register_diag_field=>register_SIS_diag_field, time_type
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_framework,     only : safe_alloc
 use SIS_hor_grid,      only : SIS_hor_grid_type
 use SIS_tracer_advect, only : advect_tracers_thicker, SIS_tracer_advect_CS
@@ -218,6 +219,7 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
       write(mesg,'(i4)') n
       call check_SIS_tracer_bounds(TrReg, G, IG, "After advect_SIS_tracers "//trim(mesg))
     endif
+  call SIS_diag_send_complete()
   enddo
 
 end subroutine ice_cat_transport

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -219,7 +219,7 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
       write(mesg,'(i4)') n
       call check_SIS_tracer_bounds(TrReg, G, IG, "After advect_SIS_tracers "//trim(mesg))
     endif
-  call SIS_diag_send_complete()
+    call SIS_diag_send_complete()
   enddo
 
 end subroutine ice_cat_transport

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -63,6 +63,7 @@ use SIS_debugging,     only : chksum, uvchksum, Bchksum, SIS_debugging_init
 use SIS_diag_mediator, only : set_SIS_axes_info, SIS_diag_mediator_init, SIS_diag_mediator_end
 use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
 use SIS_diag_mediator, only : post_SIS_data, post_data=>post_SIS_data
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_dyn_trans,     only : SIS_dynamics_trans, SIS_multi_dyn_trans, update_icebergs
 use SIS_dyn_trans,     only : slab_ice_dyn_trans
 use SIS_dyn_trans,     only : SIS_dyn_trans_register_restarts, SIS_dyn_trans_init, SIS_dyn_trans_end
@@ -1548,6 +1549,7 @@ subroutine fast_radiation_diagnostics(ABT, Ice, IST, Rad, FIA, G, US, IG, CS, &
 
   if (Rad%id_coszen>0) call post_data(Rad%id_coszen, Rad%coszen_nextrad, CS%diag)
 
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
 end subroutine fast_radiation_diagnostics

--- a/src/specified_ice.F90
+++ b/src/specified_ice.F90
@@ -17,6 +17,7 @@ use MOM_time_manager, only : operator(>), operator(*), operator(/), operator(/=)
 use MOM_unit_scaling, only : unit_scale_type
 
 use SIS_diag_mediator, only : enable_SIS_averaging, disable_SIS_averaging
+use SIS_diag_mediator, only : SIS_diag_send_complete
 use SIS_diag_mediator, only : query_SIS_averaging_enabled, SIS_diag_ctrl
 use SIS_hor_grid,  only : SIS_hor_grid_type
 use SIS_ice_diags, only : ice_state_diags_type, register_ice_state_diagnostics
@@ -93,6 +94,7 @@ subroutine specified_ice_dynamics(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG)
 
   call enable_SIS_averaging(US%T_to_s*dt_slow, CS%Time, CS%diag)
   call post_ice_state_diagnostics(CS%IDs, IST, OSS, IOF, dt_slow, CS%Time, G, US, IG, CS%diag)
+  call SIS_diag_send_complete()
   call disable_SIS_averaging(CS%diag)
 
   if (CS%debug) call IST_chksum("End specified_ice_dynamics", IST, G, US, IG)


### PR DESCRIPTION
Adds a `SIS_diag_send_complete` subroutine which calls `diag_send_complete_infra` from MOM6. These are needed for the new diag manager but are backwards compatible with the old. 

This is called after every:
- `EVP_steps` in `SIS_C_dynamics`
-  `ndyn_steps` in `SIS_dynamics_trans`,  `SIS_merged_dyn_cont`, and `slab_ice_dyn_trans`
- `nsteps` in `ice_cat_transport`

It is also called before `disable_SIS_averaging` calls.

Unfortunately, this PR requires https://github.com/NOAA-GFDL/MOM6/pull/637 