### PR TITLE
 This is the code update for calling new Icepack.

### DIFF
--- a/config_src/external/Icepack_interfaces/icepack_itd.F90
+++ b/config_src/external/Icepack_interfaces/icepack_itd.F90
@@ -1,136 +1,135 @@
-      module icepack_itd
+module icepack_itd
 
-      use icepack_kinds
-!      use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny
-!      use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, Tocnfrz, rhoi
-!      use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin
-!      use icepack_tracers,    only: nt_Tsfc, nt_qice, nt_qsno, nt_aero, nt_isosno, nt_isoice
-!      use icepack_tracers,    only: nt_apnd, nt_hpnd, nt_fbri, tr_brine, nt_bgc_S, bio_index
-!      use icepack_tracers,    only: n_iso
-!      use icepack_tracers,    only: tr_iso
-!      use icepack_tracers,    only: icepack_compute_tracers
-!      use icepack_parameters, only: solve_zsal, skl_bgc, z_tracers
-!      use icepack_parameters, only: kcatbound, kitd
-!      use icepack_therm_shared, only: Tmin, hi_min
-!      use icepack_warnings,   only: warnstr, icepack_warnings_add
-!      use icepack_warnings,   only: icepack_warnings_setabort, icepack_warnings_aborted
-!      use icepack_zbgc_shared,only: zap_small_bgc
+  use icepack_kinds, only: int_kind, dbl_kind, log_kind
+! use icepack_parameters, only: c0, c1, c2, c3, c15, c25, c100, p1, p01, p001, p5, puny
+! use icepack_parameters, only: Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, Tocnfrz, rhoi
+! use icepack_parameters, only: rhosi, sk_l, hs_ssl, min_salin
+! use icepack_tracers,    only: nt_Tsfc, nt_qice, nt_qsno, nt_aero, nt_isosno, nt_isoice
+! use icepack_tracers,    only: nt_apnd, nt_hpnd, nt_fbri, tr_brine, nt_bgc_S, bio_index
+! use icepack_tracers,    only: n_iso
+! use icepack_tracers,    only: tr_iso
+! use icepack_tracers,    only: icepack_compute_tracers
+! use icepack_parameters, only: solve_zsal, skl_bgc, z_tracers
+! use icepack_parameters, only: kcatbound, kitd
+! use icepack_therm_shared, only: Tmin, hi_min
+! use icepack_warnings,   only: warnstr, icepack_warnings_add
+! use icepack_warnings,   only: icepack_warnings_setabort, icepack_warnings_aborted
+! use icepack_zbgc_shared,only: zap_small_bgc
 
-      implicit none
+  implicit none
 
-      private
-      public :: cleanup_itd ,icepack_init_itd
+  private
+  public :: cleanup_itd ,icepack_init_itd
 
 
-
-!=======================================================================
-
-      contains
 
 !=======================================================================
 
-      subroutine icepack_init_itd(ncat, hin_max)
-
-      integer (kind=int_kind), intent(in) :: &
-           ncat ! number of thickness categories
-
-      real (kind=dbl_kind), intent(out) :: &
-           hin_max(0:ncat)  ! category limits (m)
-
-
-      end subroutine icepack_init_itd
-
-      subroutine cleanup_itd (dt,          ntrcr,      &
-                              nilyr,       nslyr,      &
-                              ncat,        hin_max,    &
-                              aicen,       trcrn,      &
-                              vicen,       vsnon,      &
-                              aice0,       aice,       &
-                              n_aero,                  &
-                              nbtrcr,      nblyr,      &
-                              tr_aero,                 &
-                              tr_pond_topo,            &
-                              heat_capacity,           &
-                              first_ice,               &
-                              trcr_depend, trcr_base,  &
-                              n_trcr_strata,nt_strata, &
-                              fpond,       fresh,      &
-                              fsalt,       fhocn,      &
-                              faero_ocn,   fiso_ocn,   &
-                              fzsal,                   &
-                              flux_bio,    limit_aice_in)
-
-      integer (kind=int_kind), intent(in) :: &
-         ncat  , & ! number of thickness categories
-         nilyr , & ! number of ice layers
-         nblyr , & ! number of bio layers
-         nslyr , & ! number of snow layers
-         ntrcr , & ! number of tracers in use
-         nbtrcr, & ! number of bio tracers in use
-         n_aero    ! number of aerosol tracers
-
-      real (kind=dbl_kind), intent(in) :: &
-         dt        ! time step
-
-      real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
-         hin_max   ! category boundaries (m)
-
-      real (kind=dbl_kind), dimension (:), intent(inout) :: &
-         aicen , & ! concentration of ice
-         vicen , & ! volume per unit area of ice          (m)
-         vsnon     ! volume per unit area of snow         (m)
-
-      real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
-         trcrn     ! ice tracers
-
-      real (kind=dbl_kind), intent(inout) :: &
-         aice  , & ! total ice concentration
-         aice0     ! concentration of open water
-
-      integer (kind=int_kind), dimension (:), intent(in) :: &
-         trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
-         n_trcr_strata  ! number of underlying tracer layers
-
-      real (kind=dbl_kind), dimension (:,:), intent(in) :: &
-         trcr_base      ! = 0 or 1 depending on tracer dependency
-                        ! argument 2:  (1) aice, (2) vice, (3) vsno
-
-      integer (kind=int_kind), dimension (:,:), intent(in) :: &
-         nt_strata      ! indices of underlying tracer layers
-
-      logical (kind=log_kind), intent(in) :: &
-         tr_aero,      & ! aerosol flag
-         tr_pond_topo, & ! topo pond flag
-         heat_capacity   ! if false, ice and snow have zero heat capacity
-
-      logical (kind=log_kind), dimension(ncat), intent(inout) :: &
-         first_ice   ! For bgc and S tracers. set to true if zapping ice.
-
-      ! ice-ocean fluxes (required for strict conservation)
-
-      real (kind=dbl_kind), intent(inout), optional :: &
-         fpond    , & ! fresh water flux to ponds (kg/m^2/s)
-         fresh    , & ! fresh water flux to ocean (kg/m^2/s)
-         fsalt    , & ! salt flux to ocean        (kg/m^2/s)
-         fhocn    , & ! net heat flux to ocean     (W/m^2)
-         fzsal        ! net salt flux to ocean from zsalinity (kg/m^2/s)
-
-      real (kind=dbl_kind), dimension (:), intent(inout), optional :: &
-         flux_bio     ! net tracer flux to ocean from biology (mmol/m^2/s)
-
-      real (kind=dbl_kind), dimension (:), intent(inout), optional :: &
-         faero_ocn    ! aerosol flux to ocean     (kg/m^2/s)
-
-      real (kind=dbl_kind), dimension (:), intent(inout) :: &
-         fiso_ocn     ! isotope flux to ocean     (kg/m^2/s)
-
-      logical (kind=log_kind), intent(in), optional ::   &
-         limit_aice_in      ! if false, allow aice to be out of bounds
-                            ! may want to allow this for unit tests
-
-
-      end subroutine cleanup_itd
-
-      end module icepack_itd
+  contains
 
 !=======================================================================
+
+  !> Stub for Icepack routine initializing ice thickness distribution
+  subroutine icepack_init_itd(ncat, hin_max)
+
+    integer (kind=int_kind), intent(in) :: &
+           ncat !< number of thickness categories
+
+    real (kind=dbl_kind), intent(out) :: &
+           hin_max(0:ncat)  !< category limits (m)
+
+
+  end subroutine icepack_init_itd
+
+  !> Stub for Icepack routine cleaning up ice thickness distribution
+  subroutine cleanup_itd (dt,          ntrcr,      &
+                          nilyr,       nslyr,      &
+                          ncat,        hin_max,    &
+                          aicen,       trcrn,      &
+                          vicen,       vsnon,      &
+                          aice0,       aice,       &
+                          n_aero,                  &
+                          nbtrcr,      nblyr,      &
+                          tr_aero,                 &
+                          tr_pond_topo,            &
+                          heat_capacity,           &
+                          first_ice,               &
+                          trcr_depend, trcr_base,  &
+                          n_trcr_strata,nt_strata, &
+                          fpond,       fresh,      &
+                          fsalt,       fhocn,      &
+                          faero_ocn,   fiso_ocn,   &
+                          fzsal,                   &
+                          flux_bio,    limit_aice_in)
+
+    integer (kind=int_kind), intent(in) :: &
+         ncat  , & !< number of thickness categories
+         nilyr , & !< number of ice layers
+         nblyr , & !< number of bio layers
+         nslyr , & !< number of snow layers
+         ntrcr , & !< number of tracers in use
+         nbtrcr, & !< number of bio tracers in use
+         n_aero    !< number of aerosol tracers
+
+    real (kind=dbl_kind), intent(in) :: &
+         dt        !< time step
+
+    real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
+         hin_max   !< category boundaries (m)
+
+    real (kind=dbl_kind), dimension (:), intent(inout) :: &
+         aicen , & !< concentration of ice
+         vicen , & !< volume per unit area of ice          (m)
+         vsnon     !< volume per unit area of snow         (m)
+
+    real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
+         trcrn     !< ice tracers
+
+    real (kind=dbl_kind), intent(inout) :: &
+         aice  , & !< total ice concentration
+         aice0     !< concentration of open water
+
+    integer (kind=int_kind), dimension (:), intent(in) :: &
+         trcr_depend, & !< = 0 for aicen tracers, 1 for vicen, 2 for vsnon
+         n_trcr_strata  !< number of underlying tracer layers
+
+    real (kind=dbl_kind), dimension (:,:), intent(in) :: &
+         trcr_base      !< = 0 or 1 depending on tracer dependency
+                        !! argument 2:  (1) aice, (2) vice, (3) vsno
+
+    integer (kind=int_kind), dimension (:,:), intent(in) :: &
+         nt_strata      !< indices of underlying tracer layers
+
+    logical (kind=log_kind), intent(in) :: &
+         tr_aero,      & !< aerosol flag
+         tr_pond_topo, & !< topo pond flag
+         heat_capacity   !< if false, ice and snow have zero heat capacity
+
+    logical (kind=log_kind), dimension(ncat), intent(inout) :: &
+         first_ice   !< For bgc and S tracers. set to true if zapping ice.
+
+    ! ice-ocean fluxes (required for strict conservation)
+
+    real (kind=dbl_kind), intent(inout), optional :: &
+         fpond    , & !< fresh water flux to ponds (kg/m^2/s)
+         fresh    , & !< fresh water flux to ocean (kg/m^2/s)
+         fsalt    , & !< salt flux to ocean        (kg/m^2/s)
+         fhocn    , & !< net heat flux to ocean     (W/m^2)
+         fzsal        !< net salt flux to ocean from zsalinity (kg/m^2/s)
+
+    real (kind=dbl_kind), dimension (:), intent(inout), optional :: &
+         flux_bio     !< net tracer flux to ocean from biology (mmol/m^2/s)
+
+    real (kind=dbl_kind), dimension (:), intent(inout), optional :: &
+         faero_ocn    !< aerosol flux to ocean     (kg/m^2/s)
+
+    real (kind=dbl_kind), dimension (:), intent(inout) :: &
+         fiso_ocn     !< isotope flux to ocean     (kg/m^2/s)
+
+    logical (kind=log_kind), intent(in), optional ::   &
+         limit_aice_in      !< if false, allow aice to be out of bounds
+                            !! may want to allow this for unit tests
+
+  end subroutine cleanup_itd
+
+end module icepack_itd

--- a/config_src/external/Icepack_interfaces/icepack_kinds.F90
+++ b/config_src/external/Icepack_interfaces/icepack_kinds.F90
@@ -7,32 +7,26 @@
 ! 2006: ECH converted to free source form (F90)
 ! 2020: TC added support for NO_I8 and NO_R16
 
-      module icepack_kinds
+module icepack_kinds
 
-!=======================================================================
+  implicit none
+  public
 
-      implicit none
-      public
-
-      integer, parameter :: char_len  = 80, &
-                            char_len_long  = 256, &
-                            log_kind  = kind(.true.), &
-                            int_kind  = selected_int_kind(6), &
+  integer, parameter :: char_len  = 80, &
+                        char_len_long  = 256, &
+                        log_kind  = kind(.true.), &
+                        int_kind  = selected_int_kind(6), &
 #if defined (NO_I8)
-                            int8_kind = selected_int_kind(6), &
+                        int8_kind = selected_int_kind(6), &
 #else
-                            int8_kind = selected_int_kind(13), &
+                        int8_kind = selected_int_kind(13), &
 #endif
-                            real_kind = selected_real_kind(6), &
-                            dbl_kind  = selected_real_kind(13), &
+                        real_kind = selected_real_kind(6), &
+                        dbl_kind  = selected_real_kind(13), &
 #if defined (NO_R16)
-                            r16_kind  = selected_real_kind(13)
+                        r16_kind  = selected_real_kind(13)
 #else
-                            r16_kind  = selected_real_kind(33,4931)
+                        r16_kind  = selected_real_kind(33,4931)
 #endif
 
-!=======================================================================
-
-      end module icepack_kinds
-
-!=======================================================================
+end module icepack_kinds

--- a/config_src/external/Icepack_interfaces/icepack_mechred.F90
+++ b/config_src/external/Icepack_interfaces/icepack_mechred.F90
@@ -6,119 +6,109 @@
       implicit none
 
       private
-      public :: ridge_ice
+      public :: icepack_step_ridge
       contains
 
 !-----------------------------------------------------------------------
 !> Interface for updating the sea-ice state due to ice ridging processes
 !! using Icepack.
-      subroutine ridge_ice (dt,          ndtd,       &
-                            ncat,        n_aero,     &
-                            nilyr,       nslyr,      &
-                            ntrcr,       hin_max,    &
-                            rdg_conv,    rdg_shear,  &
-                            aicen,       trcrn,      &
-                            vicen,       vsnon,      &
-                            aice0,                   &
-                            trcr_depend, trcr_base,  &
-                            n_trcr_strata,           &
-                            nt_strata,               &
-                            krdg_partic, krdg_redist,&
-                            mu_rdg,      tr_brine,   &
-                            dardg1dt,    dardg2dt,   &
-                            dvirdgdt,    opening,    &
-                            fpond,                   &
-                            fresh,       fhocn,      &
-                            faero_ocn,   fiso_ocn,   &
-                            aparticn,    krdgn,      &
-                            aredistn,    vredistn,   &
-                            dardg1ndt,   dardg2ndt,  &
-                            dvirdgndt,               &
-                            araftn,      vraftn,     &
-                            closing_flag,closing )
 
-      integer (kind=int_kind), intent(in) :: &
-         ndtd       , & !< Thenumber of dynamics subcycles
-         ncat  , & !< The number of thickness categories
-         nilyr , & !< The number of ice layers
-         nslyr , & !< The number of snow layers
-         n_aero, & !< The number of aerosol tracers
-         ntrcr     !< The number of tracers in use
+      subroutine icepack_step_ridge(dt,           ndtd,          &
+                                    hin_max,                     &
+                                    rdg_conv,     rdg_shear,     &
+                                    aicen,                       &
+                                    trcrn,                       &
+                                    vicen,        vsnon,         &
+                                    aice0,        trcr_depend,   &
+                                    trcr_base,    n_trcr_strata, &
+                                    nt_strata,                   &
+                                    dardg1dt,     dardg2dt,      &
+                                    dvirdgdt,     opening,       &
+                                    fpond,                       &
+                                    fresh,        fhocn,         &
+                                    faero_ocn,    fiso_ocn,      &
+                                    aparticn,     krdgn,         &
+                                    aredistn,     vredistn,      &
+                                    dardg1ndt,    dardg2ndt,     &
+                                    dvirdgndt,                   &
+                                    araftn,       vraftn,        &
+                                    aice,         fsalt,         &
+                                    first_ice,    fzsal,         &
+                                    flux_bio,     closing,       &
+                                    Tf,                          &
+                                    docleanup, dorebin)
 
       real (kind=dbl_kind), intent(in) :: &
-         mu_rdg , & !< The e-folding scale of ridged ice [m^0.5]
-         dt         !< The time step over which ridging occurs [s]
+         dt        !< The time step over which ridging occurs [s]
+
+      integer (kind=int_kind), intent(in) :: &
+         ndtd      !< The number of dynamics subcycles
 
       real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
          hin_max   !< category limits [m]
 
-      real (kind=dbl_kind), intent(in) :: &
-         rdg_conv   , & !< Normalized energy dissipation due to convergence [s-1]
-         rdg_shear      !< Normalized energy dissipation due to shear [s-1]
-
-      real (kind=dbl_kind), dimension (:), intent(inout) :: &
-         aicen      , & !< The concentration of ice [nondim]
-         vicen      , & !< The volume per unit area of ice [m]
-         vsnon          !< The volume per unit area of snow [m]
-
-      real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
-         trcrn          !< Ice tracer concentrations [kg m-3]
-
-      real (kind=dbl_kind), intent(inout) :: &
-         aice0          !< The concentration of open water [nondim]
-
       integer (kind=int_kind), dimension (:), intent(in) :: &
-         trcr_depend, & !<  = 0 for aicen tracers, 1 for vicen, 2 for vsnon
+         trcr_depend, & !< = 0 for aicen tracers, 1 for vicen, 2 for vsnon
          n_trcr_strata  !< The number of underlying tracer layers
 
       real (kind=dbl_kind), dimension (:,:), intent(in) :: &
-         trcr_base      !< = 0 or 1 depending on tracer dependency [nondim]
+         trcr_base      !< = 0 or 1 depending on tracer dependency
                         !! argument 2:  (1) aice, (2) vice, (3) vsno [nondim]
 
       integer (kind=int_kind), dimension (:,:), intent(in) :: &
-         nt_strata      !< Tndices of underlying tracer layers
+         nt_strata      !< Indices of underlying tracer layers
 
-      integer (kind=int_kind), intent(in) :: &
-         krdg_partic, & !< Selects participation function
-         krdg_redist    !< Selects redistribution function
+      real (kind=dbl_kind), intent(inout) :: &
+         aice     , & !< sea ice concentration
+         aice0    , & !< The concentration of open water [nondim]
+         rdg_conv , & !< Normalized energy dissipation due to convergence [s-1]
+         rdg_shear, & !< Normalized energy dissipation due to shear [s-1]
+         dardg1dt , & !< rate of area loss by ridging ice [s-1]
+         dardg2dt , & !< rate of area gain by new ridges [s-1]
+         dvirdgdt , & !< rate of ice volume ridged [m s-1]
+         opening  , & !< rate of opening due to divergence/shear [s-1]
+         fpond    , & !< fresh water flux to ponds [kg m2 s-1]
+         fresh    , & !< fresh water flux to ocean [kg m2 s-1]
+         fsalt    , & !< salt flux to ocean [kg m2 s-1]
+         fhocn        !< net heat flux to ocean [W m-2]
 
-      logical (kind=log_kind), intent(in) :: &
-         closing_flag, &!< flag if closing is valid
-         tr_brine       !< if .true., brine height differs from ice thickness
-
-      ! optional history fields
       real (kind=dbl_kind), intent(inout), optional :: &
-         dardg1dt   , & !< The rate of fractional area loss by ridging ice [s-1]
-         dardg2dt   , & !< The rate of fractional area gain by new ridges [s-1]
-         dvirdgdt   , & !< The rate of ice volume ridged [m s-1]
-         opening    , & !< The rate of opening due to divergence/shear [s-1]
-         closing    , & !< The rate of closing due to divergence/shear [s-1]
-         fpond      , & !< The fresh water flux to ponds [kg m2 s-1]
-         fresh      , & !< The fresh water flux to ocean [kg m2 s-1]
-         fhocn          !< The net heat flux to ocean [W m-2]
+         fzsal        !< zsalinity flux to ocean [kg m2 s-1] (deprecated)
+
+      real (kind=dbl_kind), intent(inout), optional :: &
+         closing      !< rate of closing due to divergence/shear [s-1]
+
+      real (kind=dbl_kind), dimension(:), intent(inout) :: &
+         aicen    , & !< The concentration of ice [nondim]
+         vicen    , & !< The volume per unit area of ice [m]
+         vsnon    , & !< The volume per unit area of snow [m]
+         dardg1ndt, & !< The rate of area loss by ridging ice [s-1]
+         dardg2ndt, & !< The rate of area gain by new ridges [s-1]
+         dvirdgndt, & !< The rate of ice volume ridged [m s-1]
+         aparticn , & !< The participation function [nondim]
+         krdgn    , & !< The mean ridge thickness/thickness of ridging ice [m]
+         araftn   , & !< The rafting ice area [m2]
+         vraftn   , & !< The rafting ice volume [m3]
+         aredistn , & !< The redistribution function: fraction of new ridge area [nondim]
+         vredistn , & !< The redistribution function: fraction of new ridge volume [nondim]
+         faero_ocn, & !< The aerosol flux to ocean [kg m-2 s-1]
+         flux_bio     !< All bio fluxes to ocean
 
       real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         dardg1ndt  , & !< The rate of fractional area loss by ridging ice [s-1]
-         dardg2ndt  , & !< The rate of fractional area gain by new ridges [s-1]
-         dvirdgndt  , & !< The rate of ice volume ridged [m s-1]
-         aparticn   , & !< The participation function [nondim]
-         krdgn      , & !< The mean ridge thickness/thickness of ridging ice [m]
-         araftn     , & !< The rafting ice area [m2]
-         vraftn     , & !< The rafting ice volume [m3]
-         aredistn   , & !< The redistribution function: fraction of new ridge area [nondim]
-         vredistn       !< The redistribution function: fraction of new ridge volume [nondim]
+         fiso_ocn     !< isotope flux to ocean [kg m-2 s-1]
 
-      real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         faero_ocn      !< The aerosol flux to ocean [kg m-2 s-1]
+      real (kind=dbl_kind), dimension(:,:), intent(inout) :: &
+         trcrn        !< Ice tracer concentrations [kg m-3]
 
-      real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
-         fiso_ocn       !< isotope flux to ocean [kg m-2 s-1]
+      logical (kind=log_kind), dimension(:), intent(inout) :: &
+         first_ice    !< True until ice forms
+      real (kind=dbl_kind), intent(in) :: &
+         Tf           !< freezing temperature
+      logical (kind=log_kind), dimension(:), intent(in), optional :: &
+         docleanup, & !< True to call cleanup_itd in Icepack
+         dorebin      !< True to call rebin in Icepack
 
-
-
-
-      end subroutine ridge_ice
-
+      end subroutine icepack_step_ridge
 
       end module icepack_mechred
 

--- a/config_src/external/Icepack_interfaces/icepack_mechred.F90
+++ b/config_src/external/Icepack_interfaces/icepack_mechred.F90
@@ -1,15 +1,14 @@
-      module icepack_mechred
+module icepack_mechred
 
-      use icepack_kinds
-      use icepack_tracers, only : n_iso, n_aero
+  use icepack_kinds, only : int_kind, dbl_kind, log_kind
+  use icepack_tracers, only : n_iso, n_aero
 
-      implicit none
+  implicit none
 
       private
       public :: icepack_step_ridge
       contains
 
-!-----------------------------------------------------------------------
 !> Interface for updating the sea-ice state due to ice ridging processes
 !! using Icepack.
 
@@ -44,7 +43,7 @@
       integer (kind=int_kind), intent(in) :: &
          ndtd      !< The number of dynamics subcycles
 
-      real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
+      real (kind=dbl_kind), dimension(0:), intent(inout) :: &
          hin_max   !< category limits [m]
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
@@ -104,7 +103,7 @@
          first_ice    !< True until ice forms
       real (kind=dbl_kind), intent(in) :: &
          Tf           !< freezing temperature
-      logical (kind=log_kind), dimension(:), intent(in), optional :: &
+      logical (kind=log_kind), intent(in), optional :: &
          docleanup, & !< True to call cleanup_itd in Icepack
          dorebin      !< True to call rebin in Icepack
 

--- a/config_src/external/Icepack_interfaces/icepack_mechred.F90
+++ b/config_src/external/Icepack_interfaces/icepack_mechred.F90
@@ -32,10 +32,10 @@ module icepack_mechred
                                     dvirdgndt,                   &
                                     araftn,       vraftn,        &
                                     aice,         fsalt,         &
-                                    first_ice,    fzsal,         &
+                                    first_ice,                   &
                                     flux_bio,     closing,       &
                                     Tf,                          &
-                                    docleanup, dorebin)
+                                    docleanup,    dorebin)
 
       real (kind=dbl_kind), intent(in) :: &
          dt        !< The time step over which ridging occurs [s]
@@ -70,9 +70,6 @@ module icepack_mechred
          fresh    , & !< fresh water flux to ocean [kg m2 s-1]
          fsalt    , & !< salt flux to ocean [kg m2 s-1]
          fhocn        !< net heat flux to ocean [W m-2]
-
-      real (kind=dbl_kind), intent(inout), optional :: &
-         fzsal        !< zsalinity flux to ocean [kg m2 s-1] (deprecated)
 
       real (kind=dbl_kind), intent(inout), optional :: &
          closing      !< rate of closing due to divergence/shear [s-1]

--- a/config_src/external/Icepack_interfaces/icepack_meltpond_lvl.F90
+++ b/config_src/external/Icepack_interfaces/icepack_meltpond_lvl.F90
@@ -1,0 +1,69 @@
+module icepack_meltpond_lvl
+
+  use icepack_kinds, only : int_kind, dbl_kind, char_len
+  use icepack_tracers, only : n_iso, n_aero
+
+  implicit none
+
+  private
+  public :: compute_ponds_lvl
+  contains
+
+!> Interface for updating the melt ponds using Icepack.
+  subroutine compute_ponds_lvl(dt,     nilyr,        &
+                                   ktherm,               &
+                                   hi_min, dpscale,      &
+                                   frzpnd,               &
+                                   rfrac,  meltt, melts, &
+                                   frain,  Tair,  fsurfn,&
+                                   dhs,    ffrac,        &
+                                   aicen,  vicen, vsnon, &
+                                   qicen,  sicen,        &
+                                   Tsfcn,  alvl,         &
+                                   apnd,   hpnd,  ipnd,  &
+                                   meltsliqn)
+
+    integer (kind=int_kind), intent(in) :: &
+         nilyr, &    !< number of ice layers
+         ktherm      !< type of thermodynamics (-1 none, 1 BL99, 2 mushy)
+
+    real (kind=dbl_kind), intent(in) :: &
+         dt,       & !< time step (s)
+         hi_min,   & !< minimum ice thickness allowed for thermo (m)
+         dpscale     !< alter e-folding time scale for flushing
+
+    character (len=char_len), intent(in) :: &
+         frzpnd      !< pond refreezing parameterization
+
+    real (kind=dbl_kind), intent(in) :: &
+         Tsfcn, &    !< surface temperature (C)
+         alvl,  &    !< fraction of level ice
+         rfrac, &    !< water fraction retained for melt ponds
+         meltt, &    !< top melt rate (m/s)
+         melts, &    !< snow melt rate (m/s)
+         frain, &    !< rainfall rate (kg/m2/s)
+         Tair,  &    !< air temperature (K)
+         fsurfn,&    !< atm-ice surface heat flux  (W/m2)
+         aicen, &    !< ice area fraction
+         vicen, &    !< ice volume (m)
+         vsnon, &    !< snow volume (m)
+         meltsliqn   !< liquid contribution to meltponds in dt (kg/m^2)
+
+    real (kind=dbl_kind), intent(inout) :: &
+         apnd, &     !< pond fraction
+         hpnd, &     !< pond depth (m)
+         ipnd        !< ice pond thickness (m)
+
+    real (kind=dbl_kind), dimension (:), intent(in) :: &
+         qicen, &  !< ice layer enthalpy (J m-3)
+         sicen     !< salinity (ppt)
+
+    real (kind=dbl_kind), intent(in) :: &
+         dhs       !< depth difference for snow on sea ice and pond ice (m)
+
+    real (kind=dbl_kind), intent(out) :: &
+         ffrac     !< fraction of fsurfn over pond used to melt ipond
+
+  end subroutine compute_ponds_lvl
+
+end module icepack_meltpond_lvl

--- a/config_src/external/Icepack_interfaces/icepack_meltpond_lvl.F90
+++ b/config_src/external/Icepack_interfaces/icepack_meltpond_lvl.F90
@@ -10,32 +10,20 @@ module icepack_meltpond_lvl
   contains
 
 !> Interface for updating the melt ponds using Icepack.
-  subroutine compute_ponds_lvl(dt,     nilyr,        &
-                                   ktherm,               &
-                                   hi_min, dpscale,      &
-                                   frzpnd,               &
-                                   rfrac,  meltt, melts, &
-                                   frain,  Tair,  fsurfn,&
-                                   dhs,    ffrac,        &
-                                   aicen,  vicen, vsnon, &
-                                   qicen,  sicen,        &
-                                   Tsfcn,  alvl,         &
-                                   apnd,   hpnd,  ipnd,  &
-                                   meltsliqn)
+  subroutine compute_ponds_lvl(dt,                   &
+                               rfrac,  meltt, melts, &
+                               frain,  Tair,  fsurfn,&
+                               dhs,    ffrac,        &
+                               aicen,  vicen, vsnon, &
+                               qicen,  sicen,        &
+                               Tsfcn,  alvl,         &
+                               apnd,   hpnd,  ipnd,  &
+                               meltsliqn)
 
-    integer (kind=int_kind), intent(in) :: &
-         nilyr, &    !< number of ice layers
-         ktherm      !< type of thermodynamics (-1 none, 1 BL99, 2 mushy)
+  real (kind=dbl_kind), intent(in) :: &
+         dt          !< time step (s)
 
-    real (kind=dbl_kind), intent(in) :: &
-         dt,       & !< time step (s)
-         hi_min,   & !< minimum ice thickness allowed for thermo (m)
-         dpscale     !< alter e-folding time scale for flushing
-
-    character (len=char_len), intent(in) :: &
-         frzpnd      !< pond refreezing parameterization
-
-    real (kind=dbl_kind), intent(in) :: &
+  real (kind=dbl_kind), intent(in) :: &
          Tsfcn, &    !< surface temperature (C)
          alvl,  &    !< fraction of level ice
          rfrac, &    !< water fraction retained for melt ponds

--- a/config_src/external/Icepack_interfaces/icepack_meltpond_topo.F90
+++ b/config_src/external/Icepack_interfaces/icepack_meltpond_topo.F90
@@ -1,0 +1,66 @@
+module icepack_meltpond_topo
+
+  use icepack_kinds, only : int_kind, dbl_kind
+  use icepack_tracers, only : n_iso, n_aero
+
+  implicit none
+
+  private
+  public :: compute_ponds_topo
+  contains
+
+!> Interface for updating the melt ponds using Icepack.
+  subroutine compute_ponds_topo(dt, ncat, nilyr,        &
+                                    ktherm,             &
+                                    aice,  aicen,       &
+                                    vice,  vicen,       &
+                                    vsno,  vsnon,       &
+                                    meltt,              &
+                                    fsurf, fpond,       &
+                                    Tsfcn, Tf,          &
+                                    qicen, sicen,       &
+                                    apnd,  hpnd, ipnd   )
+
+    integer (kind=int_kind), intent(in) :: &
+         ncat , &   !< number of thickness categories
+         nilyr, &   !< number of ice layers
+         ktherm     !< type of thermodynamics (0 0-layer, 1 BL99, 2 mushy)
+
+    real (kind=dbl_kind), intent(in) :: &
+         dt !< time step (s)
+
+    real (kind=dbl_kind), intent(in) :: &
+         aice, &    !< total ice area fraction
+         vsno, &    !< total snow volume (m)
+         Tf   !< ocean freezing temperature [= ice bottom temperature] (degC)
+
+    real (kind=dbl_kind), intent(inout) :: &
+         vice, &    !< total ice volume (m)
+         fpond      !< fresh water flux to ponds (m)
+
+    real (kind=dbl_kind), dimension (:), intent(in) :: &
+         aicen, &   !< ice area fraction, per category
+         vsnon      !< snow volume, per category (m)
+
+    real (kind=dbl_kind), dimension (:), intent(inout) :: &
+         vicen      !< ice volume, per category (m)
+
+    real (kind=dbl_kind), dimension (:), intent(in) :: &
+         Tsfcn      !< surface temperature
+
+    real (kind=dbl_kind), dimension (:,:), intent(in) :: &
+         qicen, &   !< ice enthalpy
+         sicen      !< ice salinity
+
+    real (kind=dbl_kind), dimension (:), intent(inout) :: &
+         apnd, &    !< pond fractional area
+         hpnd, &    !< pond depth (m)
+         ipnd       !< pond ice thickness (m)
+
+    real (kind=dbl_kind), intent(in) :: &
+         meltt, &   !< total surface meltwater flux
+         fsurf      !< thermodynamic heat flux at ice/snow surface (W/m^2)
+
+  end subroutine compute_ponds_topo
+
+end module icepack_meltpond_topo

--- a/config_src/external/Icepack_interfaces/icepack_meltpond_topo.F90
+++ b/config_src/external/Icepack_interfaces/icepack_meltpond_topo.F90
@@ -10,20 +10,18 @@ module icepack_meltpond_topo
   contains
 
 !> Interface for updating the melt ponds using Icepack.
-  subroutine compute_ponds_topo(dt, ncat, nilyr,        &
-                                    ktherm,             &
-                                    aice,  aicen,       &
-                                    vice,  vicen,       &
-                                    vsno,  vsnon,       &
-                                    meltt,              &
-                                    fsurf, fpond,       &
-                                    Tsfcn, Tf,          &
-                                    qicen, sicen,       &
-                                    apnd,  hpnd, ipnd   )
+  subroutine compute_ponds_topo(dt,                 &
+                                ktherm,             &
+                                aice,  aicen,       &
+                                vice,  vicen,       &
+                                vsno,  vsnon,       &
+                                meltt,       &
+                                fsurf, fpond,       &
+                                Tsfcn, Tf,          &
+                                qicen, sicen,       &
+                                apnd,  hpnd, ipnd   )
 
     integer (kind=int_kind), intent(in) :: &
-         ncat , &   !< number of thickness categories
-         nilyr, &   !< number of ice layers
          ktherm     !< type of thermodynamics (0 0-layer, 1 BL99, 2 mushy)
 
     real (kind=dbl_kind), intent(in) :: &

--- a/config_src/external/Icepack_interfaces/icepack_parameters.F90
+++ b/config_src/external/Icepack_interfaces/icepack_parameters.F90
@@ -4,27 +4,27 @@
 !
 ! authors: Elizabeth C. Hunke, LANL
 
-      module icepack_parameters
+module icepack_parameters
 
-      use icepack_kinds
-      use icepack_warnings, only: icepack_warnings_aborted
+  use icepack_kinds, only: int_kind, dbl_kind, log_kind, char_len
+  use icepack_warnings, only: icepack_warnings_aborted
 
-      implicit none
-      private
+  implicit none
+  private
 
-      public :: icepack_init_parameters
-      public :: icepack_query_parameters
-      public :: icepack_write_parameters
-      public :: icepack_recompute_constants
+  public :: icepack_init_parameters
+  public :: icepack_query_parameters
+  public :: icepack_write_parameters
+  public :: icepack_recompute_constants
 
       !-----------------------------------------------------------------
       ! parameter constants
       !-----------------------------------------------------------------
 
-      integer (kind=int_kind), parameter, public :: &
-         nspint = 3                ! number of solar spectral intervals
+  integer (kind=int_kind), parameter, public :: &
+         nspint = 3                !< number of solar spectral intervals
 
-      real (kind=dbl_kind), parameter, public :: &
+  real (kind=dbl_kind), parameter, public :: &
          c0   = 0.0_dbl_kind, &
          c1   = 1.0_dbl_kind, &
          c1p5 = 1.5_dbl_kind, &
@@ -57,7 +57,7 @@
          p666 = c2/c3, &
          spval_const= -1.0e36_dbl_kind
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          secday = 86400.0_dbl_kind ,&! seconds in calendar day
          puny   = 1.0e-11_dbl_kind, &
          bignum = 1.0e+30_dbl_kind, &
@@ -70,7 +70,7 @@
       !    Cp     = 0.5_dbl_kind*gravit*(rhow-rhoi)*rhoi/rhow ,&! proport const for PE
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          pih        = spval_const     ,&! 0.5 * pi
          piq        = spval_const     ,&! 0.25 * pi
          pi2        = spval_const     ,&! 2 * pi
@@ -79,11 +79,11 @@
          cprho      = spval_const     ,&! for ocean mixed layer (J kg / K m^3)
          Cp         = spval_const       ! proport const for PE
 
-      !-----------------------------------------------------------------
-      ! Densities
-      !-----------------------------------------------------------------
+  !-----------------------------------------------------------------
+  ! Densities
+  !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          rhos      = 330.0_dbl_kind   ,&! density of snow (kg/m^3)
          rhoi      = 917.0_dbl_kind   ,&! density of ice (kg/m^3)
          rhosi     = 940.0_dbl_kind   ,&! average sea ice density
@@ -95,7 +95,7 @@
 ! Parameters for thermodynamics
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          hfrazilmin = 0.05_dbl_kind   ,&! min thickness of new frazil ice (m)
          cp_ice    = 2106._dbl_kind   ,&! specific heat of fresh ice (J/kg/K)
          cp_ocn    = 4218._dbl_kind   ,&! specific heat of ocn    (J/kg/K)
@@ -133,17 +133,17 @@
          phi_c_slow_mode   =    0.05_dbl_kind,&! critical liquid fraction porosity cutoff
          phi_i_mushy       =    0.85_dbl_kind  ! liquid fraction of congelation ice
 
-      integer (kind=int_kind), public :: &
+  integer (kind=int_kind), public :: &
          ktherm = 1      ! type of thermodynamics
                          ! 0 = 0-layer approximation
                          ! 1 = Bitz and Lipscomb 1999
                          ! 2 = mushy layer theory
 
-      character (char_len), public :: &
+  character (char_len), public :: &
          conduct = 'bubbly', &      ! 'MU71' or 'bubbly'
          fbot_xfer_type = 'constant' ! transfer coefficient type for ice-ocean heat flux
 
-      logical (kind=log_kind), public :: &
+  logical (kind=log_kind), public :: &
          heat_capacity = .true. ,&! if true, ice has nonzero heat capacity
                                   ! if false, use zero-layer thermodynamics
          calc_Tsfc     = .true. ,&! if true, calculate surface temperature
@@ -155,7 +155,7 @@
                                   ! only for use with tr_aero or tr_zaero
          conserv_check = .false.  ! if true, do conservations checks and abort
 
-      character(len=char_len), public :: &
+  character(len=char_len), public :: &
          tfrz_option  = 'mushy'   ! form of ocean freezing temperature
                                   ! 'minus1p8' = -1.8 C
                                   ! 'linear_salt' = -depressT * sss
@@ -165,7 +165,7 @@
 ! Parameters for radiation
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          ! (Briegleb JGR 97 11475-11485  July 1992)
          emissivity = 0.985_dbl_kind,&! emissivity of snow and ice
          albocn     = 0.06_dbl_kind ,&! ocean albedo
@@ -194,13 +194,13 @@
       ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
       ! in a summer polar atmosphere with 1.5m bare sea ice surface:
       ! .636/.364 vis/nir with only 0.5% direct for each band.
-      real (kind=dbl_kind), public :: &                 ! currently used only
+  real (kind=dbl_kind), public :: &                 ! currently used only
          awtvdr = 0.00318_dbl_kind, &! visible, direct  ! for history and
          awtidr = 0.00182_dbl_kind, &! near IR, direct  ! diagnostics
          awtvdf = 0.63282_dbl_kind, &! visible, diffuse
          awtidf = 0.36218_dbl_kind   ! near IR, diffuse
 
-      character (len=char_len), public :: &
+  character (len=char_len), public :: &
          shortwave   = 'dEdd', & ! shortwave method, 'ccsm3' or 'dEdd'
          albedo_type = 'ccsm3'   ! albedo parameterization, 'ccsm3' or 'constant'
                                  ! shortwave='dEdd' overrides this parameter
@@ -209,7 +209,7 @@
 ! Parameters for dynamics, including ridging and strength
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), public :: & ! defined in namelist
+  integer (kind=int_kind), public :: & ! defined in namelist
          kstrength   = 1, & ! 0 for simple Hibler (1979) formulation
                             ! 1 for Rothrock (1975) pressure formulation
          krdg_partic = 1, & ! 0 for Thorndike et al. (1975) formulation
@@ -217,7 +217,7 @@
          krdg_redist = 1    ! 0 for Hibler (1980) formulation
                             ! 1 for exponential redistribution function
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          Cf       = 17._dbl_kind     ,&! ratio of ridging work to PE change in ridging
          Pstar    = 2.75e4_dbl_kind  ,&! constant in Hibler strength formula
                                        ! (kstrength = 0)
@@ -232,7 +232,7 @@
 ! Parameters for atmosphere
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          cp_air = 1005.0_dbl_kind    ,&! specific heat of air (J/kg/K)
          cp_wv  = 1.81e3_dbl_kind    ,&! specific heat of water vapor (J/kg/K)
          zvir   = 0.606_dbl_kind     ,&! rh2o/rair - 1.0
@@ -243,25 +243,25 @@
          qqqocn = 627572.4_dbl_kind  ,&! for qsat over ocn
          TTTocn = 5107.4_dbl_kind      ! for qsat over ocn
 
-      character (len=char_len), public :: &
+  character (len=char_len), public :: &
          atmbndy = 'default' ! atmo boundary method, 'default' ('ccsm3') or 'constant'
 
-      logical (kind=log_kind), public :: &
+  logical (kind=log_kind), public :: &
          calc_strair     = .true.  , & ! if true, calculate wind stress
          formdrag        = .false. , & ! if true, calculate form drag
          highfreq        = .false.     ! if true, calculate high frequency coupling
 
-      integer (kind=int_kind), public :: &
+  integer (kind=int_kind), public :: &
          natmiter        = 5 ! number of iterations for atm boundary layer calcs
 
       ! Flux convergence tolerance
-      real (kind=dbl_kind), public :: atmiter_conv = c0
+  real (kind=dbl_kind), public :: atmiter_conv = c0
 
 !-----------------------------------------------------------------------
 ! Parameters for the ice thickness distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), public :: &
+  integer (kind=int_kind), public :: &
          kitd      = 1 ,&! type of itd conversions
                          !   0 = delta function
                          !   1 = linear remap
@@ -274,33 +274,33 @@
 ! Parameters for the floe size distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), public :: &
+  integer (kind=int_kind), public :: &
          nfreq = 25                   ! number of frequencies
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          floeshape = 0.66_dbl_kind    ! constant from Steele (unitless)
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          floediam  = 300.0_dbl_kind   ! effective floe diameter for lateral melt (m)
 
-      logical (kind=log_kind), public :: &
+  logical (kind=log_kind), public :: &
          wave_spec = .false.          ! if true, use wave forcing
 
-      character (len=char_len), public :: &
+  character (len=char_len), public :: &
          wave_spec_type = 'constant'  ! 'none', 'constant', or 'random'
 
 !-----------------------------------------------------------------------
 ! Parameters for melt ponds
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          hs0       = 0.03_dbl_kind    ! snow depth for transition to bare sea ice (m)
 
       ! level-ice ponds
-      character (len=char_len), public :: &
+  character (len=char_len), public :: &
          frzpnd    = 'cesm'           ! pond refreezing parameterization
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          dpscale   = c1, &            ! alter e-folding time scale for flushing
          rfracmin  = 0.15_dbl_kind, & ! minimum retained fraction of meltwater
          rfracmax  = 0.85_dbl_kind, & ! maximum retained fraction of meltwater
@@ -308,25 +308,25 @@
          hs1       = 0.03_dbl_kind    ! snow depth for transition to bare pond ice (m)
 
       ! topo ponds
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          hp1       = 0.01_dbl_kind    ! critical pond lid thickness for topo ponds
 
 !-----------------------------------------------------------------------
 ! Parameters for biogeochemistry
 !-----------------------------------------------------------------------
 
-      character(char_len), public :: &
+  character(char_len), public :: &
       ! skl biology parameters
          bgc_flux_type = 'Jin2006'  ! type of ocean-ice poston velocity (or 'constant')
 
-      logical (kind=log_kind), public :: &
+  logical (kind=log_kind), public :: &
          z_tracers  = .false.,    & ! if .true., bgc or aerosol tracers are vertically resolved
          scale_bgc  = .false.,    & ! if .true., initialize bgc tracers proportionally with salinity
          solve_zbgc = .false.,    & ! if .true., solve vertical biochemistry portion of code
          dEdd_algae = .false.,    & ! if .true., algal absorption of shortwave is computed in the
          skl_bgc    = .false.       ! if true, solve skeletal biochemistry
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          phi_snow     = p5              , & ! snow porosity
          grid_o       = c5              , & ! for bottom flux
          initbio_frac = c1              , & ! fraction of ocean trcr concentration in bio trcrs
@@ -363,23 +363,19 @@
 ! Parameters for shortwave redistribution
 !-----------------------------------------------------------------------
 
-      logical (kind=log_kind), public :: &
+  logical (kind=log_kind), public :: &
          sw_redist     = .false.
 
-      real (kind=dbl_kind), public :: &
+  real (kind=dbl_kind), public :: &
          sw_frac      = 0.9_dbl_kind    , & ! Fraction of internal shortwave moved to surface
          sw_dtemp     = 0.02_dbl_kind       ! temperature difference from melting
 
 !=======================================================================
 
-      contains
+  contains
 
-!=======================================================================
-
-!autodocument_start icepack_init_parameters
-! subroutine to set the column package internal parameters
-
-      subroutine icepack_init_parameters(   &
+  !> stub for Icepack subroutine to set the column package internal parameters
+  subroutine icepack_init_parameters(   &
          puny_in, bignum_in, pi_in, secday_in, &
          rhos_in, rhoi_in, rhow_in, cp_air_in, emissivity_in, &
          cp_ice_in, cp_ocn_in, hfrazilmin_in, floediam_in, &
@@ -422,461 +418,455 @@
       ! parameter constants
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         secday_in,     & !
-         puny_in,       & !
-         bignum_in,     & !
-         pi_in            !
+    real (kind=dbl_kind), intent(in), optional :: &
+         secday_in,     & !< seconds per day
+         puny_in,       & !< some small number
+         bignum_in,     & !< some large number
+         pi_in            !< pi
 
       !-----------------------------------------------------------------
       ! densities
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         rhos_in,       & ! density of snow (kg/m^3)
-         rhoi_in,       & ! density of ice (kg/m^3)
-         rhosi_in,      & ! average sea ice density (kg/m2)
-         rhow_in,       & ! density of seawater (kg/m^3)
-         rhofresh_in      ! density of fresh water (kg/m^3)
+    real (kind=dbl_kind), intent(in), optional :: &
+         rhos_in,       & !< density of snow (kg/m^3)
+         rhoi_in,       & !< density of ice (kg/m^3)
+         rhosi_in,      & !< average sea ice density (kg/m2)
+         rhow_in,       & !< density of seawater (kg/m^3)
+         rhofresh_in      !< density of fresh water (kg/m^3)
 
 !-----------------------------------------------------------------------
 ! Parameters for thermodynamics
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         floediam_in,   & ! effective floe diameter for lateral melt (m)
-         hfrazilmin_in, & ! min thickness of new frazil ice (m)
-         cp_ice_in,     & ! specific heat of fresh ice (J/kg/K)
-         cp_ocn_in,     & ! specific heat of ocn    (J/kg/K)
-         depressT_in,   & ! Tf:brine salinity ratio (C/ppt)
-         viscosity_dyn_in, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz_in,    & ! freezing temp of seawater (C)
-         Tffresh_in,    & ! freezing temp of fresh ice (K)
-         Lsub_in,       & ! latent heat, sublimation freshwater (J/kg)
-         Lvap_in,       & ! latent heat, vaporization freshwater (J/kg)
-         Timelt_in,     & ! melting temperature, ice top surface  (C)
-         Tsmelt_in,     & ! melting temperature, snow top surface (C)
-         ice_ref_salinity_in, & ! (ppt)
-         kice_in,       & ! thermal conductivity of fresh ice(W/m/deg)
-         kseaice_in,    & ! thermal conductivity of sea ice (W/m/deg)
-         ksno_in,       & ! thermal conductivity of snow  (W/m/deg)
-         hs_min_in,     & ! min snow thickness for computing zTsn (m)
-         snowpatch_in,  & ! parameter for fractional snow area (m)
-         saltmax_in,    & ! max salinity at ice base for BL99 (ppt)
-         phi_init_in,   & ! initial liquid fraction of frazil
-         min_salin_in,  & ! threshold for brine pocket treatment
-         salt_loss_in,  & ! fraction of salt retained in zsalinity
-         dSin0_frazil_in  ! bulk salinity reduction of newly formed frazil
+    real (kind=dbl_kind), intent(in), optional :: &
+         floediam_in,   & !< effective floe diameter for lateral melt (m)
+         hfrazilmin_in, & !< min thickness of new frazil ice (m)
+         cp_ice_in,     & !< specific heat of fresh ice (J/kg/K)
+         cp_ocn_in,     & !< specific heat of ocn    (J/kg/K)
+         depressT_in,   & !< Tf:brine salinity ratio (C/ppt)
+         viscosity_dyn_in, & !< dynamic viscosity of brine (kg/m/s)
+         Tocnfrz_in,    & !< freezing temp of seawater (C)
+         Tffresh_in,    & !< freezing temp of fresh ice (K)
+         Lsub_in,       & !< latent heat, sublimation freshwater (J/kg)
+         Lvap_in,       & !< latent heat, vaporization freshwater (J/kg)
+         Timelt_in,     & !< melting temperature, ice top surface  (C)
+         Tsmelt_in,     & !< melting temperature, snow top surface (C)
+         ice_ref_salinity_in, & !< (ppt)
+         kice_in,       & !< thermal conductivity of fresh ice(W/m/deg)
+         kseaice_in,    & !< thermal conductivity of sea ice (W/m/deg)
+         ksno_in,       & !< thermal conductivity of snow  (W/m/deg)
+         hs_min_in,     & !< min snow thickness for computing zTsn (m)
+         snowpatch_in,  & !< parameter for fractional snow area (m)
+         saltmax_in,    & !< max salinity at ice base for BL99 (ppt)
+         phi_init_in,   & !< initial liquid fraction of frazil
+         min_salin_in,  & !< threshold for brine pocket treatment
+         salt_loss_in,  & !< fraction of salt retained in zsalinity
+         dSin0_frazil_in  !< bulk salinity reduction of newly formed frazil
 
-      integer (kind=int_kind), intent(in), optional :: &
-         ktherm_in          ! type of thermodynamics
-                            ! 0 = 0-layer approximation
-                            ! 1 = Bitz and Lipscomb 1999
-                            ! 2 = mushy layer theory
+    integer (kind=int_kind), intent(in), optional :: &
+         ktherm_in          !< type of thermodynamics
+                            !! 0 = 0-layer approximation
+                            !! 1 = Bitz and Lipscomb 1999
+                            !! 2 = mushy layer theory
 
-      character (char_len), intent(in), optional :: &
-         conduct_in, &      ! 'MU71' or 'bubbly'
-         fbot_xfer_type_in  ! transfer coefficient type for ice-ocean heat flux
+    character (char_len), intent(in), optional :: &
+         conduct_in, &      !< 'MU71' or 'bubbly'
+         fbot_xfer_type_in  !< transfer coefficient type for ice-ocean heat flux
 
-      logical (kind=log_kind), intent(in), optional :: &
-         heat_capacity_in, &! if true, ice has nonzero heat capacity
-                            ! if false, use zero-layer thermodynamics
-         calc_Tsfc_in    , &! if true, calculate surface temperature
-                            ! if false, Tsfc is computed elsewhere and
-                            ! atmos-ice fluxes are provided to CICE
-         update_ocn_f_in    ! include fresh water and salt fluxes for frazil
+    logical (kind=log_kind), intent(in), optional :: &
+         heat_capacity_in, &!< if true, ice has nonzero heat capacity
+                            !! if false, use zero-layer thermodynamics
+         calc_Tsfc_in    , &!< if true, calculate surface temperature
+                            !! if false, Tsfc is computed elsewhere and
+                            !! atmos-ice fluxes are provided to CICE
+         update_ocn_f_in    !< include fresh water and salt fluxes for frazil
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         dts_b_in,   &      ! zsalinity timestep
-         ustar_min_in       ! minimum friction velocity for ice-ocean heat flux
+    real (kind=dbl_kind), intent(in), optional :: &
+         dts_b_in,   &      !< zsalinity timestep
+         ustar_min_in       !< minimum friction velocity for ice-ocean heat flux
 
       ! mushy thermo
-      real(kind=dbl_kind), intent(in), optional :: &
-         a_rapid_mode_in      , & ! channel radius for rapid drainage mode (m)
-         Rac_rapid_mode_in    , & ! critical Rayleigh number for rapid drainage mode
-         aspect_rapid_mode_in , & ! aspect ratio for rapid drainage mode (larger=wider)
-         dSdt_slow_mode_in    , & ! slow mode drainage strength (m s-1 K-1)
-         phi_c_slow_mode_in   , & ! liquid fraction porosity cutoff for slow mode
-         phi_i_mushy_in           ! liquid fraction of congelation ice
+    real(kind=dbl_kind), intent(in), optional :: &
+         a_rapid_mode_in      , & !< channel radius for rapid drainage mode (m)
+         Rac_rapid_mode_in    , & !< critical Rayleigh number for rapid drainage mode
+         aspect_rapid_mode_in , & !< aspect ratio for rapid drainage mode (larger=wider)
+         dSdt_slow_mode_in    , & !< slow mode drainage strength (m s-1 K-1)
+         phi_c_slow_mode_in   , & !< liquid fraction porosity cutoff for slow mode
+         phi_i_mushy_in           !< liquid fraction of congelation ice
 
-        character(len=char_len), intent(in), optional :: &
-             tfrz_option_in              ! form of ocean freezing temperature
-                                         ! 'minus1p8' = -1.8 C
-                                         ! 'linear_salt' = -depressT * sss
-                                         ! 'mushy' conforms with ktherm=2
+      character(len=char_len), intent(in), optional :: &
+             tfrz_option_in   !< form of ocean freezing temperature
+                              !! 'minus1p8' = -1.8 C
+                              !! 'linear_salt' = -depressT * sss
+                              !! 'mushy' conforms with ktherm=2
 
 !-----------------------------------------------------------------------
 ! Parameters for radiation
 !-----------------------------------------------------------------------
 
-      real(kind=dbl_kind), intent(in), optional :: &
-         emissivity_in, & ! emissivity of snow and ice
-         albocn_in,     & ! ocean albedo
-         vonkar_in,     & ! von Karman constant
-         stefan_boltzmann_in, & !  W/m^2/K^4
-         kappav_in,     & ! vis extnctn coef in ice, wvlngth<700nm (1/m)
-         hi_ssl_in,     & ! ice surface scattering layer thickness (m)
-         hs_ssl_in,     & ! visible, direct
-         awtvdr_in,     & ! visible, direct  ! for history and
-         awtidr_in,     & ! near IR, direct  ! diagnostics
-         awtvdf_in,     & ! visible, diffuse
-         awtidf_in        ! near IR, diffuse
+    real(kind=dbl_kind), intent(in), optional :: &
+         emissivity_in, & !< emissivity of snow and ice
+         albocn_in,     & !< ocean albedo
+         vonkar_in,     & !< von Karman constant
+         stefan_boltzmann_in, & !<  W/m^2/K^4
+         kappav_in,     & !< vis extnctn coef in ice, wvlngth<700nm (1/m)
+         hi_ssl_in,     & !< ice surface scattering layer thickness (m)
+         hs_ssl_in,     & !< visible, direct
+         awtvdr_in,     & !< visible, direct  ! for history and
+         awtidr_in,     & !< near IR, direct  ! diagnostics
+         awtvdf_in,     & !< visible, diffuse
+         awtidf_in        !< near IR, diffuse
 
-      character (len=char_len), intent(in), optional :: &
-         shortwave_in, & ! shortwave method, 'ccsm3' or 'dEdd'
-         albedo_type_in  ! albedo parameterization, 'ccsm3' or 'constant'
-                         ! shortwave='dEdd' overrides this parameter
+    character (len=char_len), intent(in), optional :: &
+         shortwave_in, & !< shortwave method, 'ccsm3' or 'dEdd'
+         albedo_type_in  !< albedo parameterization, 'ccsm3' or 'constant'
+                         !! shortwave='dEdd' overrides this parameter
 
       ! baseline albedos for ccsm3 shortwave, set in namelist
-      real (kind=dbl_kind), intent(in), optional :: &
-         albicev_in  , & ! visible ice albedo for h > ahmax
-         albicei_in  , & ! near-ir ice albedo for h > ahmax
-         albsnowv_in , & ! cold snow albedo, visible
-         albsnowi_in , & ! cold snow albedo, near IR
-         ahmax_in        ! thickness above which ice albedo is constant (m)
+    real (kind=dbl_kind), intent(in), optional :: &
+         albicev_in  , & !< visible ice albedo for h > ahmax
+         albicei_in  , & !< near-ir ice albedo for h > ahmax
+         albsnowv_in , & !< cold snow albedo, visible
+         albsnowi_in , & !< cold snow albedo, near IR
+         ahmax_in        !< thickness above which ice albedo is constant (m)
 
       ! dEdd tuning parameters, set in namelist
-      real (kind=dbl_kind), intent(in), optional :: &
-         R_ice_in    , & ! sea ice tuning parameter; +1 > 1sig increase in albedo
-         R_pnd_in    , & ! ponded ice tuning parameter; +1 > 1sig increase in albedo
-         R_snw_in    , & ! snow tuning parameter; +1 > ~.01 change in broadband albedo
-         dT_mlt_in   , & ! change in temp for non-melt to melt snow grain
-                         ! radius change (C)
-         rsnw_mlt_in , & ! maximum melting snow grain radius (10^-6 m)
-         kalg_in         ! algae absorption coefficient for 0.5 m thick layer
+    real (kind=dbl_kind), intent(in), optional :: &
+         R_ice_in    , & !< sea ice tuning parameter; +1 > 1sig increase in albedo
+         R_pnd_in    , & !< ponded ice tuning parameter; +1 > 1sig increase in albedo
+         R_snw_in    , & !< snow tuning parameter; +1 > ~.01 change in broadband albedo
+         dT_mlt_in   , & !< change in temp for non-melt to melt snow grain
+                         !< radius change (C)
+         rsnw_mlt_in , & !< maximum melting snow grain radius (10^-6 m)
+         kalg_in         !< algae absorption coefficient for 0.5 m thick layer
 
-      logical (kind=log_kind), intent(in), optional :: &
-         sw_redist_in    ! redistribute shortwave
+    logical (kind=log_kind), intent(in), optional :: &
+         sw_redist_in    !< redistribute shortwave
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         sw_frac_in  , & ! Fraction of internal shortwave moved to surface
-         sw_dtemp_in     ! temperature difference from melting
+    real (kind=dbl_kind), intent(in), optional :: &
+         sw_frac_in  , & !< Fraction of internal shortwave moved to surface
+         sw_dtemp_in     !< temperature difference from melting
 
 !-----------------------------------------------------------------------
 ! Parameters for dynamics
 !-----------------------------------------------------------------------
 
-      real(kind=dbl_kind), intent(in), optional :: &
-         Cf_in,         & ! ratio of ridging work to PE change in ridging
-         Pstar_in,      & ! constant in Hibler strength formula
-         Cstar_in,      & ! constant in Hibler strength formula
-         dragio_in,     & ! ice-ocn drag coefficient
-         gravit_in,     & ! gravitational acceleration (m/s^2)
-         iceruf_in        ! ice surface roughness (m)
+    real(kind=dbl_kind), intent(in), optional :: &
+         Cf_in,         & !< ratio of ridging work to PE change in ridging
+         Pstar_in,      & !< constant in Hibler strength formula
+         Cstar_in,      & !< constant in Hibler strength formula
+         dragio_in,     & !< ice-ocn drag coefficient
+         gravit_in,     & !< gravitational acceleration (m/s^2)
+         iceruf_in        !< ice surface roughness (m)
 
-      integer (kind=int_kind), intent(in), optional :: & ! defined in namelist
-         kstrength_in  , & ! 0 for simple Hibler (1979) formulation
-                           ! 1 for Rothrock (1975) pressure formulation
-         krdg_partic_in, & ! 0 for Thorndike et al. (1975) formulation
-                           ! 1 for exponential participation function
-         krdg_redist_in    ! 0 for Hibler (1980) formulation
-                           ! 1 for exponential redistribution function
+    integer (kind=int_kind), intent(in), optional :: & ! defined in namelist
+         kstrength_in  , & !< 0 for simple Hibler (1979) formulation
+                           !! 1 for Rothrock (1975) pressure formulation
+         krdg_partic_in, & !< 0 for Thorndike et al. (1975) formulation
+                           !! 1 for exponential participation function
+         krdg_redist_in    !< 0 for Hibler (1980) formulation
+                           !! 1 for exponential redistribution function
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         mu_rdg_in         ! gives e-folding scale of ridged ice (m^.5)
+    real (kind=dbl_kind), intent(in), optional :: &
+         mu_rdg_in         !< gives e-folding scale of ridged ice (m^.5)
                            ! (krdg_redist = 1)
 
 !-----------------------------------------------------------------------
 ! Parameters for atmosphere
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         cp_air_in,     & ! specific heat of air (J/kg/K)
-         cp_wv_in,      & ! specific heat of water vapor (J/kg/K)
-         zvir_in,       & ! rh2o/rair - 1.0
-         zref_in,       & ! reference height for stability (m)
-         qqqice_in,     & ! for qsat over ice
-         TTTice_in,     & ! for qsat over ice
-         qqqocn_in,     & ! for qsat over ocn
-         TTTocn_in        ! for qsat over ocn
+    real (kind=dbl_kind), intent(in), optional :: &
+         cp_air_in,     & !< specific heat of air (J/kg/K)
+         cp_wv_in,      & !< specific heat of water vapor (J/kg/K)
+         zvir_in,       & !< rh2o/rair - 1.0
+         zref_in,       & !< reference height for stability (m)
+         qqqice_in,     & !< for qsat over ice
+         TTTice_in,     & !< for qsat over ice
+         qqqocn_in,     & !< for qsat over ocn
+         TTTocn_in        !< for qsat over ocn
 
-      character (len=char_len), intent(in), optional :: &
-         atmbndy_in ! atmo boundary method, 'default' ('ccsm3') or 'constant'
+    character (len=char_len), intent(in), optional :: &
+         atmbndy_in !< atmo boundary method, 'default' ('ccsm3') or 'constant'
 
-      logical (kind=log_kind), intent(in), optional :: &
-         calc_strair_in, &  ! if true, calculate wind stress components
-         formdrag_in,    &  ! if true, calculate form drag
-         highfreq_in        ! if true, use high frequency coupling
+    logical (kind=log_kind), intent(in), optional :: &
+         calc_strair_in, &  !< if true, calculate wind stress components
+         formdrag_in,    &  !< if true, calculate form drag
+         highfreq_in        !< if true, use high frequency coupling
 
-      integer (kind=int_kind), intent(in), optional :: &
-         natmiter_in        ! number of iterations for boundary layer calculations
+    integer (kind=int_kind), intent(in), optional :: &
+         natmiter_in        !< number of iterations for boundary layer calculations
 
-      ! Flux convergence tolerance
-      real (kind=dbl_kind), intent(in), optional :: atmiter_conv_in
+    real (kind=dbl_kind), intent(in), optional :: &
+         atmiter_conv_in    !< flux convergence tolerance
 
 !-----------------------------------------------------------------------
 ! Parameters for the ice thickness distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), intent(in), optional :: &
-         kitd_in        , & ! type of itd conversions
-                            !   0 = delta function
-                            !   1 = linear remap
-         kcatbound_in       !   0 = old category boundary formula
-                            !   1 = new formula giving round numbers
-                            !   2 = WMO standard
-                            !   3 = asymptotic formula
+    integer (kind=int_kind), intent(in), optional :: &
+         kitd_in        , & !< type of itd conversions
+                            !!   0 = delta function
+                            !!   1 = linear remap
+         kcatbound_in       !<   0 = old category boundary formula
+                            !!   1 = new formula giving round numbers
+                            !!   2 = WMO standard
+                            !!   3 = asymptotic formula
 
 !-----------------------------------------------------------------------
 ! Parameters for the floe size distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), intent(in), optional :: &
-         nfreq_in           ! number of frequencies
+    integer (kind=int_kind), intent(in), optional :: &
+         nfreq_in           !< number of frequencies
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         floeshape_in       ! constant from Steele (unitless)
+    real (kind=dbl_kind), intent(in), optional :: &
+         floeshape_in       !< constant from Steele (unitless)
 
-      logical (kind=log_kind), intent(in), optional :: &
-         wave_spec_in       ! if true, use wave forcing
+    logical (kind=log_kind), intent(in), optional :: &
+         wave_spec_in       !< if true, use wave forcing
 
-      character (len=char_len), intent(in), optional :: &
-         wave_spec_type_in  ! type of wave spectrum forcing
+    character (len=char_len), intent(in), optional :: &
+         wave_spec_type_in  !< type of wave spectrum forcing
 
 !-----------------------------------------------------------------------
 ! Parameters for biogeochemistry
 !-----------------------------------------------------------------------
 
-     character(char_len), intent(in), optional :: &
-        bgc_flux_type_in    ! type of ocean-ice piston velocity
-                            ! 'constant', 'Jin2006'
+    character(char_len), intent(in), optional :: &
+        bgc_flux_type_in    !< type of ocean-ice piston velocity
+                            !! 'constant', 'Jin2006'
 
-      logical (kind=log_kind), intent(in), optional :: &
-         z_tracers_in,      & ! if .true., bgc or aerosol tracers are vertically resolved
-         scale_bgc_in,      & ! if .true., initialize bgc tracers proportionally with salinity
-         solve_zbgc_in,     & ! if .true., solve vertical biochemistry portion of code
-         dEdd_algae_in,     & ! if .true., algal absorptionof Shortwave is computed in the
-         modal_aero_in,     & ! if .true., use modal aerosol formulation in shortwave
-         conserv_check_in     ! if .true., run conservation checks and abort if checks fail
+    logical (kind=log_kind), intent(in), optional :: &
+         z_tracers_in,      & !< if .true., bgc or aerosol tracers are vertically resolved
+         scale_bgc_in,      & !< if .true., initialize bgc tracers proportionally with salinity
+         solve_zbgc_in,     & !< if .true., solve vertical biochemistry portion of code
+         dEdd_algae_in,     & !< if .true., algal absorptionof Shortwave is computed in the
+         modal_aero_in,     & !< if .true., use modal aerosol formulation in shortwave
+         conserv_check_in     !< if .true., run conservation checks and abort if checks fail
 
-      logical (kind=log_kind), intent(in), optional :: &
-         skl_bgc_in,        &   ! if true, solve skeletal biochemistry
-         solve_zsal_in          ! if true, update salinity profile from solve_S_dt
+    logical (kind=log_kind), intent(in), optional :: &
+         skl_bgc_in,        &   !< if true, solve skeletal biochemistry
+         solve_zsal_in          !< if true, update salinity profile from solve_S_dt
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         grid_o_in      , & ! for bottom flux
-         l_sk_in        , & ! characteristic diffusive scale (zsalinity) (m)
-         initbio_frac_in, & ! fraction of ocean tracer concentration used to initialize tracer
-         phi_snow_in        ! snow porosity at the ice/snow interface
+    real (kind=dbl_kind), intent(in), optional :: &
+         grid_o_in      , & !< for bottom flux
+         l_sk_in        , & !< characteristic diffusive scale (zsalinity) (m)
+         initbio_frac_in, & !< fraction of ocean tracer concentration used to initialize tracer
+         phi_snow_in        !< snow porosity at the ice/snow interface
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         grid_oS_in     , & ! for bottom flux (zsalinity)
-         l_skS_in           ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
-      real (kind=dbl_kind), intent(in), optional :: &
-         fr_resp_in           , &   ! fraction of algal growth lost due to respiration
-         algal_vel_in         , &   ! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
-         R_dFe2dust_in        , &   !  g/g (3.5% content) Tagliabue 2009
-         dustFe_sol_in        , &   ! solubility fraction
-         T_max_in            , & ! maximum temperature (C)
-         fsal_in             , & ! Salinity limitation (ppt)
-         op_dep_min_in       , & ! Light attenuates for optical depths exceeding min
-         fr_graze_s_in       , & ! fraction of grazing spilled or slopped
-         fr_graze_e_in       , & ! fraction of assimilation excreted
-         fr_mort2min_in      , & ! fractionation of mortality to Am
-         fr_dFe_in           , & ! fraction of remineralized nitrogen
-                                    ! (in units of algal iron)
-         k_nitrif_in         , & ! nitrification rate (1/day)
-         t_iron_conv_in      , & ! desorption loss pFe to dFe (day)
-         max_loss_in         , & ! restrict uptake to % of remaining value
-         max_dfe_doc1_in     , & ! max ratio of dFe to saccharides in the ice
+    real (kind=dbl_kind), intent(in), optional :: &
+         grid_oS_in     , & !< for bottom flux (zsalinity)
+         l_skS_in           !< 0.02 characteristic skeletal layer thickness (m) (zsalinity)
+    real (kind=dbl_kind), intent(in), optional :: &
+         fr_resp_in           , &   !< fraction of algal growth lost due to respiration
+         algal_vel_in         , &   !< 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
+         R_dFe2dust_in        , &   !<  g/g (3.5% content) Tagliabue 2009
+         dustFe_sol_in        , &   !< solubility fraction
+         T_max_in            , & !< maximum temperature (C)
+         fsal_in             , & !< Salinity limitation (ppt)
+         op_dep_min_in       , & !< Light attenuates for optical depths exceeding min
+         fr_graze_s_in       , & !< fraction of grazing spilled or slopped
+         fr_graze_e_in       , & !< fraction of assimilation excreted
+         fr_mort2min_in      , & !< fractionation of mortality to Am
+         fr_dFe_in           , & !< fraction of remineralized nitrogen
+                                 !! (in units of algal iron)
+         k_nitrif_in         , & !< nitrification rate (1/day)
+         t_iron_conv_in      , & !< desorption loss pFe to dFe (day)
+         max_loss_in         , & !< restrict uptake to % of remaining value
+         max_dfe_doc1_in     , & !< max ratio of dFe to saccharides in the ice
                                     ! (nM Fe/muM C)
-         fr_resp_s_in        , & ! DMSPd fraction of respiration loss as DMSPd
-         y_sk_DMS_in         , & ! fraction conversion given high yield
-         t_sk_conv_in        , & ! Stefels conversion time (d)
-         t_sk_ox_in          , & ! DMS oxidation time (d)
-         frazil_scav_in          ! scavenging fraction or multiple in frazil ice
+         fr_resp_s_in        , & !< DMSPd fraction of respiration loss as DMSPd
+         y_sk_DMS_in         , & !< fraction conversion given high yield
+         t_sk_conv_in        , & !< Stefels conversion time (d)
+         t_sk_ox_in          , & !< DMS oxidation time (d)
+         frazil_scav_in          !< scavenging fraction or multiple in frazil ice
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         sk_l_in,       & ! skeletal layer thickness (m)
-         min_bgc_in       ! fraction of ocean bgc concentration in surface melt
+    real (kind=dbl_kind), intent(in), optional :: &
+         sk_l_in,       & !< skeletal layer thickness (m)
+         min_bgc_in       !< fraction of ocean bgc concentration in surface melt
 
 !-----------------------------------------------------------------------
 ! Parameters for melt ponds
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         hs0_in             ! snow depth for transition to bare sea ice (m)
+    real (kind=dbl_kind), intent(in), optional :: &
+         hs0_in             !< snow depth for transition to bare sea ice (m)
 
       ! level-ice ponds
-      character (len=char_len), intent(in), optional :: &
-         frzpnd_in          ! pond refreezing parameterization
+    character (len=char_len), intent(in), optional :: &
+         frzpnd_in          !< pond refreezing parameterization
 
-      real (kind=dbl_kind), intent(in), optional :: &
-         dpscale_in, &      ! alter e-folding time scale for flushing
-         rfracmin_in, &     ! minimum retained fraction of meltwater
-         rfracmax_in, &     ! maximum retained fraction of meltwater
-         pndaspect_in, &    ! ratio of pond depth to pond fraction
-         hs1_in             ! tapering parameter for snow on pond ice
+    real (kind=dbl_kind), intent(in), optional :: &
+         dpscale_in, &      !< alter e-folding time scale for flushing
+         rfracmin_in, &     !< minimum retained fraction of meltwater
+         rfracmax_in, &     !< maximum retained fraction of meltwater
+         pndaspect_in, &    !< ratio of pond depth to pond fraction
+         hs1_in             !< tapering parameter for snow on pond ice
 
       ! topo ponds
-      real (kind=dbl_kind), intent(in), optional :: &
-         hp1_in             ! critical parameter for pond ice thickness
+    real (kind=dbl_kind), intent(in), optional :: &
+         hp1_in             !< critical parameter for pond ice thickness
 
-!autodocument_end
+    character(len=*),parameter :: subname='(icepack_init_parameters)'
 
-      character(len=*),parameter :: subname='(icepack_init_parameters)'
+    if (present(rhos_in)              ) rhos             = rhos_in
+    if (present(rhoi_in)              ) rhoi             = rhoi_in
+    if (present(rhow_in)              ) rhow             = rhow_in
+    if (present(cp_air_in)            ) cp_air           = cp_air_in
+    if (present(emissivity_in)        ) emissivity       = emissivity_in
+    if (present(floediam_in)          ) floediam         = floediam_in
+    if (present(hfrazilmin_in)        ) hfrazilmin       = hfrazilmin_in
+    if (present(cp_ice_in)            ) cp_ice           = cp_ice_in
+    if (present(cp_ocn_in)            ) cp_ocn           = cp_ocn_in
+    if (present(depressT_in)          ) depressT         = depressT_in
+    if (present(dragio_in)            ) dragio           = dragio_in
+    if (present(albocn_in)            ) albocn           = albocn_in
+    if (present(gravit_in)            ) gravit           = gravit_in
+    if (present(viscosity_dyn_in)     ) viscosity_dyn    = viscosity_dyn_in
+    if (present(Tocnfrz_in)           ) Tocnfrz          = Tocnfrz_in
+    if (present(rhofresh_in)          ) rhofresh         = rhofresh_in
+    if (present(zvir_in)              ) zvir             = zvir_in
+    if (present(vonkar_in)            ) vonkar           = vonkar_in
+    if (present(cp_wv_in)             ) cp_wv            = cp_wv_in
+    if (present(stefan_boltzmann_in)  ) stefan_boltzmann = stefan_boltzmann_in
+    if (present(Tffresh_in)           ) Tffresh          = Tffresh_in
+    if (present(Lsub_in)              ) Lsub             = Lsub_in
+    if (present(Lvap_in)              ) Lvap             = Lvap_in
+    if (present(Timelt_in)            ) Timelt           = Timelt_in
+    if (present(Tsmelt_in)            ) Tsmelt           = Tsmelt_in
+    if (present(ice_ref_salinity_in)  ) ice_ref_salinity = ice_ref_salinity_in
+    if (present(iceruf_in)            ) iceruf           = iceruf_in
+    if (present(Cf_in)                ) Cf               = Cf_in
+    if (present(Pstar_in)             ) Pstar            = Pstar_in
+    if (present(Cstar_in)             ) Cstar            = Cstar_in
+    if (present(kappav_in)            ) kappav           = kappav_in
+    if (present(kice_in)              ) kice             = kice_in
+    if (present(kseaice_in)           ) kseaice          = kseaice_in
+    if (present(ksno_in)              ) ksno             = ksno_in
+    if (present(zref_in)              ) zref             = zref_in
+    if (present(hs_min_in)            ) hs_min           = hs_min_in
+    if (present(snowpatch_in)         ) snowpatch        = snowpatch_in
+    if (present(rhosi_in)             ) rhosi            = rhosi_in
+    if (present(sk_l_in)              ) sk_l             = sk_l_in
+    if (present(saltmax_in)           ) saltmax          = saltmax_in
+    if (present(phi_init_in)          ) phi_init         = phi_init_in
+    if (present(min_salin_in)         ) min_salin        = min_salin_in
+    if (present(salt_loss_in)         ) salt_loss        = salt_loss_in
+    if (present(min_bgc_in)           ) min_bgc          = min_bgc_in
+    if (present(dSin0_frazil_in)      ) dSin0_frazil     = dSin0_frazil_in
+    if (present(hi_ssl_in)            ) hi_ssl           = hi_ssl_in
+    if (present(hs_ssl_in)            ) hs_ssl           = hs_ssl_in
+    if (present(awtvdr_in)            ) awtvdr           = awtvdr_in
+    if (present(awtidr_in)            ) awtidr           = awtidr_in
+    if (present(awtvdf_in)            ) awtvdf           = awtvdf_in
+    if (present(awtidf_in)            ) awtidf           = awtidf_in
+    if (present(qqqice_in)            ) qqqice           = qqqice_in
+    if (present(TTTice_in)            ) TTTice           = TTTice_in
+    if (present(qqqocn_in)            ) qqqocn           = qqqocn_in
+    if (present(TTTocn_in)            ) TTTocn           = TTTocn_in
+    if (present(puny_in)              ) puny             = puny_in
+    if (present(bignum_in)            ) bignum           = bignum_in
+    if (present(pi_in)                ) pi               = pi_in
+    if (present(secday_in)            ) secday           = secday_in
+    if (present(ktherm_in)            ) ktherm           = ktherm_in
+    if (present(conduct_in)           ) conduct          = conduct_in
+    if (present(fbot_xfer_type_in)    ) fbot_xfer_type   = fbot_xfer_type_in
+    if (present(heat_capacity_in)     ) heat_capacity    = heat_capacity_in
+    if (present(calc_Tsfc_in)         ) calc_Tsfc        = calc_Tsfc_in
+    if (present(update_ocn_f_in)      ) update_ocn_f     = update_ocn_f_in
+    if (present(dts_b_in)             ) dts_b            = dts_b_in
+    if (present(ustar_min_in)         ) ustar_min        = ustar_min_in
+    if (present(a_rapid_mode_in)      ) a_rapid_mode     = a_rapid_mode_in
+    if (present(Rac_rapid_mode_in)    ) Rac_rapid_mode   = Rac_rapid_mode_in
+    if (present(aspect_rapid_mode_in) ) aspect_rapid_mode= aspect_rapid_mode_in
+    if (present(dSdt_slow_mode_in)    ) dSdt_slow_mode   = dSdt_slow_mode_in
+    if (present(phi_c_slow_mode_in)   ) phi_c_slow_mode  = phi_c_slow_mode_in
+    if (present(phi_i_mushy_in)       ) phi_i_mushy      = phi_i_mushy_in
+    if (present(shortwave_in)         ) shortwave        = shortwave_in
+    if (present(albedo_type_in)       ) albedo_type      = albedo_type_in
+    if (present(albicev_in)           ) albicev          = albicev_in
+    if (present(albicei_in)           ) albicei          = albicei_in
+    if (present(albsnowv_in)          ) albsnowv         = albsnowv_in
+    if (present(albsnowi_in)          ) albsnowi         = albsnowi_in
+    if (present(ahmax_in)             ) ahmax            = ahmax_in
+    if (present(R_ice_in)             ) R_ice            = R_ice_in
+    if (present(R_pnd_in)             ) R_pnd            = R_pnd_in
+    if (present(R_snw_in)             ) R_snw            = R_snw_in
+    if (present(dT_mlt_in)            ) dT_mlt           = dT_mlt_in
+    if (present(rsnw_mlt_in)          ) rsnw_mlt         = rsnw_mlt_in
+    if (present(kalg_in)              ) kalg             = kalg_in
+    if (present(kstrength_in)         ) kstrength        = kstrength_in
+    if (present(krdg_partic_in)       ) krdg_partic      = krdg_partic_in
+    if (present(krdg_redist_in)       ) krdg_redist      = krdg_redist_in
+    if (present(mu_rdg_in)            ) mu_rdg           = mu_rdg_in
+    if (present(atmbndy_in)           ) atmbndy          = atmbndy_in
+    if (present(calc_strair_in)       ) calc_strair      = calc_strair_in
+    if (present(formdrag_in)          ) formdrag         = formdrag_in
+    if (present(highfreq_in)          ) highfreq         = highfreq_in
+    if (present(natmiter_in)          ) natmiter         = natmiter_in
+    if (present(atmiter_conv_in)      ) atmiter_conv     = atmiter_conv_in
+    if (present(tfrz_option_in)       ) tfrz_option      = tfrz_option_in
+    if (present(kitd_in)              ) kitd             = kitd_in
+    if (present(kcatbound_in)         ) kcatbound        = kcatbound_in
+    if (present(floeshape_in)         ) floeshape        = floeshape_in
+    if (present(wave_spec_in)         ) wave_spec        = wave_spec_in
+    if (present(wave_spec_type_in)    ) wave_spec_type   = wave_spec_type_in
+    if (present(nfreq_in)             ) nfreq            = nfreq_in
+    if (present(hs0_in)               ) hs0              = hs0_in
+    if (present(frzpnd_in)            ) frzpnd           = frzpnd_in
+    if (present(dpscale_in)           ) dpscale          = dpscale_in
+    if (present(rfracmin_in)          ) rfracmin         = rfracmin_in
+    if (present(rfracmax_in)          ) rfracmax         = rfracmax_in
+    if (present(pndaspect_in)         ) pndaspect        = pndaspect_in
+    if (present(hs1_in)               ) hs1              = hs1_in
+    if (present(hp1_in)               ) hp1              = hp1_in
+    if (present(bgc_flux_type_in)     ) bgc_flux_type    = bgc_flux_type_in
+    if (present(z_tracers_in)         ) z_tracers        = z_tracers_in
+    if (present(scale_bgc_in)         ) scale_bgc        = scale_bgc_in
+    if (present(solve_zbgc_in)        ) solve_zbgc       = solve_zbgc_in
+    if (present(dEdd_algae_in)        ) dEdd_algae       = dEdd_algae_in
+    if (present(modal_aero_in)        ) modal_aero       = modal_aero_in
+    if (present(conserv_check_in)     ) conserv_check    = conserv_check_in
+    if (present(skl_bgc_in)           ) skl_bgc          = skl_bgc_in
+    if (present(solve_zsal_in)        ) solve_zsal       = solve_zsal_in
+    if (present(grid_o_in)            ) grid_o           = grid_o_in
+    if (present(l_sk_in)              ) l_sk             = l_sk_in
+    if (present(initbio_frac_in)      ) initbio_frac     = initbio_frac_in
+    if (present(grid_oS_in)           ) grid_oS          = grid_oS_in
+    if (present(l_skS_in)             ) l_skS            = l_skS_in
+    if (present(phi_snow_in)          ) phi_snow         = phi_snow_in
+    if (present(fr_resp_in)           ) fr_resp          = fr_resp_in
+    if (present(algal_vel_in)         ) algal_vel        = algal_vel_in
+    if (present(R_dFe2dust_in)        ) R_dFe2dust       = R_dFe2dust_in
+    if (present(dustFe_sol_in)        ) dustFe_sol       = dustFe_sol_in
+    if (present(T_max_in)             ) T_max            = T_max_in
+    if (present(fsal_in)              ) fsal             = fsal_in
+    if (present(op_dep_min_in)        ) op_dep_min       = op_dep_min_in
+    if (present(fr_graze_s_in)        ) fr_graze_s       = fr_graze_s_in
+    if (present(fr_graze_e_in)        ) fr_graze_e       = fr_graze_e_in
+    if (present(fr_mort2min_in)       ) fr_mort2min      = fr_mort2min_in
+    if (present(fr_dFe_in)            ) fr_dFe           = fr_dFe_in
+    if (present(k_nitrif_in)          ) k_nitrif         = k_nitrif_in
+    if (present(t_iron_conv_in)       ) t_iron_conv      = t_iron_conv_in
+    if (present(max_loss_in)          ) max_loss         = max_loss_in
+    if (present(max_dfe_doc1_in)      ) max_dfe_doc1     = max_dfe_doc1_in
+    if (present(fr_resp_s_in)         ) fr_resp_s        = fr_resp_s_in
+    if (present(y_sk_DMS_in)          ) y_sk_DMS         = y_sk_DMS_in
+    if (present(t_sk_conv_in)         ) t_sk_conv        = t_sk_conv_in
+    if (present(t_sk_ox_in)           ) t_sk_ox          = t_sk_ox_in
+    if (present(frazil_scav_in)       ) frazil_scav      = frazil_scav_in
+    if (present(sw_redist_in)         ) sw_redist        = sw_redist_in
+    if (present(sw_frac_in)           ) sw_frac          = sw_frac_in
+    if (present(sw_dtemp_in)          ) sw_dtemp         = sw_dtemp_in
 
-      if (present(rhos_in)              ) rhos             = rhos_in
-      if (present(rhoi_in)              ) rhoi             = rhoi_in
-      if (present(rhow_in)              ) rhow             = rhow_in
-      if (present(cp_air_in)            ) cp_air           = cp_air_in
-      if (present(emissivity_in)        ) emissivity       = emissivity_in
-      if (present(floediam_in)          ) floediam         = floediam_in
-      if (present(hfrazilmin_in)        ) hfrazilmin       = hfrazilmin_in
-      if (present(cp_ice_in)            ) cp_ice           = cp_ice_in
-      if (present(cp_ocn_in)            ) cp_ocn           = cp_ocn_in
-      if (present(depressT_in)          ) depressT         = depressT_in
-      if (present(dragio_in)            ) dragio           = dragio_in
-      if (present(albocn_in)            ) albocn           = albocn_in
-      if (present(gravit_in)            ) gravit           = gravit_in
-      if (present(viscosity_dyn_in)     ) viscosity_dyn    = viscosity_dyn_in
-      if (present(Tocnfrz_in)           ) Tocnfrz          = Tocnfrz_in
-      if (present(rhofresh_in)          ) rhofresh         = rhofresh_in
-      if (present(zvir_in)              ) zvir             = zvir_in
-      if (present(vonkar_in)            ) vonkar           = vonkar_in
-      if (present(cp_wv_in)             ) cp_wv            = cp_wv_in
-      if (present(stefan_boltzmann_in)  ) stefan_boltzmann = stefan_boltzmann_in
-      if (present(Tffresh_in)           ) Tffresh          = Tffresh_in
-      if (present(Lsub_in)              ) Lsub             = Lsub_in
-      if (present(Lvap_in)              ) Lvap             = Lvap_in
-      if (present(Timelt_in)            ) Timelt           = Timelt_in
-      if (present(Tsmelt_in)            ) Tsmelt           = Tsmelt_in
-      if (present(ice_ref_salinity_in)  ) ice_ref_salinity = ice_ref_salinity_in
-      if (present(iceruf_in)            ) iceruf           = iceruf_in
-      if (present(Cf_in)                ) Cf               = Cf_in
-      if (present(Pstar_in)             ) Pstar            = Pstar_in
-      if (present(Cstar_in)             ) Cstar            = Cstar_in
-      if (present(kappav_in)            ) kappav           = kappav_in
-      if (present(kice_in)              ) kice             = kice_in
-      if (present(kseaice_in)           ) kseaice          = kseaice_in
-      if (present(ksno_in)              ) ksno             = ksno_in
-      if (present(zref_in)              ) zref             = zref_in
-      if (present(hs_min_in)            ) hs_min           = hs_min_in
-      if (present(snowpatch_in)         ) snowpatch        = snowpatch_in
-      if (present(rhosi_in)             ) rhosi            = rhosi_in
-      if (present(sk_l_in)              ) sk_l             = sk_l_in
-      if (present(saltmax_in)           ) saltmax          = saltmax_in
-      if (present(phi_init_in)          ) phi_init         = phi_init_in
-      if (present(min_salin_in)         ) min_salin        = min_salin_in
-      if (present(salt_loss_in)         ) salt_loss        = salt_loss_in
-      if (present(min_bgc_in)           ) min_bgc          = min_bgc_in
-      if (present(dSin0_frazil_in)      ) dSin0_frazil     = dSin0_frazil_in
-      if (present(hi_ssl_in)            ) hi_ssl           = hi_ssl_in
-      if (present(hs_ssl_in)            ) hs_ssl           = hs_ssl_in
-      if (present(awtvdr_in)            ) awtvdr           = awtvdr_in
-      if (present(awtidr_in)            ) awtidr           = awtidr_in
-      if (present(awtvdf_in)            ) awtvdf           = awtvdf_in
-      if (present(awtidf_in)            ) awtidf           = awtidf_in
-      if (present(qqqice_in)            ) qqqice           = qqqice_in
-      if (present(TTTice_in)            ) TTTice           = TTTice_in
-      if (present(qqqocn_in)            ) qqqocn           = qqqocn_in
-      if (present(TTTocn_in)            ) TTTocn           = TTTocn_in
-      if (present(puny_in)              ) puny             = puny_in
-      if (present(bignum_in)            ) bignum           = bignum_in
-      if (present(pi_in)                ) pi               = pi_in
-      if (present(secday_in)            ) secday           = secday_in
-      if (present(ktherm_in)            ) ktherm           = ktherm_in
-      if (present(conduct_in)           ) conduct          = conduct_in
-      if (present(fbot_xfer_type_in)    ) fbot_xfer_type   = fbot_xfer_type_in
-      if (present(heat_capacity_in)     ) heat_capacity    = heat_capacity_in
-      if (present(calc_Tsfc_in)         ) calc_Tsfc        = calc_Tsfc_in
-      if (present(update_ocn_f_in)      ) update_ocn_f     = update_ocn_f_in
-      if (present(dts_b_in)             ) dts_b            = dts_b_in
-      if (present(ustar_min_in)         ) ustar_min        = ustar_min_in
-      if (present(a_rapid_mode_in)      ) a_rapid_mode     = a_rapid_mode_in
-      if (present(Rac_rapid_mode_in)    ) Rac_rapid_mode   = Rac_rapid_mode_in
-      if (present(aspect_rapid_mode_in) ) aspect_rapid_mode= aspect_rapid_mode_in
-      if (present(dSdt_slow_mode_in)    ) dSdt_slow_mode   = dSdt_slow_mode_in
-      if (present(phi_c_slow_mode_in)   ) phi_c_slow_mode  = phi_c_slow_mode_in
-      if (present(phi_i_mushy_in)       ) phi_i_mushy      = phi_i_mushy_in
-      if (present(shortwave_in)         ) shortwave        = shortwave_in
-      if (present(albedo_type_in)       ) albedo_type      = albedo_type_in
-      if (present(albicev_in)           ) albicev          = albicev_in
-      if (present(albicei_in)           ) albicei          = albicei_in
-      if (present(albsnowv_in)          ) albsnowv         = albsnowv_in
-      if (present(albsnowi_in)          ) albsnowi         = albsnowi_in
-      if (present(ahmax_in)             ) ahmax            = ahmax_in
-      if (present(R_ice_in)             ) R_ice            = R_ice_in
-      if (present(R_pnd_in)             ) R_pnd            = R_pnd_in
-      if (present(R_snw_in)             ) R_snw            = R_snw_in
-      if (present(dT_mlt_in)            ) dT_mlt           = dT_mlt_in
-      if (present(rsnw_mlt_in)          ) rsnw_mlt         = rsnw_mlt_in
-      if (present(kalg_in)              ) kalg             = kalg_in
-      if (present(kstrength_in)         ) kstrength        = kstrength_in
-      if (present(krdg_partic_in)       ) krdg_partic      = krdg_partic_in
-      if (present(krdg_redist_in)       ) krdg_redist      = krdg_redist_in
-      if (present(mu_rdg_in)            ) mu_rdg           = mu_rdg_in
-      if (present(atmbndy_in)           ) atmbndy          = atmbndy_in
-      if (present(calc_strair_in)       ) calc_strair      = calc_strair_in
-      if (present(formdrag_in)          ) formdrag         = formdrag_in
-      if (present(highfreq_in)          ) highfreq         = highfreq_in
-      if (present(natmiter_in)          ) natmiter         = natmiter_in
-      if (present(atmiter_conv_in)      ) atmiter_conv     = atmiter_conv_in
-      if (present(tfrz_option_in)       ) tfrz_option      = tfrz_option_in
-      if (present(kitd_in)              ) kitd             = kitd_in
-      if (present(kcatbound_in)         ) kcatbound        = kcatbound_in
-      if (present(floeshape_in)         ) floeshape        = floeshape_in
-      if (present(wave_spec_in)         ) wave_spec        = wave_spec_in
-      if (present(wave_spec_type_in)    ) wave_spec_type   = wave_spec_type_in
-      if (present(nfreq_in)             ) nfreq            = nfreq_in
-      if (present(hs0_in)               ) hs0              = hs0_in
-      if (present(frzpnd_in)            ) frzpnd           = frzpnd_in
-      if (present(dpscale_in)           ) dpscale          = dpscale_in
-      if (present(rfracmin_in)          ) rfracmin         = rfracmin_in
-      if (present(rfracmax_in)          ) rfracmax         = rfracmax_in
-      if (present(pndaspect_in)         ) pndaspect        = pndaspect_in
-      if (present(hs1_in)               ) hs1              = hs1_in
-      if (present(hp1_in)               ) hp1              = hp1_in
-      if (present(bgc_flux_type_in)     ) bgc_flux_type    = bgc_flux_type_in
-      if (present(z_tracers_in)         ) z_tracers        = z_tracers_in
-      if (present(scale_bgc_in)         ) scale_bgc        = scale_bgc_in
-      if (present(solve_zbgc_in)        ) solve_zbgc       = solve_zbgc_in
-      if (present(dEdd_algae_in)        ) dEdd_algae       = dEdd_algae_in
-      if (present(modal_aero_in)        ) modal_aero       = modal_aero_in
-      if (present(conserv_check_in)     ) conserv_check    = conserv_check_in
-      if (present(skl_bgc_in)           ) skl_bgc          = skl_bgc_in
-      if (present(solve_zsal_in)        ) solve_zsal       = solve_zsal_in
-      if (present(grid_o_in)            ) grid_o           = grid_o_in
-      if (present(l_sk_in)              ) l_sk             = l_sk_in
-      if (present(initbio_frac_in)      ) initbio_frac     = initbio_frac_in
-      if (present(grid_oS_in)           ) grid_oS          = grid_oS_in
-      if (present(l_skS_in)             ) l_skS            = l_skS_in
-      if (present(phi_snow_in)          ) phi_snow         = phi_snow_in
-      if (present(fr_resp_in)           ) fr_resp          = fr_resp_in
-      if (present(algal_vel_in)         ) algal_vel        = algal_vel_in
-      if (present(R_dFe2dust_in)        ) R_dFe2dust       = R_dFe2dust_in
-      if (present(dustFe_sol_in)        ) dustFe_sol       = dustFe_sol_in
-      if (present(T_max_in)             ) T_max            = T_max_in
-      if (present(fsal_in)              ) fsal             = fsal_in
-      if (present(op_dep_min_in)        ) op_dep_min       = op_dep_min_in
-      if (present(fr_graze_s_in)        ) fr_graze_s       = fr_graze_s_in
-      if (present(fr_graze_e_in)        ) fr_graze_e       = fr_graze_e_in
-      if (present(fr_mort2min_in)       ) fr_mort2min      = fr_mort2min_in
-      if (present(fr_dFe_in)            ) fr_dFe           = fr_dFe_in
-      if (present(k_nitrif_in)          ) k_nitrif         = k_nitrif_in
-      if (present(t_iron_conv_in)       ) t_iron_conv      = t_iron_conv_in
-      if (present(max_loss_in)          ) max_loss         = max_loss_in
-      if (present(max_dfe_doc1_in)      ) max_dfe_doc1     = max_dfe_doc1_in
-      if (present(fr_resp_s_in)         ) fr_resp_s        = fr_resp_s_in
-      if (present(y_sk_DMS_in)          ) y_sk_DMS         = y_sk_DMS_in
-      if (present(t_sk_conv_in)         ) t_sk_conv        = t_sk_conv_in
-      if (present(t_sk_ox_in)           ) t_sk_ox          = t_sk_ox_in
-      if (present(frazil_scav_in)       ) frazil_scav      = frazil_scav_in
-      if (present(sw_redist_in)         ) sw_redist        = sw_redist_in
-      if (present(sw_frac_in)           ) sw_frac          = sw_frac_in
-      if (present(sw_dtemp_in)          ) sw_dtemp         = sw_dtemp_in
+    call icepack_recompute_constants()
+    if (icepack_warnings_aborted(subname)) return
 
-      call icepack_recompute_constants()
-      if (icepack_warnings_aborted(subname)) return
+  end subroutine icepack_init_parameters
 
-      end subroutine icepack_init_parameters
-
-!=======================================================================
-
-!autodocument_start icepack_query_parameters
-! subroutine to query the column package internal parameters
-
-      subroutine icepack_query_parameters(   &
+  !> Icepack stub to query the column package internal parameters
+  subroutine icepack_query_parameters(   &
          puny_out, bignum_out, pi_out, rad_to_deg_out,&
          secday_out, c0_out, c1_out, c1p5_out, c2_out, c3_out, c4_out, &
          c5_out, c6_out, c8_out, c10_out, c15_out, c16_out, c20_out, &
@@ -924,705 +914,689 @@
       ! parameter constants
       !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(out), optional :: &
+    real (kind=dbl_kind), intent(out), optional :: &
          c0_out, c1_out, c1p5_out, c2_out, c3_out, c4_out, &
          c5_out, c6_out, c8_out, c10_out, c15_out, c16_out, c20_out, &
          c25_out, c180_out, c100_out, c1000_out, p001_out, p01_out, p1_out, &
          p2_out, p4_out, p5_out, p6_out, p05_out, p15_out, p25_out, p75_out, &
          p333_out, p666_out, spval_const_out, pih_out, piq_out, pi2_out, &
-         secday_out,     & ! number of seconds per day
-         puny_out,       & ! a small number
-         bignum_out,     & ! a big number
-         pi_out,         & ! pi
-         rad_to_deg_out, & ! conversion factor from radians to degrees
-         Lfresh_out,     & ! latent heat of melting of fresh ice (J/kg)
-         cprho_out,      & ! for ocean mixed layer (J kg / K m^3)
-         Cp_out            ! proport const for PE
+         secday_out,     & !< number of seconds per day
+         puny_out,       & !< a small number
+         bignum_out,     & !< a big number
+         pi_out,         & !< pi
+         rad_to_deg_out, & !< conversion factor from radians to degrees
+         Lfresh_out,     & !< latent heat of melting of fresh ice (J/kg)
+         cprho_out,      & !< for ocean mixed layer (J kg / K m^3)
+         Cp_out            !< proport const for PE
 
-      !-----------------------------------------------------------------
-      ! densities
-      !-----------------------------------------------------------------
+    !-----------------------------------------------------------------
+    ! densities
+    !-----------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         rhos_out,       & ! density of snow (kg/m^3)
-         rhoi_out,       & ! density of ice (kg/m^3)
-         rhosi_out,      & ! average sea ice density (kg/m2)
-         rhow_out,       & ! density of seawater (kg/m^3)
-         rhofresh_out      ! density of fresh water (kg/m^3)
+    real (kind=dbl_kind), intent(out), optional :: &
+         rhos_out,       & !< density of snow (kg/m^3)
+         rhoi_out,       & !< density of ice (kg/m^3)
+         rhosi_out,      & !< average sea ice density (kg/m2)
+         rhow_out,       & !< density of seawater (kg/m^3)
+         rhofresh_out      !< density of fresh water (kg/m^3)
 
 !-----------------------------------------------------------------------
 ! Parameters for thermodynamics
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         floediam_out,   & ! effective floe diameter for lateral melt (m)
-         hfrazilmin_out, & ! min thickness of new frazil ice (m)
-         cp_ice_out,     & ! specific heat of fresh ice (J/kg/K)
-         cp_ocn_out,     & ! specific heat of ocn    (J/kg/K)
-         depressT_out,   & ! Tf:brine salinity ratio (C/ppt)
-         viscosity_dyn_out, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz_out,    & ! freezing temp of seawater (C)
-         Tffresh_out,    & ! freezing temp of fresh ice (K)
-         Lsub_out,       & ! latent heat, sublimation freshwater (J/kg)
-         Lvap_out,       & ! latent heat, vaporization freshwater (J/kg)
-         Timelt_out,     & ! melting temperature, ice top surface  (C)
-         Tsmelt_out,     & ! melting temperature, snow top surface (C)
-         ice_ref_salinity_out, & ! (ppt)
-         kice_out,       & ! thermal conductivity of fresh ice(W/m/deg)
-         kseaice_out,    & ! thermal conductivity of sea ice (W/m/deg)
-         ksno_out,       & ! thermal conductivity of snow  (W/m/deg)
-         hs_min_out,     & ! min snow thickness for computing zTsn (m)
-         snowpatch_out,  & ! parameter for fractional snow area (m)
-         saltmax_out,    & ! max salinity at ice base for BL99 (ppt)
-         phi_init_out,   & ! initial liquid fraction of frazil
-         min_salin_out,  & ! threshold for brine pocket treatment
-         salt_loss_out,  & ! fraction of salt retained in zsalinity
-         dSin0_frazil_out  ! bulk salinity reduction of newly formed frazil
+    real (kind=dbl_kind), intent(out), optional :: &
+         floediam_out,   & !< effective floe diameter for lateral melt (m)
+         hfrazilmin_out, & !< min thickness of new frazil ice (m)
+         cp_ice_out,     & !< specific heat of fresh ice (J/kg/K)
+         cp_ocn_out,     & !< specific heat of ocn    (J/kg/K)
+         depressT_out,   & !< Tf:brine salinity ratio (C/ppt)
+         viscosity_dyn_out, & !< dynamic viscosity of brine (kg/m/s)
+         Tocnfrz_out,    & !< freezing temp of seawater (C)
+         Tffresh_out,    & !< freezing temp of fresh ice (K)
+         Lsub_out,       & !< latent heat, sublimation freshwater (J/kg)
+         Lvap_out,       & !< latent heat, vaporization freshwater (J/kg)
+         Timelt_out,     & !< melting temperature, ice top surface  (C)
+         Tsmelt_out,     & !< melting temperature, snow top surface (C)
+         ice_ref_salinity_out, & !< (ppt)
+         kice_out,       & !< thermal conductivity of fresh ice(W/m/deg)
+         kseaice_out,    & !< thermal conductivity of sea ice (W/m/deg)
+         ksno_out,       & !< thermal conductivity of snow  (W/m/deg)
+         hs_min_out,     & !< min snow thickness for computing zTsn (m)
+         snowpatch_out,  & !< parameter for fractional snow area (m)
+         saltmax_out,    & !< max salinity at ice base for BL99 (ppt)
+         phi_init_out,   & !< initial liquid fraction of frazil
+         min_salin_out,  & !< threshold for brine pocket treatment
+         salt_loss_out,  & !< fraction of salt retained in zsalinity
+         dSin0_frazil_out  !< bulk salinity reduction of newly formed frazil
 
-      integer (kind=int_kind), intent(out), optional :: &
-         ktherm_out         ! type of thermodynamics
-                            ! 0 = 0-layer approximation
-                            ! 1 = Bitz and Lipscomb 1999
-                            ! 2 = mushy layer theory
+    integer (kind=int_kind), intent(out), optional :: &
+         ktherm_out         !< type of thermodynamics
+                            !! 0 = 0-layer approximation
+                            !! 1 = Bitz and Lipscomb 1999
+                            !! 2 = mushy layer theory
 
-      character (char_len), intent(out), optional :: &
-         conduct_out, &     ! 'MU71' or 'bubbly'
-         fbot_xfer_type_out ! transfer coefficient type for ice-ocean heat flux
+    character (char_len), intent(out), optional :: &
+         conduct_out, &     !< 'MU71' or 'bubbly'
+         fbot_xfer_type_out !< transfer coefficient type for ice-ocean heat flux
 
-      logical (kind=log_kind), intent(out), optional :: &
-         heat_capacity_out,&! if true, ice has nonzero heat capacity
-                            ! if false, use zero-layer thermodynamics
-         calc_Tsfc_out    ,&! if true, calculate surface temperature
-                            ! if false, Tsfc is computed elsewhere and
-                            ! atmos-ice fluxes are provided to CICE
-         update_ocn_f_out   ! include fresh water and salt fluxes for frazil
+    logical (kind=log_kind), intent(out), optional :: &
+         heat_capacity_out,&!< if true, ice has nonzero heat capacity
+                            !! if false, use zero-layer thermodynamics
+         calc_Tsfc_out    ,&!< if true, calculate surface temperature
+                            !! if false, Tsfc is computed elsewhere and
+                            !! atmos-ice fluxes are provided to CICE
+         update_ocn_f_out   !< include fresh water and salt fluxes for frazil
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         dts_b_out,   &      ! zsalinity timestep
-         ustar_min_out       ! minimum friction velocity for ice-ocean heat flux
+    real (kind=dbl_kind), intent(out), optional :: &
+         dts_b_out,   &      !< zsalinity timestep
+         ustar_min_out       !< minimum friction velocity for ice-ocean heat flux
 
       ! mushy thermo
-      real(kind=dbl_kind), intent(out), optional :: &
-         a_rapid_mode_out      , & ! channel radius for rapid drainage mode (m)
-         Rac_rapid_mode_out    , & ! critical Rayleigh number for rapid drainage mode
-         aspect_rapid_mode_out , & ! aspect ratio for rapid drainage mode (larger=wider)
-         dSdt_slow_mode_out    , & ! slow mode drainage strength (m s-1 K-1)
-         phi_c_slow_mode_out   , & ! liquid fraction porosity cutoff for slow mode
-         phi_i_mushy_out           ! liquid fraction of congelation ice
+    real(kind=dbl_kind), intent(out), optional :: &
+         a_rapid_mode_out      , & !< channel radius for rapid drainage mode (m)
+         Rac_rapid_mode_out    , & !< critical Rayleigh number for rapid drainage mode
+         aspect_rapid_mode_out , & !< aspect ratio for rapid drainage mode (larger=wider)
+         dSdt_slow_mode_out    , & !< slow mode drainage strength (m s-1 K-1)
+         phi_c_slow_mode_out   , & !< liquid fraction porosity cutoff for slow mode
+         phi_i_mushy_out           !< liquid fraction of congelation ice
 
-      character(len=char_len), intent(out), optional :: &
-         tfrz_option_out              ! form of ocean freezing temperature
-                                      ! 'minus1p8' = -1.8 C
-                                      ! 'linear_salt' = -depressT * sss
-                                      ! 'mushy' conforms with ktherm=2
+    character(len=char_len), intent(out), optional :: &
+         tfrz_option_out              !< form of ocean freezing temperature
+                                      !! 'minus1p8' = -1.8 C
+                                      !! 'linear_salt' = -depressT * sss
+                                      !! 'mushy' conforms with ktherm=2
 
 !-----------------------------------------------------------------------
 ! Parameters for radiation
 !-----------------------------------------------------------------------
 
-      real(kind=dbl_kind), intent(out), optional :: &
-         emissivity_out, & ! emissivity of snow and ice
-         albocn_out,     & ! ocean albedo
-         vonkar_out,     & ! von Karman constant
-         stefan_boltzmann_out, & !  W/m^2/K^4
-         kappav_out,     & ! vis extnctn coef in ice, wvlngth<700nm (1/m)
-         hi_ssl_out,     & ! ice surface scattering layer thickness (m)
-         hs_ssl_out,     & ! visible, direct
-         awtvdr_out,     & ! visible, direct  ! for history and
-         awtidr_out,     & ! near IR, direct  ! diagnostics
-         awtvdf_out,     & ! visible, diffuse
-         awtidf_out        ! near IR, diffuse
+    real(kind=dbl_kind), intent(out), optional :: &
+         emissivity_out, & !< emissivity of snow and ice
+         albocn_out,     & !< ocean albedo
+         vonkar_out,     & !< von Karman constant
+         stefan_boltzmann_out, & !<  W/m^2/K^4
+         kappav_out,     & !< vis extnctn coef in ice, wvlngth<700nm (1/m)
+         hi_ssl_out,     & !< ice surface scattering layer thickness (m)
+         hs_ssl_out,     & !< visible, direct
+         awtvdr_out,     & !< visible, direct  ! for history and
+         awtidr_out,     & !< near IR, direct  ! diagnostics
+         awtvdf_out,     & !< visible, diffuse
+         awtidf_out        !< near IR, diffuse
 
-      character (len=char_len), intent(out), optional :: &
-         shortwave_out, & ! shortwave method, 'ccsm3' or 'dEdd'
-         albedo_type_out  ! albedo parameterization, 'ccsm3' or 'constant'
+    character (len=char_len), intent(out), optional :: &
+         shortwave_out, & !< shortwave method, 'ccsm3' or 'dEdd'
+         albedo_type_out  !< albedo parameterization, 'ccsm3' or 'constant'
                              ! shortwave='dEdd' overrides this parameter
 
-      ! baseline albedos for ccsm3 shortwave, set in namelist
-      real (kind=dbl_kind), intent(out), optional :: &
-         albicev_out  , & ! visible ice albedo for h > ahmax
-         albicei_out  , & ! near-ir ice albedo for h > ahmax
-         albsnowv_out , & ! cold snow albedo, visible
-         albsnowi_out , & ! cold snow albedo, near IR
-         ahmax_out        ! thickness above which ice albedo is constant (m)
+    ! baseline albedos for ccsm3 shortwave, set in namelist
+    real (kind=dbl_kind), intent(out), optional :: &
+         albicev_out  , & !< visible ice albedo for h > ahmax
+         albicei_out  , & !< near-ir ice albedo for h > ahmax
+         albsnowv_out , & !< cold snow albedo, visible
+         albsnowi_out , & !< cold snow albedo, near IR
+         ahmax_out        !< thickness above which ice albedo is constant (m)
 
-      ! dEdd tuning parameters, set in namelist
-      real (kind=dbl_kind), intent(out), optional :: &
-         R_ice_out    , & ! sea ice tuning parameter; +1 > 1sig increase in albedo
-         R_pnd_out    , & ! ponded ice tuning parameter; +1 > 1sig increase in albedo
-         R_snw_out    , & ! snow tuning parameter; +1 > ~.01 change in broadband albedo
-         dT_mlt_out   , & ! change in temp for non-melt to melt snow grain
-                          ! radius change (C)
-         rsnw_mlt_out , & ! maximum melting snow grain radius (10^-6 m)
-         kalg_out         ! algae absorption coefficient for 0.5 m thick layer
+    ! dEdd tuning parameters, set in namelist
+    real (kind=dbl_kind), intent(out), optional :: &
+         R_ice_out    , & !< sea ice tuning parameter; +1 > 1sig increase in albedo
+         R_pnd_out    , & !< ponded ice tuning parameter; +1 > 1sig increase in albedo
+         R_snw_out    , & !< snow tuning parameter; +1 > ~.01 change in broadband albedo
+         dT_mlt_out   , & !< change in temp for non-melt to melt snow grain
+                          !! radius change (C)
+         rsnw_mlt_out , & !< maximum melting snow grain radius (10^-6 m)
+         kalg_out         !< algae absorption coefficient for 0.5 m thick layer
 
-      logical (kind=log_kind), intent(out), optional :: &
-         sw_redist_out    ! redistribute shortwave
+    logical (kind=log_kind), intent(out), optional :: &
+         sw_redist_out    !< redistribute shortwave
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         sw_frac_out  , & ! Fraction of internal shortwave moved to surface
-         sw_dtemp_out     ! temperature difference from melting
+    real (kind=dbl_kind), intent(out), optional :: &
+         sw_frac_out  , & !< Fraction of internal shortwave moved to surface
+         sw_dtemp_out     !< temperature difference from melting
 
 !-----------------------------------------------------------------------
 ! Parameters for dynamics
 !-----------------------------------------------------------------------
 
-      real(kind=dbl_kind), intent(out), optional :: &
-         Cf_out,         & ! ratio of ridging work to PE change in ridging
-         Pstar_out,      & ! constant in Hibler strength formula
-         Cstar_out,      & ! constant in Hibler strength formula
-         dragio_out,     & ! ice-ocn drag coefficient
-         gravit_out,     & ! gravitational acceleration (m/s^2)
-         iceruf_out        ! ice surface roughness (m)
+    real(kind=dbl_kind), intent(out), optional :: &
+         Cf_out,         & !< ratio of ridging work to PE change in ridging
+         Pstar_out,      & !< constant in Hibler strength formula
+         Cstar_out,      & !< constant in Hibler strength formula
+         dragio_out,     & !< ice-ocn drag coefficient
+         gravit_out,     & !< gravitational acceleration (m/s^2)
+         iceruf_out        !< ice surface roughness (m)
 
-      integer (kind=int_kind), intent(out), optional :: & ! defined in namelist
-         kstrength_out  , & ! 0 for simple Hibler (1979) formulation
-                            ! 1 for Rothrock (1975) pressure formulation
-         krdg_partic_out, & ! 0 for Thorndike et al. (1975) formulation
-                            ! 1 for exponential participation function
-         krdg_redist_out    ! 0 for Hibler (1980) formulation
-                            ! 1 for exponential redistribution function
+    integer (kind=int_kind), intent(out), optional :: & ! defined in namelist
+         kstrength_out  , & !< 0 for simple Hibler (1979) formulation
+                            !! 1 for Rothrock (1975) pressure formulation
+         krdg_partic_out, & !< 0 for Thorndike et al. (1975) formulation
+                            !! 1 for exponential participation function
+         krdg_redist_out    !< 0 for Hibler (1980) formulation
+                            !! 1 for exponential redistribution function
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         mu_rdg_out         ! gives e-folding scale of ridged ice (m^.5)
-                            ! (krdg_redist = 1)
+    real (kind=dbl_kind), intent(out), optional :: &
+         mu_rdg_out         !< gives e-folding scale of ridged ice (m^.5)
+                            !! (krdg_redist = 1)
 
 !-----------------------------------------------------------------------
 ! Parameters for atmosphere
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         cp_air_out,     & ! specific heat of air (J/kg/K)
-         cp_wv_out,      & ! specific heat of water vapor (J/kg/K)
-         zvir_out,       & ! rh2o/rair - 1.0
-         zref_out,       & ! reference height for stability (m)
-         qqqice_out,     & ! for qsat over ice
-         TTTice_out,     & ! for qsat over ice
-         qqqocn_out,     & ! for qsat over ocn
-         TTTocn_out        ! for qsat over ocn
+    real (kind=dbl_kind), intent(out), optional :: &
+         cp_air_out,     & !< specific heat of air (J/kg/K)
+         cp_wv_out,      & !< specific heat of water vapor (J/kg/K)
+         zvir_out,       & !< rh2o/rair - 1.0
+         zref_out,       & !< reference height for stability (m)
+         qqqice_out,     & !< for qsat over ice
+         TTTice_out,     & !< for qsat over ice
+         qqqocn_out,     & !< for qsat over ocn
+         TTTocn_out        !< for qsat over ocn
 
-      character (len=char_len), intent(out), optional :: &
-         atmbndy_out ! atmo boundary method, 'default' ('ccsm3') or 'constant'
+    character (len=char_len), intent(out), optional :: &
+         atmbndy_out !< atmo boundary method, 'default' ('ccsm3') or 'constant'
 
-      logical (kind=log_kind), intent(out), optional :: &
-         calc_strair_out, &  ! if true, calculate wind stress components
-         formdrag_out,    &  ! if true, calculate form drag
-         highfreq_out        ! if true, use high frequency coupling
+    logical (kind=log_kind), intent(out), optional :: &
+         calc_strair_out, &  !< if true, calculate wind stress components
+         formdrag_out,    &  !< if true, calculate form drag
+         highfreq_out        !< if true, use high frequency coupling
 
-      integer (kind=int_kind), intent(out), optional :: &
-         natmiter_out        ! number of iterations for boundary layer calculations
+    integer (kind=int_kind), intent(out), optional :: &
+         natmiter_out        !< number of iterations for boundary layer calculations
 
-      ! Flux convergence tolerance
-      real (kind=dbl_kind), intent(out), optional :: atmiter_conv_out
+    real (kind=dbl_kind), intent(out), optional :: &
+         atmiter_conv_out    !< Flux convergence tolerance
 
 !-----------------------------------------------------------------------
 ! Parameters for the ice thickness distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), intent(out), optional :: &
-         kitd_out        , & ! type of itd conversions
-                             !   0 = delta function
-                             !   1 = linear remap
-         kcatbound_out       !   0 = old category boundary formula
-                             !   1 = new formula giving round numbers
-                             !   2 = WMO standard
-                             !   3 = asymptotic formula
+    integer (kind=int_kind), intent(out), optional :: &
+         kitd_out        , & !< type of itd conversions
+                             !!   0 = delta function
+                             !!   1 = linear remap
+         kcatbound_out       !<   0 = old category boundary formula
+                             !!   1 = new formula giving round numbers
+                             !!   2 = WMO standard
+                             !!   3 = asymptotic formula
 
 !-----------------------------------------------------------------------
 ! Parameters for the floe size distribution
 !-----------------------------------------------------------------------
 
-      integer (kind=int_kind), intent(out), optional :: &
-         nfreq_out          ! number of frequencies
+    integer (kind=int_kind), intent(out), optional :: &
+         nfreq_out          !< number of frequencies
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         floeshape_out      ! constant from Steele (unitless)
+    real (kind=dbl_kind), intent(out), optional :: &
+         floeshape_out      !< constant from Steele (unitless)
 
-      logical (kind=log_kind), intent(out), optional :: &
-         wave_spec_out      ! if true, use wave forcing
+    logical (kind=log_kind), intent(out), optional :: &
+         wave_spec_out      !< if true, use wave forcing
 
-      character (len=char_len), intent(out), optional :: &
-         wave_spec_type_out ! type of wave spectrum forcing
+    character (len=char_len), intent(out), optional :: &
+         wave_spec_type_out !< type of wave spectrum forcing
 
 !-----------------------------------------------------------------------
 ! Parameters for biogeochemistry
 !-----------------------------------------------------------------------
 
-      character(char_len), intent(out), optional :: &
-         bgc_flux_type_out    ! type of ocean-ice piston velocity
-                              ! 'constant', 'Jin2006'
+    character(char_len), intent(out), optional :: &
+         bgc_flux_type_out    !< type of ocean-ice piston velocity
+                              !! 'constant', 'Jin2006'
 
-      logical (kind=log_kind), intent(out), optional :: &
-         z_tracers_out,      & ! if .true., bgc or aerosol tracers are vertically resolved
-         scale_bgc_out,      & ! if .true., initialize bgc tracers proportionally with salinity
-         solve_zbgc_out,     & ! if .true., solve vertical biochemistry portion of code
-         dEdd_algae_out,     & ! if .true., algal absorptionof Shortwave is computed in the
-         modal_aero_out,     & ! if .true., use modal aerosol formulation in shortwave
-         conserv_check_out     ! if .true., run conservation checks and abort if checks fail
+    logical (kind=log_kind), intent(out), optional :: &
+         z_tracers_out,      & !< if .true., bgc or aerosol tracers are vertically resolved
+         scale_bgc_out,      & !< if .true., initialize bgc tracers proportionally with salinity
+         solve_zbgc_out,     & !< if .true., solve vertical biochemistry portion of code
+         dEdd_algae_out,     & !< if .true., algal absorptionof Shortwave is computed in the
+         modal_aero_out,     & !< if .true., use modal aerosol formulation in shortwave
+         conserv_check_out     !< if .true., run conservation checks and abort if checks fail
 
-      logical (kind=log_kind), intent(out), optional :: &
-         skl_bgc_out,        &   ! if true, solve skeletal biochemistry
-         solve_zsal_out          ! if true, update salinity profile from solve_S_dt
+    logical (kind=log_kind), intent(out), optional :: &
+         skl_bgc_out,        &   !< if true, solve skeletal biochemistry
+         solve_zsal_out          !< if true, update salinity profile from solve_S_dt
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         grid_o_out      , & ! for bottom flux
-         l_sk_out        , & ! characteristic diffusive scale (zsalinity) (m)
-         initbio_frac_out, & ! fraction of ocean tracer concentration used to initialize tracer
-         phi_snow_out        ! snow porosity at the ice/snow interface
+    real (kind=dbl_kind), intent(out), optional :: &
+         grid_o_out      , & !< for bottom flux
+         l_sk_out        , & !< characteristic diffusive scale (zsalinity) (m)
+         initbio_frac_out, & !< fraction of ocean tracer concentration used to initialize tracer
+         phi_snow_out        !< snow porosity at the ice/snow interface
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         grid_oS_out     , & ! for bottom flux (zsalinity)
-         l_skS_out           ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
-      real (kind=dbl_kind), intent(out), optional :: &
-         fr_resp_out           , &   ! fraction of algal growth lost due to respiration
-         algal_vel_out         , &   ! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
-         R_dFe2dust_out        , &   !  g/g (3.5% content) Tagliabue 2009
-         dustFe_sol_out        , &   ! solubility fraction
-         T_max_out            , & ! maximum temperature (C)
-         fsal_out             , & ! Salinity limitation (ppt)
-         op_dep_min_out       , & ! Light attenuates for optical depths exceeding min
-         fr_graze_s_out       , & ! fraction of grazing spilled or slopped
-         fr_graze_e_out       , & ! fraction of assimilation excreted
-         fr_mort2min_out      , & ! fractionation of mortality to Am
-         fr_dFe_out           , & ! fraction of remineralized nitrogen
-                                    ! (in units of algal iron)
-         k_nitrif_out         , & ! nitrification rate (1/day)
-         t_iron_conv_out      , & ! desorption loss pFe to dFe (day)
-         max_loss_out         , & ! restrict uptake to % of remaining value
-         max_dfe_doc1_out     , & ! max ratio of dFe to saccharides in the ice
-                                    ! (nM Fe/muM C)
-         fr_resp_s_out        , & ! DMSPd fraction of respiration loss as DMSPd
-         y_sk_DMS_out         , & ! fraction conversion given high yield
-         t_sk_conv_out        , & ! Stefels conversion time (d)
-         t_sk_ox_out          , & ! DMS oxidation time (d)
-         frazil_scav_out          ! scavenging fraction or multiple in frazil ice
+    real (kind=dbl_kind), intent(out), optional :: &
+         grid_oS_out     , & !< for bottom flux (zsalinity)
+         l_skS_out           !< 0.02 characteristic skeletal layer thickness (m) (zsalinity)
+    real (kind=dbl_kind), intent(out), optional :: &
+         fr_resp_out           , &   !< fraction of algal growth lost due to respiration
+         algal_vel_out         , &   !< 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
+         R_dFe2dust_out        , &   !<  g/g (3.5% content) Tagliabue 2009
+         dustFe_sol_out        , &   !< solubility fraction
+         T_max_out            , & !< maximum temperature (C)
+         fsal_out             , & !< Salinity limitation (ppt)
+         op_dep_min_out       , & !< Light attenuates for optical depths exceeding min
+         fr_graze_s_out       , & !< fraction of grazing spilled or slopped
+         fr_graze_e_out       , & !< fraction of assimilation excreted
+         fr_mort2min_out      , & !< fractionation of mortality to Am
+         fr_dFe_out           , & !< fraction of remineralized nitrogen
+                                  !! (in units of algal iron)
+         k_nitrif_out         , & !< nitrification rate (1/day)
+         t_iron_conv_out      , & !< desorption loss pFe to dFe (day)
+         max_loss_out         , & !< restrict uptake to % of remaining value
+         max_dfe_doc1_out     , & !< max ratio of dFe to saccharides in the ice
+                                  !! (nM Fe/muM C)
+         fr_resp_s_out        , & !< DMSPd fraction of respiration loss as DMSPd
+         y_sk_DMS_out         , & !< fraction conversion given high yield
+         t_sk_conv_out        , & !< Stefels conversion time (d)
+         t_sk_ox_out          , & !< DMS oxidation time (d)
+         frazil_scav_out          !< scavenging fraction or multiple in frazil ice
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         sk_l_out,       & ! skeletal layer thickness (m)
-         min_bgc_out       ! fraction of ocean bgc concentration in surface melt
+    real (kind=dbl_kind), intent(out), optional :: &
+         sk_l_out,       & !< skeletal layer thickness (m)
+         min_bgc_out       !< fraction of ocean bgc concentration in surface melt
 
 !-----------------------------------------------------------------------
 ! Parameters for melt ponds
 !-----------------------------------------------------------------------
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         hs0_out             ! snow depth for transition to bare sea ice (m)
+    real (kind=dbl_kind), intent(out), optional :: &
+         hs0_out             !< snow depth for transition to bare sea ice (m)
 
       ! level-ice ponds
-      character (len=char_len), intent(out), optional :: &
-         frzpnd_out          ! pond refreezing parameterization
+    character (len=char_len), intent(out), optional :: &
+         frzpnd_out          !< pond refreezing parameterization
 
-      real (kind=dbl_kind), intent(out), optional :: &
-         dpscale_out, &      ! alter e-folding time scale for flushing
-         rfracmin_out, &     ! minimum retained fraction of meltwater
-         rfracmax_out, &     ! maximum retained fraction of meltwater
-         pndaspect_out, &    ! ratio of pond depth to pond fraction
-         hs1_out             ! tapering parameter for snow on pond ice
+    real (kind=dbl_kind), intent(out), optional :: &
+         dpscale_out, &      !< alter e-folding time scale for flushing
+         rfracmin_out, &     !< minimum retained fraction of meltwater
+         rfracmax_out, &     !< maximum retained fraction of meltwater
+         pndaspect_out, &    !< ratio of pond depth to pond fraction
+         hs1_out             !< tapering parameter for snow on pond ice
 
       ! topo ponds
-      real (kind=dbl_kind), intent(out), optional :: &
-         hp1_out             ! critical parameter for pond ice thickness
+    real (kind=dbl_kind), intent(out), optional :: &
+         hp1_out             !< critical parameter for pond ice thickness
 
-!autodocument_end
+    character(len=*),parameter :: subname='(icepack_query_parameters)'
 
-      character(len=*),parameter :: subname='(icepack_query_parameters)'
+    if (present(puny_out)              ) puny_out         = puny
+    if (present(bignum_out)            ) bignum_out       = bignum
+    if (present(pi_out)                ) pi_out           = pi
 
-      if (present(puny_out)              ) puny_out         = puny
-      if (present(bignum_out)            ) bignum_out       = bignum
-      if (present(pi_out)                ) pi_out           = pi
+    if (present(c0_out)                ) c0_out           = c0
+    if (present(c1_out)                ) c1_out           = c1
+    if (present(c1p5_out)              ) c1p5_out         = c1p5
+    if (present(c2_out)                ) c2_out           = c2
+    if (present(c3_out)                ) c3_out           = c3
+    if (present(c4_out)                ) c4_out           = c4
+    if (present(c5_out)                ) c5_out           = c5
+    if (present(c6_out)                ) c6_out           = c6
+    if (present(c8_out)                ) c8_out           = c8
+    if (present(c10_out)               ) c10_out          = c10
+    if (present(c15_out)               ) c15_out          = c15
+    if (present(c16_out)               ) c16_out          = c16
+    if (present(c20_out)               ) c20_out          = c20
+    if (present(c25_out)               ) c25_out          = c25
+    if (present(c100_out)              ) c100_out         = c100
+    if (present(c180_out)              ) c180_out         = c180
+    if (present(c1000_out)             ) c1000_out        = c1000
+    if (present(p001_out)              ) p001_out         = p001
+    if (present(p01_out)               ) p01_out          = p01
+    if (present(p1_out)                ) p1_out           = p1
+    if (present(p2_out)                ) p2_out           = p2
+    if (present(p4_out)                ) p4_out           = p4
+    if (present(p5_out)                ) p5_out           = p5
+    if (present(p6_out)                ) p6_out           = p6
+    if (present(p05_out)               ) p05_out          = p05
+    if (present(p15_out)               ) p15_out          = p15
+    if (present(p25_out)               ) p25_out          = p25
+    if (present(p75_out)               ) p75_out          = p75
+    if (present(p333_out)              ) p333_out         = p333
+    if (present(p666_out)              ) p666_out         = p666
+    if (present(spval_const_out)       ) spval_const_out  = spval_const
+    if (present(pih_out)               ) pih_out          = pih
+    if (present(piq_out)               ) piq_out          = piq
+    if (present(pi2_out)               ) pi2_out          = pi2
+    if (present(secday_out)            ) secday_out       = secday
+    if (present(rad_to_deg_out)        ) rad_to_deg_out   = rad_to_deg
 
-      if (present(c0_out)                ) c0_out           = c0
-      if (present(c1_out)                ) c1_out           = c1
-      if (present(c1p5_out)              ) c1p5_out         = c1p5
-      if (present(c2_out)                ) c2_out           = c2
-      if (present(c3_out)                ) c3_out           = c3
-      if (present(c4_out)                ) c4_out           = c4
-      if (present(c5_out)                ) c5_out           = c5
-      if (present(c6_out)                ) c6_out           = c6
-      if (present(c8_out)                ) c8_out           = c8
-      if (present(c10_out)               ) c10_out          = c10
-      if (present(c15_out)               ) c15_out          = c15
-      if (present(c16_out)               ) c16_out          = c16
-      if (present(c20_out)               ) c20_out          = c20
-      if (present(c25_out)               ) c25_out          = c25
-      if (present(c100_out)              ) c100_out         = c100
-      if (present(c180_out)              ) c180_out         = c180
-      if (present(c1000_out)             ) c1000_out        = c1000
-      if (present(p001_out)              ) p001_out         = p001
-      if (present(p01_out)               ) p01_out          = p01
-      if (present(p1_out)                ) p1_out           = p1
-      if (present(p2_out)                ) p2_out           = p2
-      if (present(p4_out)                ) p4_out           = p4
-      if (present(p5_out)                ) p5_out           = p5
-      if (present(p6_out)                ) p6_out           = p6
-      if (present(p05_out)               ) p05_out          = p05
-      if (present(p15_out)               ) p15_out          = p15
-      if (present(p25_out)               ) p25_out          = p25
-      if (present(p75_out)               ) p75_out          = p75
-      if (present(p333_out)              ) p333_out         = p333
-      if (present(p666_out)              ) p666_out         = p666
-      if (present(spval_const_out)       ) spval_const_out  = spval_const
-      if (present(pih_out)               ) pih_out          = pih
-      if (present(piq_out)               ) piq_out          = piq
-      if (present(pi2_out)               ) pi2_out          = pi2
-      if (present(secday_out)            ) secday_out       = secday
-      if (present(rad_to_deg_out)        ) rad_to_deg_out   = rad_to_deg
+    if (present(rhos_out)              ) rhos_out         = rhos
+    if (present(rhoi_out)              ) rhoi_out         = rhoi
+    if (present(rhow_out)              ) rhow_out         = rhow
+    if (present(cp_air_out)            ) cp_air_out       = cp_air
+    if (present(emissivity_out)        ) emissivity_out   = emissivity
+    if (present(floediam_out)          ) floediam_out     = floediam
+    if (present(hfrazilmin_out)        ) hfrazilmin_out   = hfrazilmin
+    if (present(cp_ice_out)            ) cp_ice_out       = cp_ice
+    if (present(cp_ocn_out)            ) cp_ocn_out       = cp_ocn
+    if (present(depressT_out)          ) depressT_out     = depressT
+    if (present(dragio_out)            ) dragio_out       = dragio
+    if (present(albocn_out)            ) albocn_out       = albocn
+    if (present(gravit_out)            ) gravit_out       = gravit
+    if (present(viscosity_dyn_out)     ) viscosity_dyn_out= viscosity_dyn
+    if (present(Tocnfrz_out)           ) Tocnfrz_out      = Tocnfrz
+    if (present(rhofresh_out)          ) rhofresh_out     = rhofresh
+    if (present(zvir_out)              ) zvir_out         = zvir
+    if (present(vonkar_out)            ) vonkar_out       = vonkar
+    if (present(cp_wv_out)             ) cp_wv_out        = cp_wv
+    if (present(stefan_boltzmann_out)  ) stefan_boltzmann_out = stefan_boltzmann
+    if (present(Tffresh_out)           ) Tffresh_out      = Tffresh
+    if (present(Lsub_out)              ) Lsub_out         = Lsub
+    if (present(Lvap_out)              ) Lvap_out         = Lvap
+    if (present(Timelt_out)            ) Timelt_out       = Timelt
+    if (present(Tsmelt_out)            ) Tsmelt_out       = Tsmelt
+    if (present(ice_ref_salinity_out)  ) ice_ref_salinity_out = ice_ref_salinity
+    if (present(iceruf_out)            ) iceruf_out       = iceruf
+    if (present(Cf_out)                ) Cf_out           = Cf
+    if (present(Pstar_out)             ) Pstar_out        = Pstar
+    if (present(Cstar_out)             ) Cstar_out        = Cstar
+    if (present(kappav_out)            ) kappav_out       = kappav
+    if (present(kice_out)              ) kice_out         = kice
+    if (present(kseaice_out)           ) kseaice_out      = kseaice
+    if (present(ksno_out)              ) ksno_out         = ksno
+    if (present(zref_out)              ) zref_out         = zref
+    if (present(hs_min_out)            ) hs_min_out       = hs_min
+    if (present(snowpatch_out)         ) snowpatch_out    = snowpatch
+    if (present(rhosi_out)             ) rhosi_out        = rhosi
+    if (present(sk_l_out)              ) sk_l_out         = sk_l
+    if (present(saltmax_out)           ) saltmax_out      = saltmax
+    if (present(phi_init_out)          ) phi_init_out     = phi_init
+    if (present(min_salin_out)         ) min_salin_out    = min_salin
+    if (present(salt_loss_out)         ) salt_loss_out    = salt_loss
+    if (present(min_bgc_out)           ) min_bgc_out      = min_bgc
+    if (present(dSin0_frazil_out)      ) dSin0_frazil_out = dSin0_frazil
+    if (present(hi_ssl_out)            ) hi_ssl_out       = hi_ssl
+    if (present(hs_ssl_out)            ) hs_ssl_out       = hs_ssl
+    if (present(awtvdr_out)            ) awtvdr_out       = awtvdr
+    if (present(awtidr_out)            ) awtidr_out       = awtidr
+    if (present(awtvdf_out)            ) awtvdf_out       = awtvdf
+    if (present(awtidf_out)            ) awtidf_out       = awtidf
+    if (present(qqqice_out)            ) qqqice_out       = qqqice
+    if (present(TTTice_out)            ) TTTice_out       = TTTice
+    if (present(qqqocn_out)            ) qqqocn_out       = qqqocn
+    if (present(TTTocn_out)            ) TTTocn_out       = TTTocn
+    if (present(puny_out)              ) puny_out         = puny
+    if (present(bignum_out)            ) bignum_out       = bignum
+    if (present(pi_out)                ) pi_out           = pi
+    if (present(secday_out)            ) secday_out       = secday
+    if (present(ktherm_out)            ) ktherm_out       = ktherm
+    if (present(conduct_out)           ) conduct_out      = conduct
+    if (present(fbot_xfer_type_out)    ) fbot_xfer_type_out = fbot_xfer_type
+    if (present(heat_capacity_out)     ) heat_capacity_out= heat_capacity
+    if (present(calc_Tsfc_out)         ) calc_Tsfc_out    = calc_Tsfc
+    if (present(update_ocn_f_out)      ) update_ocn_f_out = update_ocn_f
+    if (present(dts_b_out)             ) dts_b_out        = dts_b
+    if (present(ustar_min_out)         ) ustar_min_out    = ustar_min
+    if (present(a_rapid_mode_out)      ) a_rapid_mode_out = a_rapid_mode
+    if (present(Rac_rapid_mode_out)    ) Rac_rapid_mode_out = Rac_rapid_mode
+    if (present(aspect_rapid_mode_out) ) aspect_rapid_mode_out = aspect_rapid_mode
+    if (present(dSdt_slow_mode_out)    ) dSdt_slow_mode_out = dSdt_slow_mode
+    if (present(phi_c_slow_mode_out)   ) phi_c_slow_mode_out = phi_c_slow_mode
+    if (present(phi_i_mushy_out)       ) phi_i_mushy_out  = phi_i_mushy
+    if (present(shortwave_out)         ) shortwave_out    = shortwave
+    if (present(albedo_type_out)       ) albedo_type_out  = albedo_type
+    if (present(albicev_out)           ) albicev_out      = albicev
+    if (present(albicei_out)           ) albicei_out      = albicei
+    if (present(albsnowv_out)          ) albsnowv_out     = albsnowv
+    if (present(albsnowi_out)          ) albsnowi_out     = albsnowi
+    if (present(ahmax_out)             ) ahmax_out        = ahmax
+    if (present(R_ice_out)             ) R_ice_out        = R_ice
+    if (present(R_pnd_out)             ) R_pnd_out        = R_pnd
+    if (present(R_snw_out)             ) R_snw_out        = R_snw
+    if (present(dT_mlt_out)            ) dT_mlt_out       = dT_mlt
+    if (present(rsnw_mlt_out)          ) rsnw_mlt_out     = rsnw_mlt
+    if (present(kalg_out)              ) kalg_out         = kalg
+    if (present(kstrength_out)         ) kstrength_out    = kstrength
+    if (present(krdg_partic_out)       ) krdg_partic_out  = krdg_partic
+    if (present(krdg_redist_out)       ) krdg_redist_out  = krdg_redist
+    if (present(mu_rdg_out)            ) mu_rdg_out       = mu_rdg
+    if (present(atmbndy_out)           ) atmbndy_out      = atmbndy
+    if (present(calc_strair_out)       ) calc_strair_out  = calc_strair
+    if (present(formdrag_out)          ) formdrag_out     = formdrag
+    if (present(highfreq_out)          ) highfreq_out     = highfreq
+    if (present(natmiter_out)          ) natmiter_out     = natmiter
+    if (present(atmiter_conv_out)      ) atmiter_conv_out = atmiter_conv
+    if (present(tfrz_option_out)       ) tfrz_option_out  = tfrz_option
+    if (present(kitd_out)              ) kitd_out         = kitd
+    if (present(kcatbound_out)         ) kcatbound_out    = kcatbound
+    if (present(floeshape_out)         ) floeshape_out    = floeshape
+    if (present(wave_spec_out)         ) wave_spec_out    = wave_spec
+    if (present(wave_spec_type_out)    ) wave_spec_type_out = wave_spec_type
+    if (present(nfreq_out)             ) nfreq_out        = nfreq
+    if (present(hs0_out)               ) hs0_out          = hs0
+    if (present(frzpnd_out)            ) frzpnd_out       = frzpnd
+    if (present(dpscale_out)           ) dpscale_out      = dpscale
+    if (present(rfracmin_out)          ) rfracmin_out     = rfracmin
+    if (present(rfracmax_out)          ) rfracmax_out     = rfracmax
+    if (present(pndaspect_out)         ) pndaspect_out    = pndaspect
+    if (present(hs1_out)               ) hs1_out          = hs1
+    if (present(hp1_out)               ) hp1_out          = hp1
+    if (present(bgc_flux_type_out)     ) bgc_flux_type_out= bgc_flux_type
+    if (present(z_tracers_out)         ) z_tracers_out    = z_tracers
+    if (present(scale_bgc_out)         ) scale_bgc_out    = scale_bgc
+    if (present(solve_zbgc_out)        ) solve_zbgc_out   = solve_zbgc
+    if (present(dEdd_algae_out)        ) dEdd_algae_out   = dEdd_algae
+    if (present(modal_aero_out)        ) modal_aero_out   = modal_aero
+    if (present(conserv_check_out)     ) conserv_check_out= conserv_check
+    if (present(skl_bgc_out)           ) skl_bgc_out      = skl_bgc
+    if (present(solve_zsal_out)        ) solve_zsal_out   = solve_zsal
+    if (present(grid_o_out)            ) grid_o_out       = grid_o
+    if (present(l_sk_out)              ) l_sk_out         = l_sk
+    if (present(initbio_frac_out)      ) initbio_frac_out = initbio_frac
+    if (present(grid_oS_out)           ) grid_oS_out      = grid_oS
+    if (present(l_skS_out)             ) l_skS_out        = l_skS
+    if (present(phi_snow_out)          ) phi_snow_out     = phi_snow
+    if (present(fr_resp_out)           ) fr_resp_out      = fr_resp
+    if (present(algal_vel_out)         ) algal_vel_out    = algal_vel
+    if (present(R_dFe2dust_out)        ) R_dFe2dust_out   = R_dFe2dust
+    if (present(dustFe_sol_out)        ) dustFe_sol_out   = dustFe_sol
+    if (present(T_max_out)             ) T_max_out        = T_max
+    if (present(fsal_out)              ) fsal_out         = fsal
+    if (present(op_dep_min_out)        ) op_dep_min_out   = op_dep_min
+    if (present(fr_graze_s_out)        ) fr_graze_s_out   = fr_graze_s
+    if (present(fr_graze_e_out)        ) fr_graze_e_out   = fr_graze_e
+    if (present(fr_mort2min_out)       ) fr_mort2min_out  = fr_mort2min
+    if (present(fr_dFe_out)            ) fr_dFe_out       = fr_dFe
+    if (present(k_nitrif_out)          ) k_nitrif_out     = k_nitrif
+    if (present(t_iron_conv_out)       ) t_iron_conv_out  = t_iron_conv
+    if (present(max_loss_out)          ) max_loss_out     = max_loss
+    if (present(max_dfe_doc1_out)      ) max_dfe_doc1_out = max_dfe_doc1
+    if (present(fr_resp_s_out)         ) fr_resp_s_out    = fr_resp_s
+    if (present(y_sk_DMS_out)          ) y_sk_DMS_out     = y_sk_DMS
+    if (present(t_sk_conv_out)         ) t_sk_conv_out    = t_sk_conv
+    if (present(t_sk_ox_out)           ) t_sk_ox_out      = t_sk_ox
+    if (present(frazil_scav_out)       ) frazil_scav_out  = frazil_scav
+    if (present(Lfresh_out)            ) Lfresh_out       = Lfresh
+    if (present(cprho_out)             ) cprho_out        = cprho
+    if (present(Cp_out)                ) Cp_out           = Cp
+    if (present(sw_redist_out)         ) sw_redist_out    = sw_redist
+    if (present(sw_frac_out)           ) sw_frac_out      = sw_frac
+    if (present(sw_dtemp_out)          ) sw_dtemp_out     = sw_dtemp
 
-      if (present(rhos_out)              ) rhos_out         = rhos
-      if (present(rhoi_out)              ) rhoi_out         = rhoi
-      if (present(rhow_out)              ) rhow_out         = rhow
-      if (present(cp_air_out)            ) cp_air_out       = cp_air
-      if (present(emissivity_out)        ) emissivity_out   = emissivity
-      if (present(floediam_out)          ) floediam_out     = floediam
-      if (present(hfrazilmin_out)        ) hfrazilmin_out   = hfrazilmin
-      if (present(cp_ice_out)            ) cp_ice_out       = cp_ice
-      if (present(cp_ocn_out)            ) cp_ocn_out       = cp_ocn
-      if (present(depressT_out)          ) depressT_out     = depressT
-      if (present(dragio_out)            ) dragio_out       = dragio
-      if (present(albocn_out)            ) albocn_out       = albocn
-      if (present(gravit_out)            ) gravit_out       = gravit
-      if (present(viscosity_dyn_out)     ) viscosity_dyn_out= viscosity_dyn
-      if (present(Tocnfrz_out)           ) Tocnfrz_out      = Tocnfrz
-      if (present(rhofresh_out)          ) rhofresh_out     = rhofresh
-      if (present(zvir_out)              ) zvir_out         = zvir
-      if (present(vonkar_out)            ) vonkar_out       = vonkar
-      if (present(cp_wv_out)             ) cp_wv_out        = cp_wv
-      if (present(stefan_boltzmann_out)  ) stefan_boltzmann_out = stefan_boltzmann
-      if (present(Tffresh_out)           ) Tffresh_out      = Tffresh
-      if (present(Lsub_out)              ) Lsub_out         = Lsub
-      if (present(Lvap_out)              ) Lvap_out         = Lvap
-      if (present(Timelt_out)            ) Timelt_out       = Timelt
-      if (present(Tsmelt_out)            ) Tsmelt_out       = Tsmelt
-      if (present(ice_ref_salinity_out)  ) ice_ref_salinity_out = ice_ref_salinity
-      if (present(iceruf_out)            ) iceruf_out       = iceruf
-      if (present(Cf_out)                ) Cf_out           = Cf
-      if (present(Pstar_out)             ) Pstar_out        = Pstar
-      if (present(Cstar_out)             ) Cstar_out        = Cstar
-      if (present(kappav_out)            ) kappav_out       = kappav
-      if (present(kice_out)              ) kice_out         = kice
-      if (present(kseaice_out)           ) kseaice_out      = kseaice
-      if (present(ksno_out)              ) ksno_out         = ksno
-      if (present(zref_out)              ) zref_out         = zref
-      if (present(hs_min_out)            ) hs_min_out       = hs_min
-      if (present(snowpatch_out)         ) snowpatch_out    = snowpatch
-      if (present(rhosi_out)             ) rhosi_out        = rhosi
-      if (present(sk_l_out)              ) sk_l_out         = sk_l
-      if (present(saltmax_out)           ) saltmax_out      = saltmax
-      if (present(phi_init_out)          ) phi_init_out     = phi_init
-      if (present(min_salin_out)         ) min_salin_out    = min_salin
-      if (present(salt_loss_out)         ) salt_loss_out    = salt_loss
-      if (present(min_bgc_out)           ) min_bgc_out      = min_bgc
-      if (present(dSin0_frazil_out)      ) dSin0_frazil_out = dSin0_frazil
-      if (present(hi_ssl_out)            ) hi_ssl_out       = hi_ssl
-      if (present(hs_ssl_out)            ) hs_ssl_out       = hs_ssl
-      if (present(awtvdr_out)            ) awtvdr_out       = awtvdr
-      if (present(awtidr_out)            ) awtidr_out       = awtidr
-      if (present(awtvdf_out)            ) awtvdf_out       = awtvdf
-      if (present(awtidf_out)            ) awtidf_out       = awtidf
-      if (present(qqqice_out)            ) qqqice_out       = qqqice
-      if (present(TTTice_out)            ) TTTice_out       = TTTice
-      if (present(qqqocn_out)            ) qqqocn_out       = qqqocn
-      if (present(TTTocn_out)            ) TTTocn_out       = TTTocn
-      if (present(puny_out)              ) puny_out         = puny
-      if (present(bignum_out)            ) bignum_out       = bignum
-      if (present(pi_out)                ) pi_out           = pi
-      if (present(secday_out)            ) secday_out       = secday
-      if (present(ktherm_out)            ) ktherm_out       = ktherm
-      if (present(conduct_out)           ) conduct_out      = conduct
-      if (present(fbot_xfer_type_out)    ) fbot_xfer_type_out = fbot_xfer_type
-      if (present(heat_capacity_out)     ) heat_capacity_out= heat_capacity
-      if (present(calc_Tsfc_out)         ) calc_Tsfc_out    = calc_Tsfc
-      if (present(update_ocn_f_out)      ) update_ocn_f_out = update_ocn_f
-      if (present(dts_b_out)             ) dts_b_out        = dts_b
-      if (present(ustar_min_out)         ) ustar_min_out    = ustar_min
-      if (present(a_rapid_mode_out)      ) a_rapid_mode_out = a_rapid_mode
-      if (present(Rac_rapid_mode_out)    ) Rac_rapid_mode_out = Rac_rapid_mode
-      if (present(aspect_rapid_mode_out) ) aspect_rapid_mode_out = aspect_rapid_mode
-      if (present(dSdt_slow_mode_out)    ) dSdt_slow_mode_out = dSdt_slow_mode
-      if (present(phi_c_slow_mode_out)   ) phi_c_slow_mode_out = phi_c_slow_mode
-      if (present(phi_i_mushy_out)       ) phi_i_mushy_out  = phi_i_mushy
-      if (present(shortwave_out)         ) shortwave_out    = shortwave
-      if (present(albedo_type_out)       ) albedo_type_out  = albedo_type
-      if (present(albicev_out)           ) albicev_out      = albicev
-      if (present(albicei_out)           ) albicei_out      = albicei
-      if (present(albsnowv_out)          ) albsnowv_out     = albsnowv
-      if (present(albsnowi_out)          ) albsnowi_out     = albsnowi
-      if (present(ahmax_out)             ) ahmax_out        = ahmax
-      if (present(R_ice_out)             ) R_ice_out        = R_ice
-      if (present(R_pnd_out)             ) R_pnd_out        = R_pnd
-      if (present(R_snw_out)             ) R_snw_out        = R_snw
-      if (present(dT_mlt_out)            ) dT_mlt_out       = dT_mlt
-      if (present(rsnw_mlt_out)          ) rsnw_mlt_out     = rsnw_mlt
-      if (present(kalg_out)              ) kalg_out         = kalg
-      if (present(kstrength_out)         ) kstrength_out    = kstrength
-      if (present(krdg_partic_out)       ) krdg_partic_out  = krdg_partic
-      if (present(krdg_redist_out)       ) krdg_redist_out  = krdg_redist
-      if (present(mu_rdg_out)            ) mu_rdg_out       = mu_rdg
-      if (present(atmbndy_out)           ) atmbndy_out      = atmbndy
-      if (present(calc_strair_out)       ) calc_strair_out  = calc_strair
-      if (present(formdrag_out)          ) formdrag_out     = formdrag
-      if (present(highfreq_out)          ) highfreq_out     = highfreq
-      if (present(natmiter_out)          ) natmiter_out     = natmiter
-      if (present(atmiter_conv_out)      ) atmiter_conv_out = atmiter_conv
-      if (present(tfrz_option_out)       ) tfrz_option_out  = tfrz_option
-      if (present(kitd_out)              ) kitd_out         = kitd
-      if (present(kcatbound_out)         ) kcatbound_out    = kcatbound
-      if (present(floeshape_out)         ) floeshape_out    = floeshape
-      if (present(wave_spec_out)         ) wave_spec_out    = wave_spec
-      if (present(wave_spec_type_out)    ) wave_spec_type_out = wave_spec_type
-      if (present(nfreq_out)             ) nfreq_out        = nfreq
-      if (present(hs0_out)               ) hs0_out          = hs0
-      if (present(frzpnd_out)            ) frzpnd_out       = frzpnd
-      if (present(dpscale_out)           ) dpscale_out      = dpscale
-      if (present(rfracmin_out)          ) rfracmin_out     = rfracmin
-      if (present(rfracmax_out)          ) rfracmax_out     = rfracmax
-      if (present(pndaspect_out)         ) pndaspect_out    = pndaspect
-      if (present(hs1_out)               ) hs1_out          = hs1
-      if (present(hp1_out)               ) hp1_out          = hp1
-      if (present(bgc_flux_type_out)     ) bgc_flux_type_out= bgc_flux_type
-      if (present(z_tracers_out)         ) z_tracers_out    = z_tracers
-      if (present(scale_bgc_out)         ) scale_bgc_out    = scale_bgc
-      if (present(solve_zbgc_out)        ) solve_zbgc_out   = solve_zbgc
-      if (present(dEdd_algae_out)        ) dEdd_algae_out   = dEdd_algae
-      if (present(modal_aero_out)        ) modal_aero_out   = modal_aero
-      if (present(conserv_check_out)     ) conserv_check_out= conserv_check
-      if (present(skl_bgc_out)           ) skl_bgc_out      = skl_bgc
-      if (present(solve_zsal_out)        ) solve_zsal_out   = solve_zsal
-      if (present(grid_o_out)            ) grid_o_out       = grid_o
-      if (present(l_sk_out)              ) l_sk_out         = l_sk
-      if (present(initbio_frac_out)      ) initbio_frac_out = initbio_frac
-      if (present(grid_oS_out)           ) grid_oS_out      = grid_oS
-      if (present(l_skS_out)             ) l_skS_out        = l_skS
-      if (present(phi_snow_out)          ) phi_snow_out     = phi_snow
-      if (present(fr_resp_out)           ) fr_resp_out      = fr_resp
-      if (present(algal_vel_out)         ) algal_vel_out    = algal_vel
-      if (present(R_dFe2dust_out)        ) R_dFe2dust_out   = R_dFe2dust
-      if (present(dustFe_sol_out)        ) dustFe_sol_out   = dustFe_sol
-      if (present(T_max_out)             ) T_max_out        = T_max
-      if (present(fsal_out)              ) fsal_out         = fsal
-      if (present(op_dep_min_out)        ) op_dep_min_out   = op_dep_min
-      if (present(fr_graze_s_out)        ) fr_graze_s_out   = fr_graze_s
-      if (present(fr_graze_e_out)        ) fr_graze_e_out   = fr_graze_e
-      if (present(fr_mort2min_out)       ) fr_mort2min_out  = fr_mort2min
-      if (present(fr_dFe_out)            ) fr_dFe_out       = fr_dFe
-      if (present(k_nitrif_out)          ) k_nitrif_out     = k_nitrif
-      if (present(t_iron_conv_out)       ) t_iron_conv_out  = t_iron_conv
-      if (present(max_loss_out)          ) max_loss_out     = max_loss
-      if (present(max_dfe_doc1_out)      ) max_dfe_doc1_out = max_dfe_doc1
-      if (present(fr_resp_s_out)         ) fr_resp_s_out    = fr_resp_s
-      if (present(y_sk_DMS_out)          ) y_sk_DMS_out     = y_sk_DMS
-      if (present(t_sk_conv_out)         ) t_sk_conv_out    = t_sk_conv
-      if (present(t_sk_ox_out)           ) t_sk_ox_out      = t_sk_ox
-      if (present(frazil_scav_out)       ) frazil_scav_out  = frazil_scav
-      if (present(Lfresh_out)            ) Lfresh_out       = Lfresh
-      if (present(cprho_out)             ) cprho_out        = cprho
-      if (present(Cp_out)                ) Cp_out           = Cp
-      if (present(sw_redist_out)         ) sw_redist_out    = sw_redist
-      if (present(sw_frac_out)           ) sw_frac_out      = sw_frac
-      if (present(sw_dtemp_out)          ) sw_dtemp_out     = sw_dtemp
+    call icepack_recompute_constants()
+    if (icepack_warnings_aborted(subname)) return
 
-      call icepack_recompute_constants()
-      if (icepack_warnings_aborted(subname)) return
-
-      end subroutine icepack_query_parameters
+  end subroutine icepack_query_parameters
 
 !=======================================================================
 
-!autodocument_start icepack_write_parameters
-! subroutine to write the column package internal parameters
+  !> Icepack subroutine to write the column package internal parameters
+  subroutine icepack_write_parameters(iounit)
 
-      subroutine icepack_write_parameters(iounit)
+    integer (kind=int_kind), intent(in) :: &
+             iounit   !< unit number for output
 
-        integer (kind=int_kind), intent(in) :: &
-             iounit   ! unit number for output
+    character(len=*),parameter :: subname='(icepack_write_parameters)'
 
-!autodocument_end
+    write(iounit,*) subname
+    write(iounit,*) "  rhos   = ",rhos
+    write(iounit,*) "  rhoi   = ",rhoi
+    write(iounit,*) "  rhow   = ",rhow
+    write(iounit,*) "  cp_air = ",cp_air
+    write(iounit,*) "  emissivity = ",emissivity
+    write(iounit,*) "  floediam   = ",floediam
+    write(iounit,*) "  hfrazilmin = ",hfrazilmin
+    write(iounit,*) "  cp_ice = ",cp_ice
+    write(iounit,*) "  cp_ocn = ",cp_ocn
+    write(iounit,*) "  depressT = ",depressT
+    write(iounit,*) "  dragio = ",dragio
+    write(iounit,*) "  albocn = ",albocn
+    write(iounit,*) "  gravit = ",gravit
+    write(iounit,*) "  viscosity_dyn = ",viscosity_dyn
+    write(iounit,*) "  Tocnfrz = ",Tocnfrz
+    write(iounit,*) "  rhofresh = ",rhofresh
+    write(iounit,*) "  zvir   = ",zvir
+    write(iounit,*) "  vonkar = ",vonkar
+    write(iounit,*) "  cp_wv  = ",cp_wv
+    write(iounit,*) "  stefan_boltzmann = ",stefan_boltzmann
+    write(iounit,*) "  Tffresh = ",Tffresh
+    write(iounit,*) "  Lsub   = ",Lsub
+    write(iounit,*) "  Lvap   = ",Lvap
+    write(iounit,*) "  Timelt = ",Timelt
+    write(iounit,*) "  Tsmelt = ",Tsmelt
+    write(iounit,*) "  ice_ref_salinity = ",ice_ref_salinity
+    write(iounit,*) "  iceruf = ",iceruf
+    write(iounit,*) "  Cf     = ",Cf
+    write(iounit,*) "  Pstar  = ",Pstar
+    write(iounit,*) "  Cstar  = ",Cstar
+    write(iounit,*) "  kappav = ",kappav
+    write(iounit,*) "  kice   = ",kice
+    write(iounit,*) "  kseaice = ",kseaice
+    write(iounit,*) "  ksno   = ",ksno
+    write(iounit,*) "  zref   = ",zref
+    write(iounit,*) "  hs_min = ",hs_min
+    write(iounit,*) "  snowpatch = ",snowpatch
+    write(iounit,*) "  rhosi  = ",rhosi
+    write(iounit,*) "  sk_l   = ",sk_l
+    write(iounit,*) "  saltmax   = ",saltmax
+    write(iounit,*) "  phi_init  = ",phi_init
+    write(iounit,*) "  min_salin = ",min_salin
+    write(iounit,*) "  salt_loss = ",salt_loss
+    write(iounit,*) "  min_bgc   = ",min_bgc
+    write(iounit,*) "  dSin0_frazil = ",dSin0_frazil
+    write(iounit,*) "  hi_ssl = ",hi_ssl
+    write(iounit,*) "  hs_ssl = ",hs_ssl
+    write(iounit,*) "  awtvdr = ",awtvdr
+    write(iounit,*) "  awtidr = ",awtidr
+    write(iounit,*) "  awtvdf = ",awtvdf
+    write(iounit,*) "  awtidf = ",awtidf
+    write(iounit,*) "  qqqice = ",qqqice
+    write(iounit,*) "  TTTice = ",TTTice
+    write(iounit,*) "  qqqocn = ",qqqocn
+    write(iounit,*) "  TTTocn = ",TTTocn
+    write(iounit,*) "  puny   = ",puny
+    write(iounit,*) "  bignum = ",bignum
+    write(iounit,*) "  secday = ",secday
+    write(iounit,*) "  pi     = ",pi
+    write(iounit,*) "  pih    = ",pih
+    write(iounit,*) "  piq    = ",piq
+    write(iounit,*) "  pi2    = ",pi2
+    write(iounit,*) "  rad_to_deg = ",rad_to_deg
+    write(iounit,*) "  Lfresh = ",Lfresh
+    write(iounit,*) "  cprho  = ",cprho
+    write(iounit,*) "  Cp     = ",Cp
+    write(iounit,*) "  ktherm        = ", ktherm
+    write(iounit,*) "  conduct       = ", conduct
+    write(iounit,*) "  fbot_xfer_type    = ", fbot_xfer_type
+    write(iounit,*) "  heat_capacity     = ", heat_capacity
+    write(iounit,*) "  calc_Tsfc         = ", calc_Tsfc
+    write(iounit,*) "  update_ocn_f      = ", update_ocn_f
+    write(iounit,*) "  dts_b             = ", dts_b
+    write(iounit,*) "  ustar_min         = ", ustar_min
+    write(iounit,*) "  a_rapid_mode      = ", a_rapid_mode
+    write(iounit,*) "  Rac_rapid_mode    = ", Rac_rapid_mode
+    write(iounit,*) "  aspect_rapid_mode = ", aspect_rapid_mode
+    write(iounit,*) "  dSdt_slow_mode    = ", dSdt_slow_mode
+    write(iounit,*) "  phi_c_slow_mode   = ", phi_c_slow_mode
+    write(iounit,*) "  phi_i_mushy       = ", phi_i_mushy
+    write(iounit,*) "  shortwave     = ", shortwave
+    write(iounit,*) "  albedo_type   = ", albedo_type
+    write(iounit,*) "  albicev       = ", albicev
+    write(iounit,*) "  albicei       = ", albicei
+    write(iounit,*) "  albsnowv      = ", albsnowv
+    write(iounit,*) "  albsnowi      = ", albsnowi
+    write(iounit,*) "  ahmax         = ", ahmax
+    write(iounit,*) "  R_ice         = ", R_ice
+    write(iounit,*) "  R_pnd         = ", R_pnd
+    write(iounit,*) "  R_snw         = ", R_snw
+    write(iounit,*) "  dT_mlt        = ", dT_mlt
+    write(iounit,*) "  rsnw_mlt      = ", rsnw_mlt
+    write(iounit,*) "  kalg          = ", kalg
+    write(iounit,*) "  kstrength     = ", kstrength
+    write(iounit,*) "  krdg_partic   = ", krdg_partic
+    write(iounit,*) "  krdg_redist   = ", krdg_redist
+    write(iounit,*) "  mu_rdg        = ", mu_rdg
+    write(iounit,*) "  atmbndy       = ", atmbndy
+    write(iounit,*) "  calc_strair   = ", calc_strair
+    write(iounit,*) "  formdrag      = ", formdrag
+    write(iounit,*) "  highfreq      = ", highfreq
+    write(iounit,*) "  natmiter      = ", natmiter
+    write(iounit,*) "  atmiter_conv  = ", atmiter_conv
+    write(iounit,*) "  tfrz_option   = ", tfrz_option
+    write(iounit,*) "  kitd          = ", kitd
+    write(iounit,*) "  kcatbound     = ", kcatbound
+    write(iounit,*) "  floeshape     = ", floeshape
+    write(iounit,*) "  wave_spec     = ", wave_spec
+    write(iounit,*) "  wave_spec_type= ", wave_spec_type
+    write(iounit,*) "  nfreq         = ", nfreq
+    write(iounit,*) "  hs0           = ", hs0
+    write(iounit,*) "  frzpnd        = ", frzpnd
+    write(iounit,*) "  dpscale       = ", dpscale
+    write(iounit,*) "  rfracmin      = ", rfracmin
+    write(iounit,*) "  rfracmax      = ", rfracmax
+    write(iounit,*) "  pndaspect     = ", pndaspect
+    write(iounit,*) "  hs1           = ", hs1
+    write(iounit,*) "  hp1           = ", hp1
+    write(iounit,*) "  bgc_flux_type = ", bgc_flux_type
+    write(iounit,*) "  z_tracers     = ", z_tracers
+    write(iounit,*) "  scale_bgc     = ", scale_bgc
+    write(iounit,*) "  solve_zbgc    = ", solve_zbgc
+    write(iounit,*) "  dEdd_algae    = ", dEdd_algae
+    write(iounit,*) "  modal_aero    = ", modal_aero
+    write(iounit,*) "  conserv_check = ", conserv_check
+    write(iounit,*) "  skl_bgc       = ", skl_bgc
+    write(iounit,*) "  solve_zsal    = ", solve_zsal
+    write(iounit,*) "  grid_o        = ", grid_o
+    write(iounit,*) "  l_sk          = ", l_sk
+    write(iounit,*) "  initbio_frac  = ", initbio_frac
+    write(iounit,*) "  grid_oS       = ", grid_oS
+    write(iounit,*) "  l_skS         = ", l_skS
+    write(iounit,*) "  phi_snow      = ", phi_snow
+    write(iounit,*) "  fr_resp       = ", fr_resp
+    write(iounit,*) "  algal_vel     = ", algal_vel
+    write(iounit,*) "  R_dFe2dust    = ", R_dFe2dust
+    write(iounit,*) "  dustFe_sol    = ", dustFe_sol
+    write(iounit,*) "  T_max         = ", T_max
+    write(iounit,*) "  fsal          = ", fsal
+    write(iounit,*) "  op_dep_min    = ", op_dep_min
+    write(iounit,*) "  fr_graze_s    = ", fr_graze_s
+    write(iounit,*) "  fr_graze_e    = ", fr_graze_e
+    write(iounit,*) "  fr_mort2min   = ", fr_mort2min
+    write(iounit,*) "  fr_dFe        = ", fr_dFe
+    write(iounit,*) "  k_nitrif      = ", k_nitrif
+    write(iounit,*) "  t_iron_conv   = ", t_iron_conv
+    write(iounit,*) "  max_loss      = ", max_loss
+    write(iounit,*) "  max_dfe_doc1  = ", max_dfe_doc1
+    write(iounit,*) "  fr_resp_s     = ", fr_resp_s
+    write(iounit,*) "  y_sk_DMS      = ", y_sk_DMS
+    write(iounit,*) "  t_sk_conv     = ", t_sk_conv
+    write(iounit,*) "  t_sk_ox       = ", t_sk_ox
+    write(iounit,*) "  frazil_scav   = ", frazil_scav
+    write(iounit,*) "  sw_redist     = ", sw_redist
+    write(iounit,*) "  sw_frac       = ", sw_frac
+    write(iounit,*) "  sw_dtemp      = ", sw_dtemp
 
-        character(len=*),parameter :: subname='(icepack_write_parameters)'
+  end subroutine icepack_write_parameters
 
-        write(iounit,*) subname
-        write(iounit,*) "  rhos   = ",rhos
-        write(iounit,*) "  rhoi   = ",rhoi
-        write(iounit,*) "  rhow   = ",rhow
-        write(iounit,*) "  cp_air = ",cp_air
-        write(iounit,*) "  emissivity = ",emissivity
-        write(iounit,*) "  floediam   = ",floediam
-        write(iounit,*) "  hfrazilmin = ",hfrazilmin
-        write(iounit,*) "  cp_ice = ",cp_ice
-        write(iounit,*) "  cp_ocn = ",cp_ocn
-        write(iounit,*) "  depressT = ",depressT
-        write(iounit,*) "  dragio = ",dragio
-        write(iounit,*) "  albocn = ",albocn
-        write(iounit,*) "  gravit = ",gravit
-        write(iounit,*) "  viscosity_dyn = ",viscosity_dyn
-        write(iounit,*) "  Tocnfrz = ",Tocnfrz
-        write(iounit,*) "  rhofresh = ",rhofresh
-        write(iounit,*) "  zvir   = ",zvir
-        write(iounit,*) "  vonkar = ",vonkar
-        write(iounit,*) "  cp_wv  = ",cp_wv
-        write(iounit,*) "  stefan_boltzmann = ",stefan_boltzmann
-        write(iounit,*) "  Tffresh = ",Tffresh
-        write(iounit,*) "  Lsub   = ",Lsub
-        write(iounit,*) "  Lvap   = ",Lvap
-        write(iounit,*) "  Timelt = ",Timelt
-        write(iounit,*) "  Tsmelt = ",Tsmelt
-        write(iounit,*) "  ice_ref_salinity = ",ice_ref_salinity
-        write(iounit,*) "  iceruf = ",iceruf
-        write(iounit,*) "  Cf     = ",Cf
-        write(iounit,*) "  Pstar  = ",Pstar
-        write(iounit,*) "  Cstar  = ",Cstar
-        write(iounit,*) "  kappav = ",kappav
-        write(iounit,*) "  kice   = ",kice
-        write(iounit,*) "  kseaice = ",kseaice
-        write(iounit,*) "  ksno   = ",ksno
-        write(iounit,*) "  zref   = ",zref
-        write(iounit,*) "  hs_min = ",hs_min
-        write(iounit,*) "  snowpatch = ",snowpatch
-        write(iounit,*) "  rhosi  = ",rhosi
-        write(iounit,*) "  sk_l   = ",sk_l
-        write(iounit,*) "  saltmax   = ",saltmax
-        write(iounit,*) "  phi_init  = ",phi_init
-        write(iounit,*) "  min_salin = ",min_salin
-        write(iounit,*) "  salt_loss = ",salt_loss
-        write(iounit,*) "  min_bgc   = ",min_bgc
-        write(iounit,*) "  dSin0_frazil = ",dSin0_frazil
-        write(iounit,*) "  hi_ssl = ",hi_ssl
-        write(iounit,*) "  hs_ssl = ",hs_ssl
-        write(iounit,*) "  awtvdr = ",awtvdr
-        write(iounit,*) "  awtidr = ",awtidr
-        write(iounit,*) "  awtvdf = ",awtvdf
-        write(iounit,*) "  awtidf = ",awtidf
-        write(iounit,*) "  qqqice = ",qqqice
-        write(iounit,*) "  TTTice = ",TTTice
-        write(iounit,*) "  qqqocn = ",qqqocn
-        write(iounit,*) "  TTTocn = ",TTTocn
-        write(iounit,*) "  puny   = ",puny
-        write(iounit,*) "  bignum = ",bignum
-        write(iounit,*) "  secday = ",secday
-        write(iounit,*) "  pi     = ",pi
-        write(iounit,*) "  pih    = ",pih
-        write(iounit,*) "  piq    = ",piq
-        write(iounit,*) "  pi2    = ",pi2
-        write(iounit,*) "  rad_to_deg = ",rad_to_deg
-        write(iounit,*) "  Lfresh = ",Lfresh
-        write(iounit,*) "  cprho  = ",cprho
-        write(iounit,*) "  Cp     = ",Cp
-        write(iounit,*) "  ktherm        = ", ktherm
-        write(iounit,*) "  conduct       = ", conduct
-        write(iounit,*) "  fbot_xfer_type    = ", fbot_xfer_type
-        write(iounit,*) "  heat_capacity     = ", heat_capacity
-        write(iounit,*) "  calc_Tsfc         = ", calc_Tsfc
-        write(iounit,*) "  update_ocn_f      = ", update_ocn_f
-        write(iounit,*) "  dts_b             = ", dts_b
-        write(iounit,*) "  ustar_min         = ", ustar_min
-        write(iounit,*) "  a_rapid_mode      = ", a_rapid_mode
-        write(iounit,*) "  Rac_rapid_mode    = ", Rac_rapid_mode
-        write(iounit,*) "  aspect_rapid_mode = ", aspect_rapid_mode
-        write(iounit,*) "  dSdt_slow_mode    = ", dSdt_slow_mode
-        write(iounit,*) "  phi_c_slow_mode   = ", phi_c_slow_mode
-        write(iounit,*) "  phi_i_mushy       = ", phi_i_mushy
-        write(iounit,*) "  shortwave     = ", shortwave
-        write(iounit,*) "  albedo_type   = ", albedo_type
-        write(iounit,*) "  albicev       = ", albicev
-        write(iounit,*) "  albicei       = ", albicei
-        write(iounit,*) "  albsnowv      = ", albsnowv
-        write(iounit,*) "  albsnowi      = ", albsnowi
-        write(iounit,*) "  ahmax         = ", ahmax
-        write(iounit,*) "  R_ice         = ", R_ice
-        write(iounit,*) "  R_pnd         = ", R_pnd
-        write(iounit,*) "  R_snw         = ", R_snw
-        write(iounit,*) "  dT_mlt        = ", dT_mlt
-        write(iounit,*) "  rsnw_mlt      = ", rsnw_mlt
-        write(iounit,*) "  kalg          = ", kalg
-        write(iounit,*) "  kstrength     = ", kstrength
-        write(iounit,*) "  krdg_partic   = ", krdg_partic
-        write(iounit,*) "  krdg_redist   = ", krdg_redist
-        write(iounit,*) "  mu_rdg        = ", mu_rdg
-        write(iounit,*) "  atmbndy       = ", atmbndy
-        write(iounit,*) "  calc_strair   = ", calc_strair
-        write(iounit,*) "  formdrag      = ", formdrag
-        write(iounit,*) "  highfreq      = ", highfreq
-        write(iounit,*) "  natmiter      = ", natmiter
-        write(iounit,*) "  atmiter_conv  = ", atmiter_conv
-        write(iounit,*) "  tfrz_option   = ", tfrz_option
-        write(iounit,*) "  kitd          = ", kitd
-        write(iounit,*) "  kcatbound     = ", kcatbound
-        write(iounit,*) "  floeshape     = ", floeshape
-        write(iounit,*) "  wave_spec     = ", wave_spec
-        write(iounit,*) "  wave_spec_type= ", wave_spec_type
-        write(iounit,*) "  nfreq         = ", nfreq
-        write(iounit,*) "  hs0           = ", hs0
-        write(iounit,*) "  frzpnd        = ", frzpnd
-        write(iounit,*) "  dpscale       = ", dpscale
-        write(iounit,*) "  rfracmin      = ", rfracmin
-        write(iounit,*) "  rfracmax      = ", rfracmax
-        write(iounit,*) "  pndaspect     = ", pndaspect
-        write(iounit,*) "  hs1           = ", hs1
-        write(iounit,*) "  hp1           = ", hp1
-        write(iounit,*) "  bgc_flux_type = ", bgc_flux_type
-        write(iounit,*) "  z_tracers     = ", z_tracers
-        write(iounit,*) "  scale_bgc     = ", scale_bgc
-        write(iounit,*) "  solve_zbgc    = ", solve_zbgc
-        write(iounit,*) "  dEdd_algae    = ", dEdd_algae
-        write(iounit,*) "  modal_aero    = ", modal_aero
-        write(iounit,*) "  conserv_check = ", conserv_check
-        write(iounit,*) "  skl_bgc       = ", skl_bgc
-        write(iounit,*) "  solve_zsal    = ", solve_zsal
-        write(iounit,*) "  grid_o        = ", grid_o
-        write(iounit,*) "  l_sk          = ", l_sk
-        write(iounit,*) "  initbio_frac  = ", initbio_frac
-        write(iounit,*) "  grid_oS       = ", grid_oS
-        write(iounit,*) "  l_skS         = ", l_skS
-        write(iounit,*) "  phi_snow      = ", phi_snow
-        write(iounit,*) "  fr_resp       = ", fr_resp
-        write(iounit,*) "  algal_vel     = ", algal_vel
-        write(iounit,*) "  R_dFe2dust    = ", R_dFe2dust
-        write(iounit,*) "  dustFe_sol    = ", dustFe_sol
-        write(iounit,*) "  T_max         = ", T_max
-        write(iounit,*) "  fsal          = ", fsal
-        write(iounit,*) "  op_dep_min    = ", op_dep_min
-        write(iounit,*) "  fr_graze_s    = ", fr_graze_s
-        write(iounit,*) "  fr_graze_e    = ", fr_graze_e
-        write(iounit,*) "  fr_mort2min   = ", fr_mort2min
-        write(iounit,*) "  fr_dFe        = ", fr_dFe
-        write(iounit,*) "  k_nitrif      = ", k_nitrif
-        write(iounit,*) "  t_iron_conv   = ", t_iron_conv
-        write(iounit,*) "  max_loss      = ", max_loss
-        write(iounit,*) "  max_dfe_doc1  = ", max_dfe_doc1
-        write(iounit,*) "  fr_resp_s     = ", fr_resp_s
-        write(iounit,*) "  y_sk_DMS      = ", y_sk_DMS
-        write(iounit,*) "  t_sk_conv     = ", t_sk_conv
-        write(iounit,*) "  t_sk_ox       = ", t_sk_ox
-        write(iounit,*) "  frazil_scav   = ", frazil_scav
-        write(iounit,*) "  sw_redist     = ", sw_redist
-        write(iounit,*) "  sw_frac       = ", sw_frac
-        write(iounit,*) "  sw_dtemp      = ", sw_dtemp
+  !> Icepack subroutine to reinitialize some derived constants
+  subroutine icepack_recompute_constants()
 
-      end subroutine icepack_write_parameters
+    character(len=*),parameter :: subname='(icepack_recompute_constants)'
 
-!=======================================================================
+    cprho  = cp_ocn*rhow
+    Lfresh = Lsub-Lvap
+    Cp     = 0.5_dbl_kind*gravit*(rhow-rhoi)*rhoi/rhow
+    pih    = p5*pi
+    piq    = p5*p5*pi
+    pi2    = c2*pi
+    rad_to_deg = c180/pi
 
-!autodocument_start icepack_recompute_constants
-! subroutine to reinitialize some derived constants
+  end subroutine icepack_recompute_constants
 
-      subroutine icepack_recompute_constants()
-
-!autodocument_end
-
-      character(len=*),parameter :: subname='(icepack_recompute_constants)'
-
-        cprho  = cp_ocn*rhow
-        Lfresh = Lsub-Lvap
-        Cp     = 0.5_dbl_kind*gravit*(rhow-rhoi)*rhoi/rhow
-        pih    = p5*pi
-        piq    = p5*p5*pi
-        pi2    = c2*pi
-        rad_to_deg = c180/pi
-
-      end subroutine icepack_recompute_constants
-
-!=======================================================================
-
-    end module icepack_parameters
-
-!=======================================================================
+end module icepack_parameters

--- a/config_src/external/Icepack_interfaces/icepack_tracers.F90
+++ b/config_src/external/Icepack_interfaces/icepack_tracers.F90
@@ -4,27 +4,23 @@
 !
 ! author Elizabeth C. Hunke, LANL
 
-      module icepack_tracers
+module icepack_tracers
 
-      use icepack_kinds
+  use icepack_kinds, only: int_kind, dbl_kind
 
-      implicit none
+  implicit none
 
-      private
-      public :: icepack_init_tracer_indices
-      public :: icepack_init_tracer_sizes
-      public :: icepack_query_tracer_sizes
+  private
+  public :: icepack_init_tracer_indices
+  public :: icepack_init_tracer_sizes
+  public :: icepack_query_tracer_sizes
 
-      integer (kind=int_kind), parameter, public :: n_iso=0,n_aero=0
+  integer (kind=int_kind), parameter, public :: n_iso=0,n_aero=0
 
-      contains
+  contains
 
-
-!=======================================================================
-!autodocument_start icepack_init_tracer_indices
-! set the number of column tracer indices
-
-      subroutine icepack_init_tracer_indices(&
+  !> stub for Icepack routine to set the number of column tracer indices
+  subroutine icepack_init_tracer_indices(&
            nt_Tsfc_in, nt_qice_in, nt_qsno_in, nt_sice_in, &
            nt_fbri_in, nt_iage_in, nt_FY_in, &
            nt_alvl_in, nt_vlvl_in, nt_apnd_in, nt_hpnd_in, nt_ipnd_in, &
@@ -41,109 +37,111 @@
            nlt_zaero_sw_in, &
            bio_index_o_in, bio_index_in)
 
-        integer, intent(in), optional :: &
-             nt_Tsfc_in, & ! ice/snow temperature
-             nt_qice_in, & ! volume-weighted ice enthalpy (in layers)
-             nt_qsno_in, & ! volume-weighted snow enthalpy (in layers)
-             nt_sice_in, & ! volume-weighted ice bulk salinity (CICE grid layers)
-             nt_fbri_in, & ! volume fraction of ice with dynamic salt (hinS/vicen*aicen)
-             nt_iage_in, & ! volume-weighted ice age
-             nt_FY_in, & ! area-weighted first-year ice area
-             nt_alvl_in, & ! level ice area fraction
-             nt_vlvl_in, & ! level ice volume fraction
-             nt_apnd_in, & ! melt pond area fraction
-             nt_hpnd_in, & ! melt pond depth
-             nt_ipnd_in, & ! melt pond refrozen lid thickness
-             nt_fsd_in,  & ! floe size distribution
-             nt_isosno_in,  & ! starting index for isotopes in snow
-             nt_isoice_in,  & ! starting index for isotopes in ice
-             nt_aero_in,    & ! starting index for aerosols in ice
-             nt_bgc_Nit_in, & ! nutrients
-             nt_bgc_Am_in,  & !
-             nt_bgc_Sil_in, & !
-             nt_bgc_DMSPp_in,&! trace gases (skeletal layer)
-             nt_bgc_DMSPd_in,&!
-             nt_bgc_DMS_in, & !
-             nt_bgc_hum_in, & !
-             nt_bgc_PON_in, & ! zooplankton and detritus
-             nlt_bgc_Nit_in,& ! nutrients
-             nlt_bgc_Am_in, & !
-             nlt_bgc_Sil_in,& !
-             nlt_bgc_DMSPp_in,&! trace gases (skeletal layer)
-             nlt_bgc_DMSPd_in,&!
-             nlt_bgc_DMS_in,& !
-             nlt_bgc_hum_in,& !
-             nlt_bgc_PON_in,& ! zooplankton and detritus
-             nt_zbgc_frac_in,&! fraction of tracer in the mobile phase
-             nt_bgc_S_in,   & ! Bulk salinity in fraction ice with dynamic salinity (Bio grid))
-             nlt_chl_sw_in    ! points to total chla in trcrn_sw
+    integer, intent(in), optional :: &
+             nt_Tsfc_in, & !< ice/snow temperature
+             nt_qice_in, & !< volume-weighted ice enthalpy (in layers)
+             nt_qsno_in, & !< volume-weighted snow enthalpy (in layers)
+             nt_sice_in, & !< volume-weighted ice bulk salinity (CICE grid layers)
+             nt_fbri_in, & !< volume fraction of ice with dynamic salt (hinS/vicen*aicen)
+             nt_iage_in, & !< volume-weighted ice age
+             nt_FY_in,   & !< area-weighted first-year ice area
+             nt_alvl_in, & !< level ice area fraction
+             nt_vlvl_in, & !< level ice volume fraction
+             nt_apnd_in, & !< melt pond area fraction
+             nt_hpnd_in, & !< melt pond depth
+             nt_ipnd_in, & !< melt pond refrozen lid thickness
+             nt_fsd_in,  & !< floe size distribution
+             nt_isosno_in,  & !< starting index for isotopes in snow
+             nt_isoice_in,  & !< starting index for isotopes in ice
+             nt_aero_in,    & !< starting index for aerosols in ice
+             nt_bgc_Nit_in, & !< nutrients
+             nt_bgc_Am_in,  & !<
+             nt_bgc_Sil_in, & !<
+             nt_bgc_DMSPp_in,&!< trace gases (skeletal layer)
+             nt_bgc_DMSPd_in,&!<
+             nt_bgc_DMS_in, & !<
+             nt_bgc_hum_in, & !<
+             nt_bgc_PON_in, & !< zooplankton and detritus
+             nlt_bgc_Nit_in,& !< nutrients
+             nlt_bgc_Am_in, & !<
+             nlt_bgc_Sil_in,& !<
+             nlt_bgc_DMSPp_in,&!< trace gases (skeletal layer)
+             nlt_bgc_DMSPd_in,&!<
+             nlt_bgc_DMS_in,& !<
+             nlt_bgc_hum_in,& !<
+             nlt_bgc_PON_in,& !< zooplankton and detritus
+             nt_zbgc_frac_in,&!< fraction of tracer in the mobile phase
+             nt_bgc_S_in,   & !< Bulk salinity in fraction ice with dynamic salinity (Bio grid))
+             nlt_chl_sw_in    !< points to total chla in trcrn_sw
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
              bio_index_o_in, &
              bio_index_in
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_bgc_N_in ,  & ! diatoms, phaeocystis, pico/small
-             nt_bgc_C_in ,  & ! diatoms, phaeocystis, pico/small
-             nt_bgc_chl_in, & ! diatoms, phaeocystis, pico/small
-             nlt_bgc_N_in , & ! diatoms, phaeocystis, pico/small
-             nlt_bgc_C_in , & ! diatoms, phaeocystis, pico/small
-             nlt_bgc_chl_in   ! diatoms, phaeocystis, pico/small
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_bgc_N_in ,  & !< diatoms, phaeocystis, pico/small
+             nt_bgc_C_in ,  & !< diatoms, phaeocystis, pico/small
+             nt_bgc_chl_in, & !< diatoms, phaeocystis, pico/small
+             nlt_bgc_N_in , & !< diatoms, phaeocystis, pico/small
+             nlt_bgc_C_in , & !< diatoms, phaeocystis, pico/small
+             nlt_bgc_chl_in   !< diatoms, phaeocystis, pico/small
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_bgc_DOC_in, & !  dissolved organic carbon
-             nlt_bgc_DOC_in   !  dissolved organic carbon
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_bgc_DOC_in, & !< dissolved organic carbon
+             nlt_bgc_DOC_in   !< dissolved organic carbon
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_bgc_DON_in, & !  dissolved organic nitrogen
-             nlt_bgc_DON_in   !  dissolved organic nitrogen
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_bgc_DON_in, & !< dissolved organic nitrogen
+             nlt_bgc_DON_in   !< dissolved organic nitrogen
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_bgc_DIC_in, & ! dissolved inorganic carbon
-             nlt_bgc_DIC_in   !  dissolved inorganic carbon
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_bgc_DIC_in, & !< dissolved inorganic carbon
+             nlt_bgc_DIC_in   !< dissolved inorganic carbon
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_bgc_Fed_in, & !  dissolved iron
-             nt_bgc_Fep_in, & !  particulate iron
-             nlt_bgc_Fed_in,& !  dissolved iron
-             nlt_bgc_Fep_in   !  particulate iron
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_bgc_Fed_in, & !< dissolved iron
+             nt_bgc_Fep_in, & !< particulate iron
+             nlt_bgc_Fed_in,& !< dissolved iron
+             nlt_bgc_Fep_in   !< particulate iron
 
-        integer (kind=int_kind), dimension(:), intent(in), optional :: &
-             nt_zaero_in,   & !  black carbon and other aerosols
-             nlt_zaero_in,  & !  black carbon and other aerosols
-             nlt_zaero_sw_in  ! black carbon and dust in trcrn_sw
+    integer (kind=int_kind), dimension(:), intent(in), optional :: &
+             nt_zaero_in,   & !< black carbon and other aerosols
+             nlt_zaero_in,  & !< black carbon and other aerosols
+             nlt_zaero_sw_in  !< black carbon and dust in trcrn_sw
 
-      end subroutine icepack_init_tracer_indices
+  end subroutine icepack_init_tracer_indices
 
-      subroutine icepack_init_tracer_sizes(&
+  !> stub for Icepack routine to initialize tracer sizes
+  subroutine icepack_init_tracer_sizes(&
          ncat_in, nilyr_in, nslyr_in, nblyr_in, nfsd_in  , &
          n_algae_in, n_DOC_in, n_aero_in, n_iso_in, &
          n_DON_in, n_DIC_in, n_fed_in, n_fep_in, n_zaero_in, &
          ntrcr_in, ntrcr_o_in, nbtrcr_in, nbtrcr_sw_in)
 
-      integer (kind=int_kind), intent(in), optional :: &
-         ncat_in   , & ! Categories
-         nfsd_in   , & !
-         nilyr_in  , & ! Layers
-         nslyr_in  , & !
-         nblyr_in  , & !
-         n_algae_in, & ! Dimensions
-         n_DOC_in  , & !
-         n_DON_in  , & !
-         n_DIC_in  , & !
-         n_fed_in  , & !
-         n_fep_in  , & !
-         n_zaero_in, & !
-         n_iso_in  , & !
-         n_aero_in , & !
-         ntrcr_in  , & ! number of tracers in use
-         ntrcr_o_in, & ! number of non-bio tracers in use
-         nbtrcr_in , & ! number of bio tracers in use
-         nbtrcr_sw_in  ! number of shortwave bio tracers in use
+    integer (kind=int_kind), intent(in), optional :: &
+         ncat_in   , & !< Categories
+         nfsd_in   , & !< fsd
+         nilyr_in  , & !< Ice layers
+         nslyr_in  , & !< Snow layers
+         nblyr_in  , & !< Bio layers
+         n_algae_in, & !< Dimensions
+         n_DOC_in  , & !< DOC
+         n_DON_in  , & !< DON
+         n_DIC_in  , & !< DIC
+         n_fed_in  , & !< fed
+         n_fep_in  , & !< fep
+         n_zaero_in, & !< zaero
+         n_iso_in  , & !< iso
+         n_aero_in , & !< aero
+         ntrcr_in  , & !< number of tracers in use
+         ntrcr_o_in, & !< number of non-bio tracers in use
+         nbtrcr_in , & !< number of bio tracers in use
+         nbtrcr_sw_in  !< number of shortwave bio tracers in use
 
-      end subroutine icepack_init_tracer_sizes
+  end subroutine icepack_init_tracer_sizes
 
-      subroutine icepack_query_tracer_sizes(&
+  !> Stub for Icepack routine to query tracer sizes
+  subroutine icepack_query_tracer_sizes(&
          max_algae_out  , max_dic_out    , max_doc_out      , &
          max_don_out    , max_fe_out     , nmodal1_out      , &
          nmodal2_out    , max_aero_out   , max_nbtrcr_out   , &
@@ -152,39 +150,37 @@
          n_DON_out, n_DIC_out, n_fed_out, n_fep_out, n_zaero_out, &
          ntrcr_out, ntrcr_o_out, nbtrcr_out, nbtrcr_sw_out)
 
-      integer (kind=int_kind), intent(out), optional :: &
-         max_algae_out  , & ! maximum number of algal types
-         max_dic_out    , & ! maximum number of dissolved inorganic carbon types
-         max_doc_out    , & ! maximum number of dissolved organic carbon types
-         max_don_out    , & ! maximum number of dissolved organic nitrogen types
-         max_fe_out     , & ! maximum number of iron types
-         nmodal1_out    , & ! dimension for modal aerosol radiation parameters
-         nmodal2_out    , & ! dimension for modal aerosol radiation parameters
-         max_aero_out   , & ! maximum number of aerosols
-         max_nbtrcr_out     ! algal nitrogen and chlorophyll
+    integer (kind=int_kind), intent(out), optional :: &
+         max_algae_out  , & !< maximum number of algal types
+         max_dic_out    , & !< maximum number of dissolved inorganic carbon types
+         max_doc_out    , & !< maximum number of dissolved organic carbon types
+         max_don_out    , & !< maximum number of dissolved organic nitrogen types
+         max_fe_out     , & !< maximum number of iron types
+         nmodal1_out    , & !< dimension for modal aerosol radiation parameters
+         nmodal2_out    , & !< dimension for modal aerosol radiation parameters
+         max_aero_out   , & !< maximum number of aerosols
+         max_nbtrcr_out     !< algal nitrogen and chlorophyll
 
-      integer (kind=int_kind), intent(out), optional :: &
-         ncat_out   , & ! Categories
-         nfsd_out   , & !
-         nilyr_out  , & ! Layers
-         nslyr_out  , & !
-         nblyr_out  , & !
-         n_algae_out, & ! Dimensions
-         n_DOC_out  , & !
-         n_DON_out  , & !
-         n_DIC_out  , & !
-         n_fed_out  , & !
-         n_fep_out  , & !
-         n_zaero_out, & !
-         n_iso_out  , & !
-         n_aero_out , & !
-         ntrcr_out  , & ! number of tracers in use
-         ntrcr_o_out, & ! number of non-bio tracers in use
-         nbtrcr_out , & ! number of bio tracers in use
-         nbtrcr_sw_out  ! number of shortwave bio tracers in use
+    integer (kind=int_kind), intent(out), optional :: &
+         ncat_out   , & !< Categories
+         nfsd_out   , & !< fsd
+         nilyr_out  , & !< Layers
+         nslyr_out  , & !< snow layers
+         nblyr_out  , & !< bio layers
+         n_algae_out, & !< Dimensions
+         n_DOC_out  , & !< DOC
+         n_DON_out  , & !< DON
+         n_DIC_out  , & !< DIC
+         n_fed_out  , & !< fed
+         n_fep_out  , & !< fep
+         n_zaero_out, & !< zaero
+         n_iso_out  , & !< iso
+         n_aero_out , & !< aero
+         ntrcr_out  , & !< number of tracers in use
+         ntrcr_o_out, & !< number of non-bio tracers in use
+         nbtrcr_out , & !< number of bio tracers in use
+         nbtrcr_sw_out  !< number of shortwave bio tracers in use
 
-      end subroutine icepack_query_tracer_sizes
+  end subroutine icepack_query_tracer_sizes
 
-      end module icepack_tracers
-
-!=======================================================================
+end module icepack_tracers

--- a/docs/zotero.bib
+++ b/docs/zotero.bib
@@ -31,6 +31,15 @@
 	journal = {J. Phys. Oceanography}
 }
 
+@techreport{Hunke2022,
+	url = {https://zenodo.org/records/7419438},
+	year = 2022,
+	title = {CICE-Consortium/Icepack: Icepack 1.3.3},
+	authors = {Elizabeth Hunke and Richard Allard and David A. Bailey and Philippe Blain and Anthony Craig and Frederic Dupont and
+                   Alice DuVivier and Robert Grumbine and David Hebert and Marika Holland and Nicole Jeffery and Jean-Francois Lemieux and
+		   Robert Osinski and Till Rasmussen and Mads Ribergaard and Lettie Roach and Andrew Roberts and Matthew Turner and Michael Winton}
+}
+
 @article{Hunke2001,
 	doi = {10.1006/jcph.2001.6710},
 	year = 2001,

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -161,6 +161,7 @@ type, public :: SIS_C_dyn_CS ; private
   integer :: id_sigi_hifreq = -1, id_sigii_hifreq = -1
   integer :: id_stren_hifreq = -1, id_ci_hifreq = -1
   integer :: id_siu = -1, id_siv = -1, id_sispeed = -1 ! SIMIP diagnostics
+  integer :: id_itheta = -1
   !!@}
 end type SIS_C_dyn_CS
 
@@ -523,6 +524,8 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
             'ice strain rate magnitude', 's-1', conversion=US%s_to_T, missing_value=missing)
   CS%id_del_sh_min = register_diag_field('ice_model', 'del_sh_min', diag%axesT1, Time, &
             'minimum ice strain rate magnitude', 's-1', conversion=US%s_to_T, missing_value=missing)
+  CS%id_itheta = register_diag_field('ice_model', 'itheta', diag%axesT1, Time, &
+            'ice atan(shear/divergence)', 'rad', missing_value=missing)
 
   CS%id_ui_hifreq = register_diag_field('ice_model', 'ui_hf', diag%axesCu1, Time, &
             'ice velocity - x component', 'm/s', missing_value=missing,        &
@@ -638,6 +641,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     dx2T, dy2T, &   ! dx^2 or dy^2 at T points [L2 ~> m2].
     dx_dyT, dy_dxT, &  ! dx/dy or dy_dx at T points [nondim].
     siu, siv, sispeed, & ! diagnostics on T points [L T-1 ~> m s-1].
+    itheta, &  ! Angle given by atan(shear/divergence)
     ui_east, & ! Surface velocity due east component [L T-1 ~> m s-1]
     vi_north   ! Surface velocity due north component [L T-1 ~> m s-1]
 
@@ -746,6 +750,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
   real :: m_neglect2 ! A tiny mass per unit area squared [R2 Z2 ~> kg2 m-4].
   real :: m_neglect4 ! A tiny mass per unit area to the 4th power [R4 Z4 ~> kg4 m-8].
   real :: sum_area   ! The sum of ocean areas around a vorticity point [L2 ~> m2].
+  real :: half_pi    ! pi/2.
 
   type(time_type) :: &
     time_it_start, &  ! The starting time of the iterative steps.
@@ -765,6 +770,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
          "SIS_C_dynamics is written to require a 2-point halo or 1-point and symmetric memory.")
 
   halo_sh_Ds = min(isc-G%isd, jsc-G%jsd, 2)
+  half_pi = 2 * atan(1.0)
 
   ! Zero these arrays to accumulate sums.
   fxoc(:,:) = 0.0 ; fyoc(:,:) = 0.0
@@ -1063,7 +1069,13 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
 
    ! calculate viscosities - how often should we do this ?
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,del_sh,zeta,sh_Dd,sh_Dt, &
-!$OMP                                  I_EC2,sh_Ds,pres_mice,mice,del_sh_min_pr)
+!$OMP                                  I_EC2,sh_Ds,pres_mice,mice,del_sh_min_pr, &
+!$OMP                                  itheta)
+    if (CS%id_itheta > 0) then
+      do j=jsc-1,jec+1 ; do i=isc-1,iec+1
+        itheta(i,j) = 0.0
+      enddo ; enddo
+    endif
     do j=jsc-1,jec+1 ; do i=isc-1,iec+1
       ! Averaging the squared shearing strain is larger than squaring
       ! the averaged strain.  I don't know what is better. -RWH
@@ -1071,6 +1083,12 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
                    (0.25 * ((sh_Ds(I-1,J-1) + sh_Ds(I,J)) + &
                             (sh_Ds(I-1,J) + sh_Ds(I,J-1))))**2 ) ) ! H&D eqn 9
 
+      if (CS%id_itheta > 0 .and. ci(i,j) > 0.0 .and. sh_Dd(i,j) /= 0.0) then
+        itheta(i,j) = atan( 0.25 * ((sh_Ds(I-1,J-1) + sh_Ds(I,J)) + &
+                                    (sh_Ds(I-1,J) + sh_Ds(I,J-1))) &
+                                     / abs(sh_Dd(i,j)) )
+        if (itheta(i,j) < 0.0) itheta(i,j) = itheta(i,j) + half_pi
+      endif
       if (max(del_sh(i,j), del_sh_min_pr(i,j)*pres_mice(i,j)) /= 0.) then
         zeta(i,j) = 0.5*pres_mice(i,j)*mice(i,j) / &
            max(del_sh(i,j), del_sh_min_pr(i,j)*pres_mice(i,j))
@@ -1556,6 +1574,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     if (CS%id_sh_s>0) call post_SIS_data(CS%id_sh_s, sh_Ds, CS%diag)
 
     if (CS%id_del_sh>0) call post_SIS_data(CS%id_del_sh, del_sh, CS%diag)
+    if (CS%id_itheta>0) call post_SIS_data(CS%id_itheta, itheta, CS%diag)
     if (CS%id_del_sh_min>0) then
       do j=jsc,jec ; do i=isc,iec
         diag_val(i,j) = del_sh_min_pr(i,j)*pres_mice(i,j)
@@ -1654,7 +1673,7 @@ subroutine limit_stresses(pres_mice, mice, str_d, str_t, str_s, G, US, CS, limit
   enddo ; enddo
 
 !    This commented out version seems to work, but is not obviously better than
-! treating each component separately, and the later is simpler.
+! treating each component separately, and the latter is simpler.
 !  EC2 = CS%EC**2
 !  do J=jsc-1,jec ; do I=isc-1,iec
 !    ! Rescale str_s based on interpolated values of str_d and str_t, which works

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1162,7 +1162,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
 
       Cor = ((azon(I,j) * vi(i+1,J) + czon(I,j) * vi(i,J-1)) + &
              (bzon(I,j) * vi(i,J) + dzon(I,j) * vi(i+1,J-1))) ! - Cor_ref_u(I,j)
-      !  Evaluate 1/m x.Div(m strain).  This expressions include all metric terms
+      !  Evaluate 1/m x.Div(m strain).  This expression includes all metric terms
       !  for an orthogonal grid.  The str_d term integrates out to no curl, while
       !  str_s & str_t terms impose no divergence and do not act on solid body rotation.
       fxic_now = G%IdxCu(I,j) * (CS%str_d(i+1,j) - CS%str_d(i,j)) + &
@@ -1248,7 +1248,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     do J=jsc-1,jec ; do i=isc,iec
       Cor = -1.0*((amer(I-1,j) * u_tmp(I-1,j) + cmer(I,j+1) * u_tmp(I,j+1)) + &
                   (bmer(I,j) * u_tmp(I,j) + dmer(I-1,j+1) * u_tmp(I-1,j+1)))
-      !  Evaluate 1/m y.Div(m strain).  This expressions include all metric terms
+      !  Evaluate 1/m y.Div(m strain).  This expression includes all metric terms
       !  for an orthogonal grid.  The str_d term integrates out to no curl, while
       !  str_s & str_t terms impose no divergence and do not act on solid body rotation.
       fyic_now = G%IdyCv(i,J) * (CS%str_d(i,j+1)-CS%str_d(i,j)) + &

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -1069,13 +1069,7 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
 
    ! calculate viscosities - how often should we do this ?
 !$OMP parallel do default(none) shared(isc,iec,jsc,jec,del_sh,zeta,sh_Dd,sh_Dt, &
-!$OMP                                  I_EC2,sh_Ds,pres_mice,mice,del_sh_min_pr, &
-!$OMP                                  itheta)
-    if (CS%id_itheta > 0) then
-      do j=jsc-1,jec+1 ; do i=isc-1,iec+1
-        itheta(i,j) = 0.0
-      enddo ; enddo
-    endif
+!$OMP                                  I_EC2,sh_Ds,pres_mice,mice,del_sh_min_pr)
     do j=jsc-1,jec+1 ; do i=isc-1,iec+1
       ! Averaging the squared shearing strain is larger than squaring
       ! the averaged strain.  I don't know what is better. -RWH
@@ -1083,12 +1077,6 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
                    (0.25 * ((sh_Ds(I-1,J-1) + sh_Ds(I,J)) + &
                             (sh_Ds(I-1,J) + sh_Ds(I,J-1))))**2 ) ) ! H&D eqn 9
 
-      if (CS%id_itheta > 0 .and. ci(i,j) > 0.0 .and. sh_Dd(i,j) /= 0.0) then
-        itheta(i,j) = atan( 0.25 * ((sh_Ds(I-1,J-1) + sh_Ds(I,J)) + &
-                                    (sh_Ds(I-1,J) + sh_Ds(I,J-1))) &
-                                     / abs(sh_Dd(i,j)) )
-        if (itheta(i,j) < 0.0) itheta(i,j) = itheta(i,j) + half_pi
-      endif
       if (max(del_sh(i,j), del_sh_min_pr(i,j)*pres_mice(i,j)) /= 0.) then
         zeta(i,j) = 0.5*pres_mice(i,j)*mice(i,j) / &
            max(del_sh(i,j), del_sh_min_pr(i,j)*pres_mice(i,j))
@@ -1096,6 +1084,20 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
         zeta(i,j) = 0.
       endif
     enddo ; enddo
+
+    if (CS%id_itheta > 0) then
+!$OMP parallel do default(none) shared(isc,iec,jsc,jec,itheta,sh_Dd,sh_Dt, &
+!$OMP                                  sh_Ds,ci,half_pi)
+      do j=jsc-1,jec+1 ; do i=isc-1,iec+1
+        itheta(i,j) = 0.0
+        if (ci(i,j) > 0.0 .and. sh_Dd(i,j) /= 0.0) then
+          itheta(i,j) = atan( 0.25 * ((sh_Ds(I-1,J-1) + sh_Ds(I,J)) + &
+                                      (sh_Ds(I-1,J) + sh_Ds(I,J-1))) &
+                                       / abs(sh_Dd(i,j)) )
+          if (itheta(i,j) < 0.0) itheta(i,j) = itheta(i,j) + half_pi
+        endif
+      enddo ; enddo
+    endif
 
     ! Step the stress component equations semi-implicitly.
     I_1pdt_T = 1.0 / (1.0 + dt_2Tdamp)

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -409,7 +409,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
                                G, US, IG, CS, OBC)
 
       ! Complete the category-resolved mass and tracer transport and update the ice state type.
-      call complete_IST_transport(CS%DS2d, CS%CAS, IST, dt_adv_cycle, G, US, IG, CS)
+      call complete_IST_transport(CS%DS2d, CS%CAS, IST, OSS, dt_adv_cycle, G, US, IG, CS)
 
     else !  (.not.CS%merged_cont)
 
@@ -626,10 +626,10 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
         if (CS%do_ridging) then
           call finish_ice_transport(CS%CAS, IST, IST%TrReg, G, US, IG, dt_slow, CS%SIS_transport_CSp, &
                !                                    rdg_rate=DS2d%avg_ridge_rate)
-                                    rdg_rate=IST%rdg_rate)
+                                    OSS=OSS, rdg_rate=IST%rdg_rate)
           DS2d%ridge_rate_count = 0. ; DS2d%avg_ridge_rate(:,:) = 0.0
         else
-          call finish_ice_transport(CS%CAS, IST, IST%TrReg, G, US, IG, dt_slow,CS%SIS_transport_CSp)
+          call finish_ice_transport(CS%CAS, IST, IST%TrReg, G, US, IG, dt_slow, CS%SIS_transport_CSp)
         endif
       endif
       call cpu_clock_end(iceClock8)
@@ -718,7 +718,7 @@ subroutine SIS_multi_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, 
     ! Complete the category-resolved mass and tracer transport and update the ice state type.
     ! This must be done before the next thermodynamic step.
     if (end_of_cycle) &
-      call complete_IST_transport(CS%DS2d, CS%CAS, IST, dt_adv_cycle, G, US, IG, CS)
+      call complete_IST_transport(CS%DS2d, CS%CAS, IST, OSS, dt_adv_cycle, G, US, IG, CS)
 
     if (CS%column_check .and. IST%valid_IST) &  ! This is just here from early debugging exercises,
       call write_ice_statistics(IST, CS%Time, CS%n_calls, G, US, IG, CS%sum_output_CSp, &
@@ -737,14 +737,16 @@ end subroutine SIS_multi_dyn_trans
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> Complete the category-resolved mass and tracer transport and update the ice state type.
-subroutine complete_IST_transport(DS2d, CAS, IST, dt_adv_cycle, G, US, IG, CS)
+subroutine complete_IST_transport(DS2d, CAS, IST, OSS, dt_adv_cycle, G, US, IG, CS)
   type(ice_state_type),          intent(inout) :: IST !< A type describing the state of the sea ice
+  type(ocean_sfc_state_type),    intent(in)    :: OSS !< A structure containing the arrays that describe
+                                                      !! the ocean's surface state for the ice model.
   type(dyn_state_2d),            intent(inout) :: DS2d !< A simplified 2-d description of the ice state
-                                                   !! integrated across thickness categories and layers.
+                                                      !! integrated across thickness categories and layers.
   type(cell_average_state_type), intent(inout) :: CAS !< A structure with ocean-cell averaged masses.
   real,                          intent(in)    :: dt_adv_cycle !< The time since the last IST transport [T ~> s].
   type(SIS_hor_grid_type),       intent(inout) :: G   !< The horizontal grid type
-  type(unit_scale_type),         intent(in)    :: US    !< A structure with unit conversion factors
+  type(unit_scale_type),         intent(in)    :: US  !< A structure with unit conversion factors
   type(ice_grid_type),           intent(inout) :: IG  !< The sea-ice specific grid type
   type(dyn_trans_CS),            pointer       :: CS  !< The control structure for the SIS_dyn_trans module
 
@@ -765,7 +767,7 @@ subroutine complete_IST_transport(DS2d, CAS, IST, dt_adv_cycle, G, US, IG, CS)
   if (CS%do_ridging) then
     call finish_ice_transport(CS%CAS, IST, IST%TrReg, G, US, IG, dt_adv_cycle, CS%SIS_transport_CSp, &
          !                              rdg_rate=DS2d%avg_ridge_rate)
-                              rdg_rate=IST%rdg_rate)
+                              OSS=OSS, rdg_rate=IST%rdg_rate)
     DS2d%ridge_rate_count = 0. ; DS2d%avg_ridge_rate(:,:) = 0.0
   else
     call finish_ice_transport(CS%CAS, IST, IST%TrReg, G, US, IG, dt_adv_cycle, CS%SIS_transport_CSp)

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -391,8 +391,8 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   if (do_ridging) then
     IDs%id_rdgf = register_diag_field('ice_model', 'RDG_FRAC', diag%axesTc, Time, &
                    'ridged ice fraction', '0-1', missing_value=missing)
-    IDs%id_rdg_h = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
-                   'ridged ice fraction', '0-1', missing_value=missing)
+!   IDs%id_rdg_h = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
+!                  'ice ridge height', 'm', conversion=US%m_to_Z, missing_value=missing)
   endif
 end subroutine register_ice_state_diagnostics
 

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -609,9 +609,13 @@ subroutine adjust_ice_categories(mH_ice, mH_snow, mH_pond, part_sz, TrReg, G, IG
       call SIS_error(FATAL, "Input to adjust_ice_categories, negative ice mass.")
     endif
     if (mH_snow(i,j,k) > 0.0) then
+      write(mesg,'("Snow on no ice at: ", 3i6, 1pe12.4)') i+G%idg_offset, j+G%jdg_offset, k, mH_snow(i,j,k)
+      call SIS_error(WARNING, mesg, all_print=.true.)
       call SIS_error(FATAL, "Input to adjust_ice_categories, non-zero snow mass rests atop no ice.")
     endif
     if (mH_pond(i,j,k) > 0.0) then
+      write(mesg,'("Pond on no ice at: ", 3i6, 1pe12.4)') i+G%idg_offset, j+G%jdg_offset, k, mH_pond(i,j,k)
+      call SIS_error(WARNING, mesg, all_print=.true.)
       call SIS_error(FATAL, "Input to adjust_ice_categories, non-zero pond mass rests atop no ice.")
     endif
     if (part_sz(i,j,k) > 0.0) resum_cat(i,j) = .true.

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -195,9 +195,11 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
       call continuity(uc, vc, mca0_ice, CAS%m_ice, uh_ice, vh_ice, dt_adv, &
                       G, US, IG, CS%continuity_CSp, use_h_neg=.true.)
       call continuity(uc, vc, mca0_snow, CAS%m_snow, uh_snow, vh_snow, dt_adv, &
-                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice)
+                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice, &
+                      use_h_neg=.true.)
       call continuity(uc, vc, mca0_pond, CAS%m_pond, uh_pond, vh_pond, dt_adv, &
-                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice)
+                      G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice, &
+                      use_h_neg=.true.)
     endif
 
     call advect_scalar(CAS%mH_ice, mca0_ice, CAS%m_ice, uh_ice, vh_ice, &

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -24,7 +24,7 @@ use SIS_tracer_advect, only : advect_scalar
 use SIS_tracer_registry, only : SIS_tracer_registry_type, get_SIS_tracer_pointer
 use SIS_tracer_registry, only : update_SIS_tracer_halos, set_massless_SIS_tracers
 use SIS_tracer_registry, only : check_SIS_tracer_bounds
-use SIS_types,         only : ice_state_type
+use SIS_types,         only : ice_state_type, ocean_sfc_state_type
 use ice_grid,          only : ice_grid_type
 use ice_ridging_mod,   only : ice_ridging_init, ice_ridging, ice_ridging_CS
 
@@ -71,6 +71,7 @@ type, public :: SIS_transport_CS ; private
 
   !>@{ Diagnostic IDs
   integer :: id_ix_trans = -1, id_iy_trans = -1, id_xprt = -1, id_rdgr = -1
+  integer :: id_rdgh=-1
   ! integer :: id_rdgo=-1, id_rdgv=-1 ! These do not exist yet
   !!@}
 
@@ -226,7 +227,7 @@ end subroutine ice_cat_transport
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 !> finish_ice_transport completes the ice transport and thickness class redistribution
-subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
+subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, OSS, rdg_rate)
   type(cell_average_state_type),     intent(inout) :: CAS !< A structure with ocean-cell averaged masses.
   type(ice_state_type),              intent(inout) :: IST !< A type describing the state of the sea ice
   type(SIS_hor_grid_type),           intent(inout) :: G   !< The horizontal grid type
@@ -235,6 +236,8 @@ subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
   type(SIS_tracer_registry_type),    pointer       :: TrReg !< The registry of SIS ice and snow tracers.
   type(unit_scale_type),             intent(in)    :: US  !< A structure with unit conversion factors
   type(SIS_transport_CS),            pointer       :: CS  !< A pointer to the control structure for this module
+  type(ocean_sfc_state_type), optional, intent(in) :: OSS !< A structure containing the arrays that describe
+                                                          !! the ocean's surface state for the ice model.
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: rdg_rate !< The ice ridging rate [T-1 ~> s-1].
 
   ! Local variables
@@ -267,7 +270,7 @@ subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
   if (CS%do_ridging) then
     ! Compress the ice using the ridging scheme taken from the CICE-Icepack module
     call ice_ridging(IST, G, IG, CAS%m_ice, CAS%m_snow, CAS%m_pond, TrReg, CS%ice_ridging_CSp, US, &
-                     dt, rdg_rate=IST%rdg_rate, rdg_height=IST%rdg_height)
+                     dt, OSS, rdg_rate=IST%rdg_rate, rdg_height=IST%rdg_height)
     ! Clean up any residuals
     call compress_ice(IST%part_size, IST%mH_ice, IST%mH_snow, IST%mH_pond, TrReg, G, US, IG, CS, CAS)
   else
@@ -391,6 +394,8 @@ subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
   if (CS%do_ridging) then
     if (CS%id_rdgr>0 .and. present(rdg_rate)) &
       call post_SIS_data(CS%id_rdgr, rdg_rate, CS%diag)
+    if (CS%id_rdgh>0) &
+      call post_SIS_data(CS%id_rdgh, IST%rdg_height, CS%diag)
 !    if (CS%id_rdgo>0) call post_SIS_data(CS%id_rdgo, rdg_open, diag)
 !    if (CS%id_rdgv>0) then
 !      do j=jsc,jec ; do i=isc,iec
@@ -1243,6 +1248,8 @@ subroutine SIS_transport_init(Time, G, IG, US, param_file, diag, CS, continuity_
                missing_value=missing)
   CS%id_rdgr = register_diag_field('ice_model', 'RDG_RATE', diag%axesT1, Time, &
                'ice ridging rate', '1/sec', conversion=US%s_to_T, missing_value=missing)
+  CS%id_rdgh = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
+               'ice ridge height', 'm', conversion=US%m_to_Z, missing_value=missing)
 !### THESE DIAGNOSTICS DO NOT EXIST YET.
 !  CS%id_rdgo = register_diag_field('ice_model', 'RDG_OPEN', diag%axesT1, Time, &
 !               'rate of opening due to ridging', '1/s', conversion=US%s_to_T, missing_value=missing)

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -487,15 +487,23 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
         if (any(vicen < 0)) then
           do k=1,nCat
             if (vicen(k) < 0.0 .and. aicen(k) > 0.0) then
-              write(mesg,'("Negative ice volume after ridging: ", i6, i6, 2x, 1pe12.4, 1pe12.4)')  &
-                            i+G%idg_offset, j+G%jdg_offset, aicen(k), vicen(k)
+              write(mesg,'("Negative ice volume after ridging: ", i6, i6, i6, 2x, 1pe12.4, 1pe12.4)')  &
+                            i+G%idg_offset, j+G%jdg_offset, k, aicen(k), vicen(k)
               call SIS_error(WARNING, mesg, all_print=.true.)
             endif
             vicen(k) = max(vicen(k),0.0)
           enddo
-  !       write(mesg,'("Negative ice volume after ridging: ", 2i6, 2x, (1pe12.4))') &
-  !                     i+G%jdg_offset, j+G%jdg_offset, aicen, vicen
-  !       call SIS_error(WARNING, mesg, all_print=.true.)
+        endif
+
+        if (any(vsnon < 0)) then
+          do k=1,nCat
+            if (vsnon(k) < 0.0 .and. aicen(k) > 0.0) then
+              write(mesg,'("Negative snow volume after ridging: ", i6, i6, i6, 2x, 1pe12.4, 1pe12.4)')  &
+                            i+G%idg_offset, j+G%jdg_offset, k, aicen(k), vsnon(k)
+              call SIS_error(WARNING, mesg, all_print=.true.)
+            endif
+            vsnon(k) = max(vsnon(k),0.0)
+          enddo
         endif
 
         if (TrReg%ntr>0) then

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -190,8 +190,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
        fpond      , & ! fresh water flux to ponds [kg m-2 s-1]
        fresh      , & ! fresh water flux to ocean [kg m-2 s-1]
        fsalt      , & ! salt flux to ocean [kg m-2 s-1]
-       fhocn      , & ! net heat flux to ocean [W m-2]
-       fzsal          ! zsalinity flux to ocean [kg m-2 s-1]
+       fhocn          ! net heat flux to ocean [W m-2]
 
   real, dimension(IG%CatIce) :: &
        dardg1ndt  , & ! rate of fractional area loss by ridging ice [s-1]
@@ -428,7 +427,6 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
         fresh = 0.0
         fhocn = 0.0
         fsalt = 0.0
-        fzsal = 0.0
         faero_ocn(:) = 0.0
         flux_bio(:) = 0.0
         fiso_ocn = 0.0
@@ -464,7 +462,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
                                  dvirdgndt,                   &
                                  araftn,       vraftn,        &
                                  aice,         fsalt,         &
-                                 first_ice,    fzsal,         &
+                                 first_ice,                   &
                                  flux_bio,     closing,       &
                                  Tf, docleanup=CS%do_cleanup, &
                                  dorebin=CS%do_rebin)

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -492,6 +492,7 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, CS, US, d
               call SIS_error(WARNING, mesg, all_print=.true.)
             endif
             vicen(k) = max(vicen(k),0.0)
+            vsnon(k) = max(vicen(k),0.0)
           enddo
         endif
 


### PR DESCRIPTION
 The "main" branch as of Oct 24, 2024 adds the optional arguments
 described here.

 It uses the public icepack_step_ridge instead of the old interface,
 which is now private. The code that was in Icepack's ridge_prep had
 to be moved to the SIS2 side. There are two new options in the call to
 icepack_step_ridge, telling it how much to do. To reproduce old answers,
 both options should be set to False. On the Icepack side, they recommend
 both being True, which will not only call the ridging code, but also put
 a limiter on some ice fields (no negative thicknesses, etc.) and call
 the rebin routine, which resets which ice is in which thickness category.

 All three versions run for me (three because rebin depends on calling
 the cleanup routine). I have promised some feedback if we later decide
 to just pick one forever.