### PR TITLE
+Rename checksum scale argument to unscale

### DIFF
--- a/src/SIS_debugging.F90
+++ b/src/SIS_debugging.F90
@@ -30,6 +30,7 @@ implicit none ; private
 
 public :: check_redundant_C, check_redundant_B, check_redundant_T
 public :: SIS_debugging_init
+public :: query_debugging_checks
 
 ! These interfaces come from MOM_checksums.
 public :: hchksum, Bchksum, is_NaN, chksum
@@ -102,20 +103,39 @@ subroutine SIS_debugging_init(param_file)
 
 end subroutine SIS_debugging_init
 
+!> Returns logicals indicating which debugging checks should be performed.
+subroutine query_debugging_checks(do_debug, do_chksums, do_redundant)
+  logical, optional, intent(out) :: do_debug     !< True if verbose debugging is to be output
+  logical, optional, intent(out) :: do_chksums   !< True if checksums are to be output
+  logical, optional, intent(out) :: do_redundant !< True if redundant points are to be checked
+
+  if (present(do_debug)) do_debug = debug
+  if (present(do_chksums)) do_chksums = debug_chksums
+  if (present(do_redundant)) do_redundant = debug_redundant
+
+end subroutine query_debugging_checks
+
 !> Check duplicated points of 3-d C-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                    intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),             intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%jsd:,:),   intent(in)    :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%isd:,G%JsdB:,:),   intent(in)    :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%IsdB:,G%jsd:,:),   intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:,:),   intent(in)    :: v_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                   optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                   optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                   optional, intent(in)    :: je   !< The ending j-index to work on
   integer,                   optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -126,32 +146,41 @@ subroutine check_redundant_vC3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vC2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale=unscale)
   enddo
 end subroutine  check_redundant_vC3d
 
 !> Check duplicated points of 2-d C-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),         intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: is   !< The starting i-index to work on
   integer,               optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,               optional, intent(in)    :: js   !< The starting j-index to work on
   integer,               optional, intent(in)    :: je   !< The ending j-index to work on
   integer,               optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
-
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed)
-  real :: v_resym(G%isd:G%ied,G%JsdB:G%JedB)
+  real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A nonsymmetric version of u_comp [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A nonsymmetric version of v_comp [A ~> a]
+  real :: u_resym(G%IsdB:G%IedB,G%jsd:G%jed) ! A reconstructed symmetric version of u_comp [A ~> a]
+  real :: v_resym(G%isd:G%ied,G%JsdB:G%JedB) ! A reconstructed symmetric version of v_comp [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -160,6 +189,8 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc  = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
@@ -185,7 +216,7 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_resym(i,j),u_comp(i,j)-u_resym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(3) = redundant_prints(3) + 1
     endif
@@ -194,8 +225,8 @@ subroutine check_redundant_vC2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_resym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(3) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)" on pe ",i4)') &
-           v_comp(i,j), v_resym(i,j),v_comp(i,j)-v_resym(i,j),i,j, &
+                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+           sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(3) = redundant_prints(3) + 1
@@ -206,15 +237,19 @@ end subroutine  check_redundant_vC2d
 
 !> Check duplicated points of 3-d B-grid scalars for consistency and
 !! document offending points
-subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                     intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),              intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%JsdB:,:),   intent(in)    :: array !< The array being checked
+  real, dimension(G%IsdB:,G%JsdB:,:),   intent(in)    :: array !< The array to be checked for consistency in
+                                                               !! arbitrary, possibly rescaled units [A ~> a]
   integer,                    optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                    optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                    optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                    optional, intent(in)    :: je   !< The ending j-index to work on
+  real,                       optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -225,27 +260,33 @@ subroutine check_redundant_sB3d(mesg, array, G, is, ie, js, je)
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_sB2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
-                              G, is, ie, js, je)
+                              G, is, ie, js, je, unscale=unscale)
   enddo
 end subroutine  check_redundant_sB3d
 
 !> Check duplicated points of 2-d B-grid scalars for consistency and
 !! document offending points
-subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                 intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: array !< The array being checked
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: array !< The array to be checked for consistency in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                optional, intent(in)    :: je   !< The ending j-index to work on
-
-  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input array while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of array [A ~> a]
+  real :: a_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of array [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -254,6 +295,8 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     a_nonsym(i,j) = array(i,j)
@@ -280,7 +323,7 @@ subroutine check_redundant_sB2d(mesg, array, G, is, ie, js, je)
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           array(i,j), a_resym(i,j),array(i,j)-a_resym(i,j),i,j,pe_here()
+           sc*array(i,j), sc*a_resym(i,j), sc*(array(i,j)-a_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
     endif
@@ -291,17 +334,23 @@ end subroutine  check_redundant_sB2d
 !> Check duplicated points of 3-d B-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                    intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),             intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:,:),  intent(in)    :: v_comp !< The v-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                   optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                   optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                   optional, intent(in)    :: je   !< The ending j-index to work on
   integer,                   optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
-
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                               !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -312,32 +361,41 @@ subroutine check_redundant_vB3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vB2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale=unscale)
   enddo
 end subroutine  check_redundant_vB3d
 
 !> Check duplicated points of 2-d B-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                                direction)
+                                direction, unscale)
   character(len=*),                intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),         intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)   :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)   :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector to be
+                                                            !! checked for consistency in arbitrary,
+                                                            !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: is   !< The starting i-index to work on
   integer,               optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,               optional, intent(in)    :: js   !< The starting j-index to work on
   integer,               optional, intent(in)    :: je   !< The ending j-index to work on
   integer,               optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
-
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
-  real :: v_resym(G%IsdB:G%IedB,G%JsdB:G%JedB)
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                            !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of u_comp [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)    ! A nonsymmetric version of v_comp [A ~> a]
+  real :: u_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of u_comp [A ~> a]
+  real :: v_resym(G%IsdB:G%IedB,G%JsdB:G%JedB) ! A reconstructed symmetric version of v_comp [A ~> a]
+  real :: sc  ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -346,6 +404,8 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     ! This only works with symmetric memory, so otherwise return.
     if ((isd == IsdB) .and. (jsd == JsdB)) return
   endif
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   do i=isd,ied ; do j=jsd,jed
     u_nonsym(i,j) = u_comp(i,j) ; v_nonsym(i,j) = v_comp(i,j)
@@ -372,7 +432,7 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_resym(i,j),u_comp(i,j)-u_resym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_resym(i,j), sc*(u_comp(i,j)-u_resym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
     endif
@@ -381,8 +441,8 @@ subroutine check_redundant_vB2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_resym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(2) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)" on pe ",i4)') &
-           v_comp(i,j), v_resym(i,j),v_comp(i,j)-v_resym(i,j),i,j, &
+                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+           sc*v_comp(i,j), sc*v_resym(i,j), sc*(v_comp(i,j)-v_resym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(2) = redundant_prints(2) + 1
@@ -393,15 +453,18 @@ end subroutine  check_redundant_vB2d
 
 !> Check duplicated points of 3-d cell-centered scalars for consistency and
 !! document offending points
-subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
-  character(len=*),                     intent(in)    :: mesg !< An identifying message
-  type(SIS_hor_grid_type),              intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%isd:,G%jsd:,:),     intent(in)    :: array !< The array being checked
-  integer,                    optional, intent(in)    :: is   !< The starting i-index to work on
-  integer,                    optional, intent(in)    :: ie   !< The ending i-index to work on
-  integer,                    optional, intent(in)    :: js   !< The starting j-index to work on
-  integer,                    optional, intent(in)    :: je   !< The ending j-index to work on
-
+subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je, unscale)
+  character(len=*),                 intent(in)    :: mesg !< An identifying message
+  type(SIS_hor_grid_type),          intent(inout) :: G    !< The horizontal grid type
+  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: array !< The array being checked for consistency in
+                                                          !! arbitrary, possibly rescaled units [A ~> a]
+  integer,                optional, intent(in)    :: is   !< The starting i-index to work on
+  integer,                optional, intent(in)    :: ie   !< The ending i-index to work on
+  integer,                optional, intent(in)    :: js   !< The starting j-index to work on
+  integer,                optional, intent(in)    :: je   !< The ending j-index to work on
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                          !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -412,31 +475,39 @@ subroutine check_redundant_sT3d(mesg, array, G, is, ie, js, je)
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_sT2d(trim(mesg)//trim(mesg_k), array(:,:,k), &
-                              G, is, ie, js, je)
+                              G, is, ie, js, je, unscale=unscale)
   enddo
 end subroutine  check_redundant_sT3d
 
 !> Check duplicated points of 2-d cell-centered scalars for consistency and
 !! document offending points
-subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
+subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je, unscale)
   character(len=*),                 intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%isd:,G%jsd:),   intent(in)    :: array !< The array being checked
+  real, dimension(G%isd:,G%jsd:),   intent(in)    :: array !< The array being checked for consistency in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                optional, intent(in)    :: je   !< The ending j-index to work on
-
-  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)
+  real,                   optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input array while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: a_nonsym(G%isd:G%ied,G%jsd:G%jed)  ! A version of array with halo points updated by message passing [A ~> a]
+  real :: sc ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
 
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
-  integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed
+  integer :: isd, ied, jsd, jed
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 
   is_ch = G%isc ; ie_ch = G%iec ; js_ch = G%jsc ; je_ch = G%jec
   if (present(is)) is_ch = is ; if (present(ie)) ie_ch = ie
   if (present(js)) js_ch = js ; if (present(js)) je_ch = je
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   ! This only works on points outside of the standard computational domain.
   if ((is_ch == G%isc) .and. (ie_ch == G%iec) .and. &
@@ -453,7 +524,7 @@ subroutine check_redundant_sT2d(mesg, array, G, is, ie, js, je)
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" Redundant points",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           array(i,j), a_nonsym(i,j),array(i,j)-a_nonsym(i,j),i,j,pe_here()
+           sc*array(i,j), sc*a_nonsym(i,j), sc*(array(i,j)-a_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
      redundant_prints(1) = redundant_prints(1) + 1
    endif
@@ -464,17 +535,24 @@ end subroutine  check_redundant_sT2d
 !> Check duplicated points of 3-d A-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                               direction)
+                               direction, unscale)
   character(len=*),                    intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),             intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: u_comp !< The u-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:,:),    intent(in)    :: v_comp !< The v-component of the vector to be
+                                                               !! checked for consistency in arbitrary,
+                                                               !! possibly rescaled units [A ~> a]
   integer,                   optional, intent(in)    :: is   !< The starting i-index to work on
   integer,                   optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,                   optional, intent(in)    :: js   !< The starting j-index to work on
   integer,                   optional, intent(in)    :: je   !< The ending j-index to work on
   integer,                   optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
+  real,                      optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
 
+  ! Local variables
   character(len=24) :: mesg_k
   integer :: k
 
@@ -485,30 +563,39 @@ subroutine check_redundant_vT3d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     else ; write(mesg_k,'(" Layer",i9," ")') k ; endif
 
     call check_redundant_vT2d(trim(mesg)//trim(mesg_k), u_comp(:,:,k), &
-             v_comp(:,:,k), G, is, ie, js, je, direction)
+             v_comp(:,:,k), G, is, ie, js, je, direction, unscale=unscale)
   enddo
 end subroutine  check_redundant_vT3d
 
 !> Check duplicated points of 2-d A-grid vectors for consistency and
 !! document offending points
 subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
-                               direction)
+                               direction, unscale)
   character(len=*),                intent(in)    :: mesg !< An identifying message
   type(SIS_hor_grid_type),         intent(inout) :: G    !< The horizontal grid type
-  real, dimension(G%isd:,G%jsd:),  intent(in)    :: u_comp !< The u-component of the vector being checked
-  real, dimension(G%isd:,G%jsd:),  intent(in)    :: v_comp !< The v-component of the vector being checked
+  real, dimension(G%isd:,G%jsd:),  intent(in)    :: u_comp !< The u-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:),  intent(in)    :: v_comp !< The v-component of the vector to be
+                                                           !! checked for consistency in arbitrary,
+                                                           !! possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: is   !< The starting i-index to work on
   integer,               optional, intent(in)    :: ie   !< The ending i-index to work on
   integer,               optional, intent(in)    :: js   !< The starting j-index to work on
   integer,               optional, intent(in)    :: je   !< The ending j-index to work on
   integer,               optional, intent(in)    :: direction !< The direction flag to pass to pass_vector
-
-  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed)
-  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed)
+  real,                  optional, intent(in)    :: unscale !< A factor that undoes the scaling for the
+                                                           !! arrays to give consistent output [a A-1 ~> 1]
+  ! Local variables
+  ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units
+  ! of the input vector while [a] indicates the unscaled (e.g., mks) units to used for output.
+  real :: u_nonsym(G%isd:G%ied,G%jsd:G%jed) ! A version of u_comp with halo points updated by message passing [A ~> a]
+  real :: v_nonsym(G%isd:G%ied,G%jsd:G%jed) ! A version of v_comp with halo points updated by message passing [A ~> a]
+  real :: sc ! A factor that undoes the scaling for the arrays to give consistent output [a A-1 ~> 1]
   character(len=128) :: mesg2
-
   integer :: i, j, is_ch, ie_ch, js_ch, je_ch
   integer :: Isq, Ieq, Jsq, Jeq, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
+
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -516,6 +603,8 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
   is_ch = G%isc ; ie_ch = G%iec ; js_ch = G%jsc ; je_ch = G%jec
   if (present(is)) is_ch = is ; if (present(ie)) ie_ch = ie
   if (present(js)) js_ch = js ; if (present(js)) je_ch = je
+
+  sc = 1.0 ; if (present(unscale)) sc = unscale
 
   ! This only works on points outside of the standard computational domain.
   if ((is_ch == G%isc) .and. (ie_ch == G%iec) .and. &
@@ -532,7 +621,7 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant u-components",2(1pe12.4)," differ by ", &
                     & 1pe12.4," at i,j = ",2i4," on pe ",i4)') &
-           u_comp(i,j), u_nonsym(i,j),u_comp(i,j)-u_nonsym(i,j),i,j,pe_here()
+           sc*u_comp(i,j), sc*u_nonsym(i,j), sc*(u_comp(i,j)-u_nonsym(i,j)), i, j, pe_here()
       write(0,'(A130)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
     endif
@@ -541,8 +630,8 @@ subroutine check_redundant_vT2d(mesg, u_comp, v_comp, G, is, ie, js, je, &
     if (v_nonsym(i,j) /= v_comp(i,j) .and. &
         redundant_prints(1) < max_redundant_prints) then
       write(mesg2,'(" redundant v-comps",2(1pe12.4)," differ by ", &
-                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)" on pe ",i4)') &
-           v_comp(i,j), v_nonsym(i,j),v_comp(i,j)-v_nonsym(i,j),i,j, &
+                    & 1pe12.4," at i,j = ",2i4," x,y = ",2(1pe12.4)," on pe ",i4)') &
+           sc*v_comp(i,j), sc*v_nonsym(i,j), sc*(v_comp(i,j)-v_nonsym(i,j)), i, j, &
            G%geoLonBu(i,j), G%geoLatBu(i,j), pe_here()
       write(0,'(A155)') trim(mesg)//trim(mesg2)
       redundant_prints(1) = redundant_prints(1) + 1
@@ -554,194 +643,218 @@ end subroutine  check_redundant_vT2d
 ! =====================================================================
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
+subroutine uvchksum_3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),           intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                             !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                             !! arbitrary, possibly rescaled units [A ~> a]
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                 optional, intent(in)    :: scalars !< If true this is a pair of
                                                               !! scalars that are being checked.
-  real,                    optional, intent(in)    :: scale  !< A scaling factor for these arrays.
+  real,                    optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                              !! units for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_C(mesg, u_comp, v_comp, G)
+      call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine uvchksum_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars, scale)
+subroutine uvchksum_2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),         intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,               optional, intent(in)    :: scalars !< If true this is a pair of
                                                             !! scalars that are being checked.
-  real,                  optional, intent(in)    :: scale  !< A scaling factor for these arrays.
+  real,                  optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                            !! units for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_C(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_C(mesg, u_comp, v_comp, G)
+      call check_redundant_C(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine uvchksum_2d
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine uvchksum_3d_dG(mesg, u_comp, v_comp, G, halos, scale)
+subroutine uvchksum_3d_dG(mesg, u_comp, v_comp, G, halos, unscale)
   character(len=*),                  intent(in)    :: mesg   !< An identifying message
   type(dyn_horgrid_type),            intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:,:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                             !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                             !! arbitrary, possibly rescaled units [A ~> a]
   integer,                 optional, intent(in)    :: halos  !< The width of halos to check (default 0)
-  real,                    optional, intent(in)    :: scale  !< A scaling factor for these arrays.
+  real,                    optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                              !! units for checksums and output [a A-1 ~> 1].
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
 
 end subroutine uvchksum_3d_dG
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine uvchksum_2d_dG(mesg, u_comp, v_comp, G, halos, scale)
+subroutine uvchksum_2d_dG(mesg, u_comp, v_comp, G, halos, unscale)
   character(len=*),                intent(in)    :: mesg   !< An identifying message
   type(dyn_horgrid_type),          intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%jsd:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%JsdB:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                           !! arbitrary, possibly rescaled units [A ~> a]
   integer,               optional, intent(in)    :: halos  !< The width of halos to check (default 0)
-  real,                  optional, intent(in)    :: scale  !< A scaling factor for these arrays.
+  real,                  optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                            !! units for checksums and output [a A-1 ~> 1].
 
   if (debug_chksums) then
-    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_uvchksum(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
 
 end subroutine uvchksum_2d_dG
 
 !> This subroutine does a checksum and redundant point check on a 3d B-grid vector.
-subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
+subroutine Bchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                   intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),            intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                              !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:,:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                              !! arbitrary, possibly rescaled units [A ~> a]
   integer,                  optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                  optional, intent(in)    :: scalars !< If true this is a pair of
                                                                !! scalars that are being checked.
-  real,                     optional, intent(in)    :: scale  !< A scaling factor for these arrays.
+  real,                     optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                               !! units for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_B(mesg, u_comp, v_comp, G)
+      call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine Bchksum_pair_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d B-grid vector.
-subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, scale)
+subroutine Bchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, symmetric, unscale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: u_comp !< The u-component array to be checksummed in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%IsdB:,G%JsdB:), intent(in)    :: v_comp !< The v-component array to be checksummed in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                              !! scalars that are being checked.
   logical,                optional, intent(in)    :: symmetric !< If true, do the checksums on the
-                                                               !! full symmetric computational domain.
-  real,                   optional, intent(in)    :: scale   !< A scaling factor for these arrays.
+                                                             !! full symmetric computational domain.
+  real,                   optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                             !! units for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, symmetric=symmetric, haloshift=halos, scale=scale)
+    call mom_Bchksum_pair(mesg, u_comp, v_comp, G%HI, symmetric=symmetric, haloshift=halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_B(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_B(mesg, u_comp, v_comp, G)
+      call check_redundant_B(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine Bchksum_pair_2d
 
 !> This subroutine does a checksum and redundant point check on a 3d C-grid vector.
-subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, scale)
+subroutine hchksum_pair_3d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),                 intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),          intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: u_comp !< The u-component of the vector in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:,:), intent(in)    :: v_comp !< The v-component of the vector in
+                                                            !! arbitrary, possibly rescaled units [A ~> a]
   integer,                optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,                optional, intent(in)    :: scalars !< If true this is a pair of
                                                              !! scalars that are being checked.
-  real,                   optional, intent(in)    :: scale   !< A scaling factor for these arrays.
+  real,                   optional, intent(in)    :: unscale !< A factor to convert these arrays back to unscaled
+                                                             !! units for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_T(mesg, u_comp, v_comp, G)
+      call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 
 end subroutine hchksum_pair_3d
 
 !> This subroutine does a checksum and redundant point check on a 2d C-grid vector.
-subroutine hchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, scale)
+subroutine hchksum_pair_2d(mesg, u_comp, v_comp, G, halos, scalars, unscale)
   character(len=*),               intent(in)    :: mesg   !< An identifying message
   type(SIS_hor_grid_type),        intent(inout) :: G      !< The ocean's grid structure
-  real, dimension(G%isd:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector
-  real, dimension(G%isd:,G%jsd:), intent(in)    :: v_comp !< The v-component of the vector
+  real, dimension(G%isd:,G%jsd:), intent(in)    :: u_comp !< The u-component of the vector in
+                                                          !! arbitrary, possibly rescaled units [A ~> a]
+  real, dimension(G%isd:,G%jsd:), intent(in)    :: v_comp !< The v-component of the vector in
+                                                          !! arbitrary, possibly rescaled units [A ~> a]
   integer,              optional, intent(in)    :: halos  !< The width of halos to check (default 0)
   logical,              optional, intent(in)    :: scalars !< If true this is a pair of
                                                            !! scalars that are being checked.
-  real,                  optional, intent(in)   :: scale   !< A scaling factor for these arrays.
+  real,                 optional, intent(in)    :: unscale !< A factor to convert this array back to unscaled units
+                                                           !! for checksums and output [a A-1 ~> 1].
 
   logical :: are_scalars
   are_scalars = .false. ; if (present(scalars)) are_scalars = scalars
 
   if (debug_chksums) then
-    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, scale=scale)
+    call mom_hchksum_pair(mesg, u_comp, v_comp, G%HI, halos, unscale=unscale)
   endif
   if (debug_redundant) then
     if (are_scalars) then
-      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair)
+      call check_redundant_T(mesg, u_comp, v_comp, G, direction=To_All+Scalar_Pair, unscale=unscale)
     else
-      call check_redundant_T(mesg, u_comp, v_comp, G)
+      call check_redundant_T(mesg, u_comp, v_comp, G, unscale=unscale)
     endif
   endif
 

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -430,16 +430,16 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
   enddo ; enddo
 
   if (CS%debug .or. CS%debug_redundant) then
-    call Bchksum_pair("sld[xy] in SIS_B_dynamics", sldx, sldy, G, symmetric=.true., scale=US%L_T_to_m_s)
+    call Bchksum_pair("sld[xy] in SIS_B_dynamics", sldx, sldy, G, symmetric=.true., unscale=US%L_T_to_m_s)
     call Bchksum_pair("f[xy]at in SIS_B_dynamics", fxat, fyat, G, symmetric=.true., &
-                      scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call Bchksum_pair("[uv]i pre-steps SIS_B_dynamics", ui, vi, G, symmetric=.true., scale=US%L_T_to_m_s)
-    call Bchksum_pair("[uv]o in SIS_B_dynamics", uo, vo, G, symmetric=.true., scale=US%L_T_to_m_s)
-    call Bchksum_pair("d[yx]d[xy] in SIS_B_dynamics", dydx, dxdy, G, scalars=.true., scale=US%L_to_m)
+                      unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call Bchksum_pair("[uv]i pre-steps SIS_B_dynamics", ui, vi, G, symmetric=.true., unscale=US%L_T_to_m_s)
+    call Bchksum_pair("[uv]o in SIS_B_dynamics", uo, vo, G, symmetric=.true., unscale=US%L_T_to_m_s)
+    call Bchksum_pair("d[yx]d[xy] in SIS_B_dynamics", dydx, dxdy, G, scalars=.true., unscale=US%L_to_m)
   endif
   if (CS%debug_redundant) then
     call check_redundant_B("civ in SIS_B_dynamics", civ, G)
-    call check_redundant_B("miv in SIS_B_dynamics", miv, G)
+    call check_redundant_B("miv in SIS_B_dynamics", miv, G, unscale=US%RZ_to_kg_m2)
   endif
 
   do l=1,EVP_steps
@@ -594,34 +594,34 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
     enddo ; enddo
 
     if (CS%debug) then
-      call hchksum(CS%sig11, "sig11 in SIS_B_dynamics", G%HI, haloshift=1, scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%sig22, "sig22 in SIS_B_dynamics", G%HI, haloshift=1, scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%sig12, "sig12 in SIS_B_dynamics", G%HI, haloshift=1, scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%sig11, "sig11 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%sig22, "sig22 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%sig12, "sig12 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
 
-      call Bchksum(fxic, "fxic in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyic, "fyic in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fxoc, "fxoc in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyoc, "fyoc in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fxco, "fxco in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyco, "fyco in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(ui, "ui in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%L_T_to_m_s)
-      call Bchksum(vi, "vi in SIS_B_dynamics", G%HI, symmetric=.true., scale=US%L_T_to_m_s)
+      call Bchksum(fxic, "fxic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fyic, "fyic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fxoc, "fxoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fyoc, "fyoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fxco, "fxco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fyco, "fyco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(ui, "ui in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
+      call Bchksum(vi, "vi in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
     endif
     if (CS%debug_redundant) then
-      call check_redundant_B("fxic/fyic in SIS_B_dynamics steps",fxic, fyic, G)
-      call check_redundant_B("fxco in SIS_B_dynamics steps", fxco, fyco, G)
-      call check_redundant_B("fxoc in SIS_B_dynamics steps", fxoc, fyoc, G)
-      call check_redundant_B("ui/vi in SIS_B_dynamics steps", ui, vi, G)
+      call check_redundant_B("fxic/fyic in SIS_B_dynamics steps",fxic, fyic, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call check_redundant_B("fxco in SIS_B_dynamics steps", fxco, fyco, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call check_redundant_B("fxoc in SIS_B_dynamics steps", fxoc, fyoc, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call check_redundant_B("ui/vi in SIS_B_dynamics steps", ui, vi, G, unscale=US%L_T_to_m_s)
     endif
 
   enddo ! l=1,EVP_steps
 
   if (CS%debug) then
-    call Bchksum(ui, "ui end SIS_B_dynamics", G%HI, symmetric=.true., scale=US%L_T_to_m_s)
-    call Bchksum(vi, "vi end SIS_B_dynamics", G%HI, symmetric=.true., scale=US%L_T_to_m_s)
+    call Bchksum(ui, "ui end SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
+    call Bchksum(vi, "vi end SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
   endif
   if (CS%debug_redundant) &
-    call check_redundant_B("ui/vi end SIS_B_dynamics", ui, vi, G)
+    call check_redundant_B("ui/vi end SIS_B_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
 
   ! make averages
   I_sub_steps = 1.0/EVP_steps

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -999,10 +999,10 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
 !$OMP end parallel
 
   if (CS%debug .or. CS%debug_redundant) then
-    call uvchksum("PF[uv] in SIS_C_dynamics", PFu, PFv, G, scale=US%L_T_to_m_s*US%s_to_T)
-    call uvchksum("f[xy]at in SIS_C_dynamics", fxat, fyat, G, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call uvchksum("[uv]i pre-steps SIS_C_dynamics", ui, vi, G, scale=US%L_T_to_m_s)
-    call uvchksum("[uv]o in SIS_C_dynamics", uo, vo, G, scale=US%L_T_to_m_s)
+    call uvchksum("PF[uv] in SIS_C_dynamics", PFu, PFv, G, unscale=US%L_T_to_m_s*US%s_to_T)
+    call uvchksum("f[xy]at in SIS_C_dynamics", fxat, fyat, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call uvchksum("[uv]i pre-steps SIS_C_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
+    call uvchksum("[uv]o in SIS_C_dynamics", uo, vo, G, unscale=US%L_T_to_m_s)
   endif
 
   dt_cumulative = 0.0
@@ -1361,23 +1361,23 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     endif
 
     if (CS%debug_EVP .and. CS%debug) then
-      call hchksum(CS%str_d, "str_d in SIS_C_dynamics", G%HI, haloshift=1, scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%str_t, "str_t in SIS_C_dynamics", G%HI, haloshift=1, scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%str_d, "str_d in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%str_t, "str_t in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
       call Bchksum(CS%str_s, "str_s in SIS_C_dynamics", G%HI, &
-                   haloshift=0, symmetric=.true., scale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                   haloshift=0, symmetric=.true., unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
     endif
     if (CS%debug_EVP .and. (CS%debug .or. CS%debug_redundant)) then
-      call uvchksum("f[xy]ic in SIS_C_dynamics", fxic, fyic, G, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("f[xy]oc in SIS_C_dynamics", fxoc, fyoc, G, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("f[xy]lf in SIS_C_dynamics", fxlf, fylf, G, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("Cor_[uv] in SIS_C_dynamics", Cor_u, Cor_v, G, scale=US%L_T_to_m_s*US%s_to_T)
-      call uvchksum("[uv]i in SIS_C_dynamics", ui, vi, G, scale=US%L_T_to_m_s)
+      call uvchksum("f[xy]ic in SIS_C_dynamics", fxic, fyic, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call uvchksum("f[xy]oc in SIS_C_dynamics", fxoc, fyoc, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call uvchksum("f[xy]lf in SIS_C_dynamics", fxlf, fylf, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call uvchksum("Cor_[uv] in SIS_C_dynamics", Cor_u, Cor_v, G, unscale=US%L_T_to_m_s*US%s_to_T)
+      call uvchksum("[uv]i in SIS_C_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
     endif
     call SIS_diag_send_complete()
   enddo ! l=1,EVP_steps
 
   if (CS%debug .or. CS%debug_redundant) &
-    call uvchksum("[uv]i end SIS_C_dynamics", ui, vi, G, scale=US%L_T_to_m_s)
+    call uvchksum("[uv]i end SIS_C_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
 
   ! Reset the time information in the diag type.
   if (do_hifreq_output) call enable_SIS_averaging(time_int_in, time_end_in, CS%diag)
@@ -1862,7 +1862,7 @@ subroutine basal_stress_coeff_C(G, mi, ci, sea_lev, CS)
     enddo
   enddo
 !          call uvchksum("Tb_[uv] before SIS_C_dynamics", CS%Tb_u, CS%Tb_v, G, &
-!                         halos=1, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+!                         halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
 
 end subroutine basal_stress_coeff_C
 

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -471,15 +471,15 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
 
           if (CS%debug) then
-            call uvchksum("Before SIS_C_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+            call uvchksum("Before SIS_C_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
             call hchksum(ice_free, "ice_free before SIS_C_dynamics", G%HI)
-            call hchksum(misp_sum, "misp_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-            call hchksum(mi_sum, "mi_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-            call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
+            call hchksum(misp_sum, "misp_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+            call hchksum(mi_sum, "mi_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+            call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
             call hchksum(ice_cover, "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
-            call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, scale=US%L_T_to_m_s)
+            call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
             call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                          halos=1, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
     !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
           endif
 
@@ -497,7 +497,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
           call cpu_clock_end(iceClocka)
 
-          if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+          if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
 
           call cpu_clock_begin(iceClockb)
           call pass_vector(IST%u_ice_C, IST%v_ice_C, G%Domain, stagger=CGRID_NE)
@@ -510,7 +510,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           if (CS%id_fay>0) call post_data(CS%id_fay, WindStr_y_Cv, CS%diag)
 
           if (CS%debug) call uvchksum("Before set_ocean_top_stress_Cgrid [uv]_ice_C", &
-                                      IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+                                      IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
 
           ! Store all mechanical ocean forcing.
           if (CS%Warsaw_sum_order) then
@@ -533,14 +533,14 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
                                    WindStr_x_ocn_B, WindStr_y_ocn_B, G, US, CS%complete_ice_cover)
 
           if (CS%debug) then
-            call Bchksum_pair("[uv]_ice_B before dynamics", IST%u_ice_B, IST%v_ice_B, G, scale=US%L_T_to_m_s)
+            call Bchksum_pair("[uv]_ice_B before dynamics", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
             call hchksum(ice_free, "ice_free before ice_dynamics", G%HI)
-            call hchksum(misp_sum, "misp_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-            call hchksum(mi_sum, "mi_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-            call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
-            call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, scale=US%L_T_to_m_s)
+            call hchksum(misp_sum, "misp_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+            call hchksum(mi_sum, "mi_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+            call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
+            call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
             call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                              scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
           endif
 
           call cpu_clock_begin(iceClocka)
@@ -558,7 +558,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
           call cpu_clock_end(iceClocka)
 
-          if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, scale=US%L_T_to_m_s)
+          if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
 
           call cpu_clock_begin(iceClockb)
           call pass_vector(IST%u_ice_B, IST%v_ice_B, G%Domain, stagger=BGRID_NE)
@@ -581,7 +581,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
 
           if (CS%debug) call Bchksum_pair("Before set_ocean_top_stress_Bgrid [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, &
-                                          G, scale=US%L_T_to_m_s)
+                                          G, unscale=US%L_T_to_m_s)
           ! Store all mechanical ocean forcing.
           if (CS%Warsaw_sum_order) then
             call set_ocean_top_stress_Bgrid(IOF, WindStr_x_ocn_B, WindStr_y_ocn_B, &
@@ -616,7 +616,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
       ! Do ice mass transport and related tracer transport.  This updates the category-decomposed ice state.
       call cpu_clock_begin(iceClock8)
       ! The code timed by iceClock8 is the non-merged_cont equivalent to complete_IST_transport.
-      if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+      if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
       call enable_SIS_averaging(dt_slow_dyn_sec, Time_cycle_start + real_to_time(nds*dt_slow_dyn_sec), CS%diag)
 
       call ice_cat_transport(CS%CAS, IST%TrReg, dt_slow_dyn, CS%adv_substeps, G, US, IG, CS%SIS_transport_CSp, &
@@ -998,15 +998,15 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
       endif
 
       if (CS%debug) then
-        call uvchksum("Before SIS_C_dynamics [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, scale=US%L_T_to_m_s)
+        call uvchksum("Before SIS_C_dynamics [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, unscale=US%L_T_to_m_s)
         call hchksum(ice_free, "ice_free before SIS_C_dynamics", G%HI)
-        call hchksum(DS2d%mca_step(:,:,DS2d%nts), "misp_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(DS2d%mi_sum, "mi_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
+        call hchksum(DS2d%mca_step(:,:,DS2d%nts), "misp_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(DS2d%mi_sum, "mi_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
         call hchksum(DS2d%ice_cover, "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
-        call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, scale=US%L_T_to_m_s)
+        call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
         call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                      halos=1, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                      halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
@@ -1023,7 +1023,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
 
       call cpu_clock_end(iceClocka)
 
-      if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, scale=US%L_T_to_m_s)
+      if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, unscale=US%L_T_to_m_s)
 
       call cpu_clock_begin(iceClockb)
       call pass_vector(DS2d%u_ice_C, DS2d%v_ice_C, G%Domain, stagger=CGRID_NE)
@@ -1035,7 +1035,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
       if (CS%id_fax>0) call post_data(CS%id_fax, WindStr_x_Cu, CS%diag)
       if (CS%id_fay>0) call post_data(CS%id_fay, WindStr_y_Cv, CS%diag)
       if (CS%debug) call uvchksum("Before set_ocean_top_stress_Cgrid [uv]_ice_C", &
-                                  DS2d%u_ice_C, DS2d%v_ice_C, G, scale=US%L_T_to_m_s)
+                                  DS2d%u_ice_C, DS2d%v_ice_C, G, unscale=US%L_T_to_m_s)
 
       ! Store all mechanical ocean forcing.
       call set_ocean_top_stress_C2(IOF, WindStr_x_ocn_Cu, WindStr_y_ocn_Cv, &
@@ -1053,14 +1053,14 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
                                WindStr_x_ocn_B, WindStr_y_ocn_B, G, US, CS%complete_ice_cover)
 
       if (CS%debug) then
-        call Bchksum_pair("[uv]_ice_B before dynamics", DS2d%u_ice_B, DS2d%v_ice_B, G, scale=US%L_T_to_m_s)
+        call Bchksum_pair("[uv]_ice_B before dynamics", DS2d%u_ice_B, DS2d%v_ice_B, G, unscale=US%L_T_to_m_s)
         call hchksum(ice_free, "ice_free before ice_dynamics", G%HI)
-        call hchksum(DS2d%mca_step(:,:,DS2d%nts), "misp_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(DS2d%mi_sum, "mi_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
-        call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, scale=US%L_T_to_m_s)
+        call hchksum(DS2d%mca_step(:,:,DS2d%nts), "misp_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(DS2d%mi_sum, "mi_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
+        call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
         call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                          scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
       endif
 
       call cpu_clock_begin(iceClocka)
@@ -1072,7 +1072,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
                           rdg_rate, dt_slow_dyn, G, US, CS%SIS_B_dyn_CSp)
       call cpu_clock_end(iceClocka)
 
-      if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", DS2d%u_ice_B, DS2d%v_ice_B, G, scale=US%L_T_to_m_s)
+      if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", DS2d%u_ice_B, DS2d%v_ice_B, G, unscale=US%L_T_to_m_s)
 
       call cpu_clock_begin(iceClockb)
       call pass_vector(DS2d%u_ice_B, DS2d%v_ice_B, G%Domain, stagger=BGRID_NE)
@@ -1095,7 +1095,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
       endif
 
       if (CS%debug) call Bchksum_pair("Before set_ocean_top_stress_Bgrid [uv]_ice_B", DS2d%u_ice_B, DS2d%v_ice_B, &
-                                      G, scale=US%L_T_to_m_s)
+                                      G, unscale=US%L_T_to_m_s)
       ! Store all mechanical ocean forcing.
       call set_ocean_top_stress_B2(IOF, WindStr_x_ocn_B, WindStr_y_ocn_B, &
                                    str_x_ice_ocn_B, str_y_ice_ocn_B, ice_free, DS2d%ice_cover, G, US)
@@ -1118,7 +1118,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
       enddo ; enddo
     endif
 
-    if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, scale=US%L_T_to_m_s)
+    if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", DS2d%u_ice_C, DS2d%v_ice_C, G, unscale=US%L_T_to_m_s)
     call enable_SIS_averaging(dt_slow_dyn_sec, Time_start + real_to_time(nds*dt_slow_dyn_sec), CS%diag)
 
     ! Update the integrated ice mass and store the transports in each step.
@@ -1241,15 +1241,15 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
                                WindStr_x_ocn_Cu, WindStr_y_ocn_Cv, G, US, CS%complete_ice_cover, OBC)
 
       if (CS%debug) then
-        call uvchksum("Before SIS_C_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+        call uvchksum("Before SIS_C_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
         call hchksum(IST%part_size(:,:,0), "ice_free before SIS_C_dynamics", G%HI)
-        call hchksum(misp_sum, "misp_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(mi_sum, "mi_sum before SIS_C_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
+        call hchksum(misp_sum, "misp_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(mi_sum, "mi_sum before SIS_C_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(OSS%sea_lev, "sea_lev before SIS_C_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
         call hchksum(IST%part_size(:,:,1), "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
-        call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, scale=US%L_T_to_m_s)
+        call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
         call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                      halos=1, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                      halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
@@ -1258,7 +1258,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
                              WindStr_x_Cu, WindStr_y_Cv, str_x_ice_ocn_Cu, str_y_ice_ocn_Cv)
       call cpu_clock_end(iceClocka)
 
-      if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+      if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
 
       call cpu_clock_begin(iceClockb)
       call pass_vector(IST%u_ice_C, IST%v_ice_C, G%Domain, stagger=CGRID_NE)
@@ -1271,7 +1271,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
       if (CS%id_fay>0) call post_data(CS%id_fay, WindStr_y_Cv, CS%diag)
 
       if (CS%debug) call uvchksum("Before set_ocean_top_stress_Cgrid [uv]_ice_C", &
-                                  IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+                                  IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
 
       ! Store all mechanical ocean forcing.
       call set_ocean_top_stress_C2(IOF, WindStr_x_ocn_Cu, WindStr_y_ocn_Cv, str_x_ice_ocn_Cu, str_y_ice_ocn_Cv, &
@@ -1292,14 +1292,14 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
                                WindStr_x_ocn_B, WindStr_y_ocn_B, G, US, CS%complete_ice_cover)
 
       if (CS%debug) then
-        call Bchksum_pair("[uv]_ice_B before dynamics", IST%u_ice_B, IST%v_ice_B, G, scale=US%L_T_to_m_s)
+        call Bchksum_pair("[uv]_ice_B before dynamics", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
         call hchksum(IST%part_size(:,:,0), "ice_free before ice_dynamics", G%HI)
-        call hchksum(misp_sum, "misp_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(mi_sum, "mi_sum before ice_dynamics", G%HI, scale=US%RZ_to_kg_m2)
-        call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, scale=US%Z_to_m)
-        call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, scale=US%L_T_to_m_s)
+        call hchksum(misp_sum, "misp_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(mi_sum, "mi_sum before ice_dynamics", G%HI, unscale=US%RZ_to_kg_m2)
+        call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
+        call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
         call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                          scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
       endif
 
       call cpu_clock_begin(iceClocka)
@@ -1307,7 +1307,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
                              WindStr_x_B, WindStr_y_B, str_x_ice_ocn_B, str_y_ice_ocn_B)
       call cpu_clock_end(iceClocka)
 
-      if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, scale=US%L_T_to_m_s)
+      if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
 
       call cpu_clock_begin(iceClockb)
       call pass_vector(IST%u_ice_B, IST%v_ice_B, G%Domain, stagger=BGRID_NE)
@@ -1330,7 +1330,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
       endif
 
       if (CS%debug) call Bchksum_pair("Before set_ocean_top_stress_Bgrid [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, &
-                                      scale=US%L_T_to_m_s)
+                                      unscale=US%L_T_to_m_s)
       ! Store all mechanical ocean forcing.
       call set_ocean_top_stress_B2(IOF, WindStr_x_ocn_B, WindStr_y_ocn_B, str_x_ice_ocn_B, str_y_ice_ocn_B, &
                                    IST%part_size(:,:,0), IST%part_size(:,:,1), G, US)
@@ -1338,7 +1338,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
 
        ! Convert the B-grid velocities to C-grid points for transport.
       if (CS%debug) call Bchksum_pair("Before ice_transport [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, &
-                                      scale=US%L_T_to_m_s)
+                                      unscale=US%L_T_to_m_s)
       do j=jsc,jec ; do I=isc-1,iec
         IST%u_ice_C(I,j) = 0.5 * ( IST%u_ice_B(I,J-1) + IST%u_ice_B(I,J) )
       enddo ; enddo
@@ -1352,7 +1352,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
 
     ! Do ice mass transport and related tracer transport.  This updates the category-decomposed ice state.
     call cpu_clock_begin(iceClock8)
-    if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, scale=US%L_T_to_m_s)
+    if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
     call enable_SIS_averaging(dt_slow_dyn_sec, CS%Time - real_to_time((ndyn_steps-nds)*dt_slow_dyn_sec), CS%diag)
 
     call slab_ice_advect(IST%u_ice_C, IST%v_ice_C, IST%mH_ice(:,:,1), 4.0*US%kg_m3_to_R*US%m_to_Z, &

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -685,20 +685,20 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
   enddo
 
   if (CS%debug_fast) then
-    call hchksum(flux_u(:,:,1:), "Mid do_fast flux_u", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(flux_v(:,:,1:), "Mid do_fast flux_v", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(flux_sh(:,:,1:), "Mid do_fast flux_sh", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(evap(:,:,1:), "Mid do_fast evap", G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(flux_lw(:,:,1:), "Mid do_fast flux_lw", G%HI, scale=US%QRZ_T_to_W_m2)
+    call hchksum(flux_u(:,:,1:), "Mid do_fast flux_u", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(flux_v(:,:,1:), "Mid do_fast flux_v", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(flux_sh(:,:,1:), "Mid do_fast flux_sh", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(evap(:,:,1:), "Mid do_fast evap", G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(flux_lw(:,:,1:), "Mid do_fast flux_lw", G%HI, unscale=US%QRZ_T_to_W_m2)
     do b=1,size(flux_sw,4)
       write(nstr, '(I4)') b ; nstr = adjustl(nstr)
-      call hchksum(flux_sw(:,:,1:,b), "Mid do_fast flux_sw("//trim(nstr)//")", G%HI, scale=US%QRZ_T_to_W_m2)
+      call hchksum(flux_sw(:,:,1:,b), "Mid do_fast flux_sw("//trim(nstr)//")", G%HI, unscale=US%QRZ_T_to_W_m2)
     enddo
-    call hchksum(lprec(:,:,1:), "Mid do_fast lprec", G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(fprec(:,:,1:), "Mid do_fast fprec", G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(dshdt(:,:,1:), "Mid do_fast dshdt", G%HI, scale=US%degC_to_C*US%QRZ_T_to_W_m2)
-    call hchksum(devapdt(:,:,1:), "Mid do_fast devapdt", G%HI, scale=US%degC_to_C*US%RZ_T_to_kg_m2s)
-    call hchksum(dlwdt(:,:,1:), "Mid do_fast dlwdt", G%HI, scale=US%degC_to_C*US%QRZ_T_to_W_m2)
+    call hchksum(lprec(:,:,1:), "Mid do_fast lprec", G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(fprec(:,:,1:), "Mid do_fast fprec", G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(dshdt(:,:,1:), "Mid do_fast dshdt", G%HI, unscale=US%degC_to_C*US%QRZ_T_to_W_m2)
+    call hchksum(devapdt(:,:,1:), "Mid do_fast devapdt", G%HI, unscale=US%degC_to_C*US%RZ_T_to_kg_m2s)
+    call hchksum(dlwdt(:,:,1:), "Mid do_fast dlwdt", G%HI, unscale=US%degC_to_C*US%QRZ_T_to_W_m2)
   endif
 
   call get_SIS2_thermo_coefs(IST%ITV, ice_salinity=S_col, Latent_vapor=LatHtVap)
@@ -967,8 +967,8 @@ subroutine redo_update_ice_model_fast(IST, sOSS, Rad, FIA, TSF, optics_CSp, &
 
   if (CS%debug_slow) then
     call hchksum(Rad%coszen_lastrad, "Redo optics coszen_lastrad", G%HI)
-    call hchksum(Rad%Tskin_rad, "Redo optics Tskin_rad", G%HI, scale=US%C_to_degC)
-    call hchksum(FIA%flux_sw_dn, "Redo optics FIA%flux_sw_dn", G%HI, scale=US%QRZ_T_to_W_m2)
+    call hchksum(Rad%Tskin_rad, "Redo optics Tskin_rad", G%HI, unscale=US%C_to_degC)
+    call hchksum(FIA%flux_sw_dn, "Redo optics FIA%flux_sw_dn", G%HI, unscale=US%QRZ_T_to_W_m2)
   endif
 
   !$OMP parallel do default(none) &
@@ -1196,16 +1196,16 @@ subroutine flux_redo_chksum(mesg, IST, Rad, FIA, TSF, G, US, IG)
       if (IST%part_size(i,j,k) > 0.0) tmp_diag(i,j,k) = FIA%flux_sw_top(i,j,k,b)
     enddo ; enddo ; enddo
     call hchksum(tmp_diag, & ! similar to FIA%flux_sw_top(:,:,1:,b), &
-                 trim(mesg)//" FIA%flux_sw_top("//trim(nstr)//")", G%HI, scale=US%QRZ_T_to_W_m2)
+                 trim(mesg)//" FIA%flux_sw_top("//trim(nstr)//")", G%HI, unscale=US%QRZ_T_to_W_m2)
     call hchksum(TSF%flux_sw(:,:,b), &
-                 trim(mesg)//" TSF%flux_sw("//trim(nstr)//")", G%HI, scale=US%QRZ_T_to_W_m2)
+                 trim(mesg)//" TSF%flux_sw("//trim(nstr)//")", G%HI, unscale=US%QRZ_T_to_W_m2)
   enddo
-  call hchksum(FIA%flux_sh0(:,:,1:), trim(mesg)//" FIA%flux_sh0", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%dshdt(:,:,1:), trim(mesg)//" FIA%dshdt", G%HI, scale=US%degC_to_C*US%QRZ_T_to_W_m2)
-  call hchksum(FIA%flux_lw0(:,:,1:), trim(mesg)//" FIA%flux_lw0", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%dlwdt(:,:,1:), trim(mesg)//" FIA%dlwdt", G%HI, scale=US%degC_to_C*US%QRZ_T_to_W_m2)
-  call hchksum(FIA%evap0(:,:,1:), trim(mesg)//" FIA%evap0", G%HI, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(FIA%devapdt(:,:,1:), trim(mesg)//" FIA%devapdt", G%HI, scale=US%degC_to_C*US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%flux_sh0(:,:,1:), trim(mesg)//" FIA%flux_sh0", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%dshdt(:,:,1:), trim(mesg)//" FIA%dshdt", G%HI, unscale=US%degC_to_C*US%QRZ_T_to_W_m2)
+  call hchksum(FIA%flux_lw0(:,:,1:), trim(mesg)//" FIA%flux_lw0", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%dlwdt(:,:,1:), trim(mesg)//" FIA%dlwdt", G%HI, unscale=US%degC_to_C*US%QRZ_T_to_W_m2)
+  call hchksum(FIA%evap0(:,:,1:), trim(mesg)//" FIA%evap0", G%HI, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%devapdt(:,:,1:), trim(mesg)//" FIA%devapdt", G%HI, unscale=US%degC_to_C*US%RZ_T_to_kg_m2s)
   do m=1,size(Rad%sw_abs_ice,4)
     write(nstr, '(I4)') m ; nstr = adjustl(nstr)
     tmp_diag(:,:,:) = 0.0

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -83,7 +83,7 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
 
   if (debug) then
     call hchksum(G%bathyT, 'SIS_initialize_fixed: depth ', G%HI, &
-                 haloshift=min(1, G%ied-G%iec, G%jed-G%jec), scale=US%Z_to_m)
+                 haloshift=min(1, G%ied-G%iec, G%jed-G%jec), unscale=US%Z_to_m)
     call hchksum(G%mask2dT, 'SIS_initialize_fixed: mask2dT ', G%HI)
     call uvchksum('SIS_initialize_fixed: mask2dC[uv] ', &
                   G%mask2dCu, G%mask2dCv, G)
@@ -118,9 +118,9 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
   !  Calculate the components of grad f (beta) [T-1 L-1 ~> s-1 m-1]
   call MOM_calculate_grad_Coriolis(G%dF_dx, G%dF_dy, G, US)
   if (debug) then
-    call Bchksum(G%CoriolisBu, "SIS_initialize_fixed: f ", G%HI, scale=US%s_to_T)
-    call hchksum(G%dF_dx, "SIS_initialize_fixed: dF_dx ", G%HI, scale=US%m_to_L*US%s_to_T)
-    call hchksum(G%dF_dy, "SIS_initialize_fixed: dF_dy ", G%HI, scale=US%m_to_L*US%s_to_T)
+    call Bchksum(G%CoriolisBu, "SIS_initialize_fixed: f ", G%HI, unscale=US%s_to_T)
+    call hchksum(G%dF_dx, "SIS_initialize_fixed: dF_dx ", G%HI, unscale=US%m_to_L*US%s_to_T)
+    call hchksum(G%dF_dy, "SIS_initialize_fixed: dF_dy ", G%HI, unscale=US%m_to_L*US%s_to_T)
   endif
 
   call initialize_grid_rotation_angle(G, PF)

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -2207,35 +2207,35 @@ subroutine IOF_chksum(mesg, IOF, G, US, mech_fluxes, thermo_fluxes)
   if (present(thermo_fluxes)) then ; do_thermo = thermo_fluxes ; endif
 
   if (do_thermo) then
-    call hchksum(IOF%flux_salt, trim(mesg)//" IOF%flux_salt", G%HI, scale=US%S_to_ppt*US%RZ_T_to_kg_m2s)
+    call hchksum(IOF%flux_salt, trim(mesg)//" IOF%flux_salt", G%HI, unscale=US%S_to_ppt*US%RZ_T_to_kg_m2s)
     if (allocated(IOF%transmutation_salt_flux)) call hchksum(IOF%transmutation_salt_flux, &
-          trim(mesg)//" IOF%transmutation_salt_flux", G%HI, scale=US%S_to_ppt*US%RZ_T_to_kg_m2s)
+          trim(mesg)//" IOF%transmutation_salt_flux", G%HI, unscale=US%S_to_ppt*US%RZ_T_to_kg_m2s)
 
-    call hchksum(IOF%flux_sh_ocn_top, trim(mesg)//" IOF%flux_sh_ocn_top", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(IOF%flux_lw_ocn_top, trim(mesg)//" IOF%flux_lw_ocn_top", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(IOF%flux_lh_ocn_top, trim(mesg)//" IOF%flux_lh_ocn_top", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(IOF%flux_sw_ocn,     trim(mesg)//" IOF%flux_sw_ocn",     G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(IOF%evap_ocn_top,    trim(mesg)//" IOF%evap_ocn_top",  G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(IOF%lprec_ocn_top,   trim(mesg)//" IOF%lprec_ocn_top", G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(IOF%fprec_ocn_top,   trim(mesg)//" IOF%fprec_ocn_top", G%HI, scale=US%RZ_T_to_kg_m2s)
+    call hchksum(IOF%flux_sh_ocn_top, trim(mesg)//" IOF%flux_sh_ocn_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(IOF%flux_lw_ocn_top, trim(mesg)//" IOF%flux_lw_ocn_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(IOF%flux_lh_ocn_top, trim(mesg)//" IOF%flux_lh_ocn_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(IOF%flux_sw_ocn,     trim(mesg)//" IOF%flux_sw_ocn",     G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(IOF%evap_ocn_top,    trim(mesg)//" IOF%evap_ocn_top",  G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(IOF%lprec_ocn_top,   trim(mesg)//" IOF%lprec_ocn_top", G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(IOF%fprec_ocn_top,   trim(mesg)//" IOF%fprec_ocn_top", G%HI, unscale=US%RZ_T_to_kg_m2s)
   endif
   if (do_mech) then
-    call hchksum(IOF%flux_u_ocn,      trim(mesg)//" IOF%flux_u_ocn",   G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(IOF%flux_v_ocn,      trim(mesg)//" IOF%flux_v_ocn",   G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(IOF%pres_ocn_top,    trim(mesg)//" IOF%pres_ocn_top", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(IOF%mass_ice_sn_p,   trim(mesg)//" IOF%mass_ice_sn_p", G%HI, scale=US%RZ_to_kg_m2)
+    call hchksum(IOF%flux_u_ocn,      trim(mesg)//" IOF%flux_u_ocn",   G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(IOF%flux_v_ocn,      trim(mesg)//" IOF%flux_v_ocn",   G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(IOF%pres_ocn_top,    trim(mesg)//" IOF%pres_ocn_top", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(IOF%mass_ice_sn_p,   trim(mesg)//" IOF%mass_ice_sn_p", G%HI, unscale=US%RZ_to_kg_m2)
     if (allocated(IOF%stress_mag)) &
-      call hchksum(IOF%stress_mag,    trim(mesg)//" IOF%stress_mag", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call hchksum(IOF%stress_mag,    trim(mesg)//" IOF%stress_mag", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
   endif
 
   if (do_thermo) then
-    call hchksum(IOF%Enth_Mass_in_atm,  trim(mesg)//" IOF%Enth_Mass_in_atm",  G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
-    call hchksum(IOF%Enth_Mass_out_atm, trim(mesg)//" IOF%Enth_Mass_out_atm", G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
-    call hchksum(IOF%Enth_Mass_in_ocn,  trim(mesg)//" IOF%Enth_Mass_in_ocn",  G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
-    call hchksum(IOF%Enth_Mass_out_ocn, trim(mesg)//" IOF%Enth_Mass_out_ocn", G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
+    call hchksum(IOF%Enth_Mass_in_atm,  trim(mesg)//" IOF%Enth_Mass_in_atm",  G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
+    call hchksum(IOF%Enth_Mass_out_atm, trim(mesg)//" IOF%Enth_Mass_out_atm", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
+    call hchksum(IOF%Enth_Mass_in_ocn,  trim(mesg)//" IOF%Enth_Mass_in_ocn",  G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
+    call hchksum(IOF%Enth_Mass_out_ocn, trim(mesg)//" IOF%Enth_Mass_out_ocn", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
 
     if (allocated(IOF%transmutation_enth)) call hchksum(IOF%transmutation_enth, &
-          trim(mesg)//" IOF%transmutation_enth", G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
+          trim(mesg)//" IOF%transmutation_enth", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
   endif
 end subroutine IOF_chksum
 
@@ -2251,48 +2251,48 @@ subroutine FIA_chksum(mesg, FIA, G, US, check_ocean)
   character(len=8) :: nstr
   integer :: b
 
-  call hchksum(FIA%flux_sh_top(:,:,1:), trim(mesg)//" FIA%flux_sh_top", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%evap_top(:,:,1:), trim(mesg)//" FIA%evap_top", G%HI, scale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%flux_sh_top(:,:,1:), trim(mesg)//" FIA%flux_sh_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%evap_top(:,:,1:), trim(mesg)//" FIA%evap_top", G%HI, unscale=US%RZ_T_to_kg_m2s)
   do b=1,size(FIA%flux_sw_top,4)
     write(nstr, '(I4)') b ; nstr = adjustl(nstr)
     call hchksum(FIA%flux_sw_top(:,:,1:,b), &
-                 trim(mesg)//" FIA%flux_sw_top("//trim(nstr)//")", G%HI, scale=US%QRZ_T_to_W_m2)
+                 trim(mesg)//" FIA%flux_sw_top("//trim(nstr)//")", G%HI, unscale=US%QRZ_T_to_W_m2)
   enddo
-  call hchksum(FIA%flux_lw_top(:,:,1:), trim(mesg)//" FIA%flux_lw_top", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%flux_lh_top(:,:,1:), trim(mesg)//" FIA%flux_lh_top", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%lprec_top(:,:,1:), trim(mesg)//" FIA%lprec_top", G%HI, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(FIA%fprec_top(:,:,1:), trim(mesg)//" FIA%fprec_top", G%HI, scale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%flux_lw_top(:,:,1:), trim(mesg)//" FIA%flux_lw_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%flux_lh_top(:,:,1:), trim(mesg)//" FIA%flux_lh_top", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%lprec_top(:,:,1:), trim(mesg)//" FIA%lprec_top", G%HI, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%fprec_top(:,:,1:), trim(mesg)//" FIA%fprec_top", G%HI, unscale=US%RZ_T_to_kg_m2s)
 
   if (present(check_ocean)) then ; if (check_ocean) then
-    call hchksum(FIA%flux_sh_top(:,:,0), trim(mesg)//" FIA%flux_sh_top0", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(FIA%evap_top(:,:,0), trim(mesg)//" FIA%evap_top0", G%HI, scale=US%RZ_T_to_kg_m2s)
+    call hchksum(FIA%flux_sh_top(:,:,0), trim(mesg)//" FIA%flux_sh_top0", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(FIA%evap_top(:,:,0), trim(mesg)//" FIA%evap_top0", G%HI, unscale=US%RZ_T_to_kg_m2s)
     do b=1,size(FIA%flux_sw_top,4)
       write(nstr, '(I4)') b ; nstr = adjustl(nstr)
       call hchksum(FIA%flux_sw_top(:,:,0,b), &
-                   trim(mesg)//" FIA%flux_sw_top0("//trim(nstr)//")", G%HI, scale=US%QRZ_T_to_W_m2)
+                   trim(mesg)//" FIA%flux_sw_top0("//trim(nstr)//")", G%HI, unscale=US%QRZ_T_to_W_m2)
     enddo
-    call hchksum(FIA%flux_lw_top(:,:,0), trim(mesg)//" FIA%flux_lw_top0", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(FIA%flux_lh_top(:,:,0), trim(mesg)//" FIA%flux_lh_top0", G%HI, scale=US%QRZ_T_to_W_m2)
-    call hchksum(FIA%lprec_top(:,:,0), trim(mesg)//" FIA%lprec_top0", G%HI, scale=US%RZ_T_to_kg_m2s)
-    call hchksum(FIA%fprec_top(:,:,0), trim(mesg)//" FIA%fprec_top0", G%HI, scale=US%RZ_T_to_kg_m2s)
+    call hchksum(FIA%flux_lw_top(:,:,0), trim(mesg)//" FIA%flux_lw_top0", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(FIA%flux_lh_top(:,:,0), trim(mesg)//" FIA%flux_lh_top0", G%HI, unscale=US%QRZ_T_to_W_m2)
+    call hchksum(FIA%lprec_top(:,:,0), trim(mesg)//" FIA%lprec_top0", G%HI, unscale=US%RZ_T_to_kg_m2s)
+    call hchksum(FIA%fprec_top(:,:,0), trim(mesg)//" FIA%fprec_top0", G%HI, unscale=US%RZ_T_to_kg_m2s)
   endif ; endif
 
-  call hchksum(FIA%tmelt, trim(mesg)//" FIA%tmelt", G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
-  call hchksum(FIA%bmelt, trim(mesg)//" FIA%bmelt", G%HI, scale=US%QRZ_T_to_W_m2*US%T_to_s)
+  call hchksum(FIA%tmelt, trim(mesg)//" FIA%tmelt", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
+  call hchksum(FIA%bmelt, trim(mesg)//" FIA%bmelt", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
   call hchksum(FIA%sw_abs_ocn, trim(mesg)//" FIA%sw_abs_ocn", G%HI)
 
-  call hchksum(FIA%WindStr_x, trim(mesg)//" FIA%WindStr_x", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_y, trim(mesg)//" FIA%WindStr_y", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_ocn_x, trim(mesg)//" FIA%WindStr_ocn_x", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_ocn_y, trim(mesg)//" FIA%WindStr_ocn_y", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%p_atm_surf, trim(mesg)//" FIA%p_atm_surf", G%HI, scale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%runoff, trim(mesg)//" FIA%runoff", G%HI, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(FIA%calving, trim(mesg)//" FIA%calving", G%HI, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(FIA%runoff_hflx, trim(mesg)//" FIA%runoff_hflx", G%HI, scale=US%QRZ_T_to_W_m2)
-  call hchksum(FIA%calving_hflx, trim(mesg)//" FIA%calving_hflx", G%HI, scale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%WindStr_x, trim(mesg)//" FIA%WindStr_x", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%WindStr_y, trim(mesg)//" FIA%WindStr_y", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%WindStr_ocn_x, trim(mesg)//" FIA%WindStr_ocn_x", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%WindStr_ocn_y, trim(mesg)//" FIA%WindStr_ocn_y", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%p_atm_surf, trim(mesg)//" FIA%p_atm_surf", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%runoff, trim(mesg)//" FIA%runoff", G%HI, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%calving, trim(mesg)//" FIA%calving", G%HI, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(FIA%runoff_hflx, trim(mesg)//" FIA%runoff_hflx", G%HI, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%calving_hflx, trim(mesg)//" FIA%calving_hflx", G%HI, unscale=US%QRZ_T_to_W_m2)
   call hchksum(FIA%ice_free, trim(mesg)//" FIA%ice_free", G%HI)
   call hchksum(FIA%ice_cover, trim(mesg)//" FIA%ice_cover", G%HI)
-  call hchksum(FIA%flux_sw_dn, trim(mesg)//" FIA%flux_sw_dn", G%HI, scale=US%QRZ_T_to_W_m2)
+  call hchksum(FIA%flux_sw_dn, trim(mesg)//" FIA%flux_sw_dn", G%HI, unscale=US%QRZ_T_to_W_m2)
 
 end subroutine FIA_chksum
 
@@ -2315,19 +2315,19 @@ subroutine OSS_chksum(mesg, OSS, G, US, haloshift)
   ! and js...je as their extent.
   hs=0 ; if (present(haloshift)) hs=haloshift
 
-  call hchksum(OSS%s_surf, trim(mesg)//" OSS%s_surf", G%HI, haloshift=hs, scale=US%S_to_ppt)
-  call hchksum(OSS%SST_C, trim(mesg)//" OSS%SST_C", G%HI, haloshift=hs, scale=US%C_to_degC)
-  call hchksum(OSS%T_fr_ocn, trim(mesg)//" OSS%T_fr_ocn", G%HI, haloshift=hs, scale=US%C_to_degC)
-  call hchksum(OSS%sea_lev, trim(mesg)//" OSS%sea_lev", G%HI, haloshift=hs, scale=US%Z_to_m)
-  call hchksum(OSS%bheat, trim(mesg)//" OSS%bheat", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2)
-  call hchksum(OSS%frazil, trim(mesg)//" OSS%frazil", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2*US%T_to_s)
+  call hchksum(OSS%s_surf, trim(mesg)//" OSS%s_surf", G%HI, haloshift=hs, unscale=US%S_to_ppt)
+  call hchksum(OSS%SST_C, trim(mesg)//" OSS%SST_C", G%HI, haloshift=hs, unscale=US%C_to_degC)
+  call hchksum(OSS%T_fr_ocn, trim(mesg)//" OSS%T_fr_ocn", G%HI, haloshift=hs, unscale=US%C_to_degC)
+  call hchksum(OSS%sea_lev, trim(mesg)//" OSS%sea_lev", G%HI, haloshift=hs, unscale=US%Z_to_m)
+  call hchksum(OSS%bheat, trim(mesg)//" OSS%bheat", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(OSS%frazil, trim(mesg)//" OSS%frazil", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
 
   if (OSS%Cgrid_dyn) then
-    call uvchksum(mesg//" OSS%[uv]_ocn_C", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=hs, scale=US%L_T_to_m_s)
-    call check_redundant_C(mesg//" OSS%u/v_ocn_C", OSS%u_ocn_C, OSS%v_ocn_C, G)
+    call uvchksum(mesg//" OSS%[uv]_ocn_C", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=hs, unscale=US%L_T_to_m_s)
+    call check_redundant_C(mesg//" OSS%u/v_ocn_C", OSS%u_ocn_C, OSS%v_ocn_C, G, unscale=US%L_T_to_m_s)
   else
-    call Bchksum_pair(mesg//" OSS%[uv]_ocn_B", OSS%u_ocn_B, OSS%v_ocn_B, G, halos=hs, scale=US%L_T_to_m_s)
-    call check_redundant_B(mesg//" OSS%u/v_ocn", OSS%u_ocn_B, OSS%v_ocn_B, G)
+    call Bchksum_pair(mesg//" OSS%[uv]_ocn_B", OSS%u_ocn_B, OSS%v_ocn_B, G, halos=hs, unscale=US%L_T_to_m_s)
+    call check_redundant_B(mesg//" OSS%u/v_ocn", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
   endif
 
 end subroutine OSS_chksum
@@ -2351,14 +2351,14 @@ subroutine TSF_chksum(mesg, TSF, G, US, haloshift)
   ! and js...je as their extent.
   hs=0 ; if (present(haloshift)) hs=haloshift
 
-  call hchksum(TSF%flux_sh, trim(mesg)//" TSF%flux_sh", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2)
-  ! call hchksum(TSF%flux_sw, trim(mesg)//" TSF%flux_sw", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2)
-  call hchksum(TSF%flux_lw, trim(mesg)//" TSF%flux_lw", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2)
-  call hchksum(TSF%flux_lh, trim(mesg)//" TSF%flux_lh", G%HI, haloshift=hs, scale=US%QRZ_T_to_W_m2)
-  call hchksum(TSF%evap, trim(mesg)//" TSF%evap", G%HI, haloshift=hs, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(TSF%lprec, trim(mesg)//" TSF%lprec", G%HI, haloshift=hs, scale=US%RZ_T_to_kg_m2s)
-  call hchksum(TSF%fprec, trim(mesg)//" TSF%fprec", G%HI, haloshift=hs, scale=US%RZ_T_to_kg_m2s)
-  call uvchksum(mesg//" TSF%flux_[uv]", TSF%flux_u, TSF%flux_v, G, halos=hs, scale=US%L_T_to_m_s)
+  call hchksum(TSF%flux_sh, trim(mesg)//" TSF%flux_sh", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2)
+  ! call hchksum(TSF%flux_sw, trim(mesg)//" TSF%flux_sw", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(TSF%flux_lw, trim(mesg)//" TSF%flux_lw", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(TSF%flux_lh, trim(mesg)//" TSF%flux_lh", G%HI, haloshift=hs, unscale=US%QRZ_T_to_W_m2)
+  call hchksum(TSF%evap, trim(mesg)//" TSF%evap", G%HI, haloshift=hs, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(TSF%lprec, trim(mesg)//" TSF%lprec", G%HI, haloshift=hs, unscale=US%RZ_T_to_kg_m2s)
+  call hchksum(TSF%fprec, trim(mesg)//" TSF%fprec", G%HI, haloshift=hs, unscale=US%RZ_T_to_kg_m2s)
+  call uvchksum(mesg//" TSF%flux_[uv]", TSF%flux_u, TSF%flux_v, G, halos=hs, unscale=US%L_T_to_m_s)
 
 end subroutine TSF_chksum
 
@@ -2384,25 +2384,25 @@ subroutine IST_chksum(mesg, IST, G, US, IG, haloshift)
 
   call hchksum(IST%part_size(:,:,0), trim(mesg)//" IST%part_size(0)", G%HI, haloshift=hs)
   call hchksum(IST%part_size(:,:,1:), trim(mesg)//" IST%part_size", G%HI, haloshift=hs)
-  call hchksum(IST%mH_ice, trim(mesg)//" IST%mH_ice", G%HI, haloshift=hs, scale=US%RZ_to_kg_m2)
+  call hchksum(IST%mH_ice, trim(mesg)//" IST%mH_ice", G%HI, haloshift=hs, unscale=US%RZ_to_kg_m2)
   do k=1,IG%NkIce
     write(k_str1,'(I8)') k ;  k_str = "("//trim(adjustl(k_str1))//")"
     call hchksum(IST%enth_ice(:,:,:,k), trim(mesg)//" IST%enth_ice("//trim(k_str), G%HI, &
-                 haloshift=hs, scale=US%Q_to_J_kg)
+                 haloshift=hs, unscale=US%Q_to_J_kg)
     call hchksum(IST%sal_ice(:,:,:,k), trim(mesg)//" IST%sal_ice("//trim(k_str), G%HI, &
-                 haloshift=hs, scale=US%S_to_ppt)
+                 haloshift=hs, unscale=US%S_to_ppt)
   enddo
-  call hchksum(IST%mH_snow, trim(mesg)//" IST%mH_snow", G%HI, haloshift=hs, scale=US%RZ_to_kg_m2)
-  call hchksum(IST%enth_snow(:,:,:,1), trim(mesg)//" IST%enth_snow", G%HI, haloshift=hs, scale=US%Q_to_J_kg)
-  call hchksum(IST%mH_pond, trim(mesg)//" IST%mH_pond", G%HI, haloshift=hs, scale=US%RZ_to_kg_m2)
+  call hchksum(IST%mH_snow, trim(mesg)//" IST%mH_snow", G%HI, haloshift=hs, unscale=US%RZ_to_kg_m2)
+  call hchksum(IST%enth_snow(:,:,:,1), trim(mesg)//" IST%enth_snow", G%HI, haloshift=hs, unscale=US%Q_to_J_kg)
+  call hchksum(IST%mH_pond, trim(mesg)//" IST%mH_pond", G%HI, haloshift=hs, unscale=US%RZ_to_kg_m2)
 
   if (allocated(IST%u_ice_B) .and. allocated(IST%v_ice_B)) then
-    call Bchksum_pair(mesg//" IST%[uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, halos=hs, scale=US%L_T_to_m_s)
-    call check_redundant_B(mesg//" IST%u/v_ice", IST%u_ice_B, IST%v_ice_B, G)
+    call Bchksum_pair(mesg//" IST%[uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, halos=hs, unscale=US%L_T_to_m_s)
+    call check_redundant_B(mesg//" IST%u/v_ice", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
   endif
   if (allocated(IST%u_ice_C) .and. allocated(IST%v_ice_C)) then
-    call uvchksum(mesg//" IST%[uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, halos=hs, scale=US%L_T_to_m_s)
-    call check_redundant_C(mesg//" IST%u/v_ice_C", IST%u_ice_C, IST%v_ice_C, G)
+    call uvchksum(mesg//" IST%[uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, halos=hs, unscale=US%L_T_to_m_s)
+    call check_redundant_C(mesg//" IST%u/v_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
   endif
 
 end subroutine IST_chksum

--- a/src/SIS_utils.F90
+++ b/src/SIS_utils.F90
@@ -303,10 +303,10 @@ subroutine ice_grid_chksum(G, US, haloshift)
   call hchksum(G%geoLatT, "G%geoLatT", G%HI, haloshift=hs)
   call hchksum(G%geoLonT, "G%geoLonT", G%HI, haloshift=hs)
 
-  call hchksum_pair("G%d[xy]T", G%dxT, G%dyT, G, halos=hs, scale=US%L_to_m)
-  call hchksum_pair("G%Id[xy]T", G%IdxT, G%IdyT, G, halos=hs, scale=US%m_to_L)
-  call hchksum(G%areaT, "G%areaT", G%HI, haloshift=hs, scale=US%L_to_m**2)
-  call hchksum(G%IareaT, "G%IareaT", G%HI, haloshift=hs, scale=US%m_to_L**2)
+  call hchksum_pair("G%d[xy]T", G%dxT, G%dyT, G, halos=hs, unscale=US%L_to_m)
+  call hchksum_pair("G%Id[xy]T", G%IdxT, G%IdyT, G, halos=hs, unscale=US%m_to_L)
+  call hchksum(G%areaT, "G%areaT", G%HI, haloshift=hs, unscale=US%L_to_m**2)
+  call hchksum(G%IareaT, "G%IareaT", G%HI, haloshift=hs, unscale=US%m_to_L**2)
   call hchksum(G%mask2dT, "G%mask2dT", G%HI, haloshift=hs)
   call hchksum(G%cos_rot, "G%cos_rot", G%HI)
   call hchksum(G%sin_rot, "G%sin_rot", G%HI)
@@ -316,31 +316,31 @@ subroutine ice_grid_chksum(G, US, haloshift)
   call Bchksum(G%geoLatBu, "G%geoLatBu", G%HI, haloshift=hs)
   call Bchksum(G%geoLonBu, "G%geoLonBu", G%HI, haloshift=hs)
 
-  call Bchksum_pair("G%d[xy]Bu", G%dxBu, G%dyBu, G, halos=hs, scalars=.true., scale=US%L_to_m)
-  call Bchksum_pair("G%Id[xy]Bu", G%IdxBu, G%IdyBu, G, halos=hs, scalars=.true., scale=US%m_to_L)
+  call Bchksum_pair("G%d[xy]Bu", G%dxBu, G%dyBu, G, halos=hs, scalars=.true., unscale=US%L_to_m)
+  call Bchksum_pair("G%Id[xy]Bu", G%IdxBu, G%IdyBu, G, halos=hs, scalars=.true., unscale=US%m_to_L)
 
-  call Bchksum(G%areaBu, "G%areaBu", G%HI, haloshift=hs, scale=US%L_to_m**2)
-  call Bchksum(G%IareaBu, "G%IareaBu", G%HI, haloshift=hs, scale=US%m_to_L**2)
+  call Bchksum(G%areaBu, "G%areaBu", G%HI, haloshift=hs, unscale=US%L_to_m**2)
+  call Bchksum(G%IareaBu, "G%IareaBu", G%HI, haloshift=hs, unscale=US%m_to_L**2)
 
-  call check_redundant_B("G%areaBu", G%areaBu, G, isc-1, iec+1, jsc-1, jec+1)
-  call check_redundant_B("G%IareaBu", G%IareaBu, G, isc-1, iec+1, jsc-1, jec+1)
+  call check_redundant_B("G%areaBu", G%areaBu, G, isc-1, iec+1, jsc-1, jec+1, unscale=US%L_to_m**2)
+  call check_redundant_B("G%IareaBu", G%IareaBu, G, isc-1, iec+1, jsc-1, jec+1, unscale=US%m_to_L**2)
 
   call uvchksum("G%mask2dC[uv]", G%mask2dCu, G%mask2dCv, G, halos=hs)
 
   call uvchksum("G%geoLatC[uv]", G%geoLatCu, G%geoLatCv, G, halos=hs)
   call uvchksum("G%geolonC[uv]", G%geoLonCu, G%geoLonCv, G, halos=hs)
 
-  call uvchksum("G%d[xy]C[uv]", G%dxCu, G%dyCv, G, halos=hs, scalars=.true., scale=US%L_to_m)
-  call uvchksum("G%d[yx]C[uv]", G%dyCu, G%dxCv, G, halos=hs, scalars=.true., scale=US%L_to_m)
-  call uvchksum("G%Id[xy]C[uv]", G%IdxCu, G%IdyCv, G, halos=hs, scalars=.true., scale=US%m_to_L)
-  call uvchksum("G%Id[yx]C[uv]", G%IdyCu, G%IdxCv, G, halos=hs, scalars=.true., scale=US%m_to_L)
+  call uvchksum("G%d[xy]C[uv]", G%dxCu, G%dyCv, G, halos=hs, scalars=.true., unscale=US%L_to_m)
+  call uvchksum("G%d[yx]C[uv]", G%dyCu, G%dxCv, G, halos=hs, scalars=.true., unscale=US%L_to_m)
+  call uvchksum("G%Id[xy]C[uv]", G%IdxCu, G%IdyCv, G, halos=hs, scalars=.true., unscale=US%m_to_L)
+  call uvchksum("G%Id[yx]C[uv]", G%IdyCu, G%IdxCv, G, halos=hs, scalars=.true., unscale=US%m_to_L)
 
-  call uvchksum("G%areaC[uv]", G%areaCu, G%areaCv, G, halos=hs, scale=US%L_to_m**2)
-  call uvchksum("G%IareaC[uv]", G%IareaCu, G%IareaCv, G, halos=hs, scale=US%m_to_L**2)
+  call uvchksum("G%areaC[uv]", G%areaCu, G%areaCv, G, halos=hs, unscale=US%L_to_m**2)
+  call uvchksum("G%IareaC[uv]", G%IareaCu, G%IareaCv, G, halos=hs, unscale=US%m_to_L**2)
 
-  call hchksum(G%bathyT, "G%bathyT", G%HI, haloshift=hs, scale=US%Z_to_m)
-  call Bchksum(G%CoriolisBu, "G%CoriolisBu", G%HI, haloshift=hs, scale=US%s_to_T)
-  call hchksum_pair("G%dF_d[xy]", G%dF_dx, G%dF_dy, G, halos=hs, scale=US%s_to_T*US%m_to_L)
+  call hchksum(G%bathyT, "G%bathyT", G%HI, haloshift=hs, unscale=US%Z_to_m)
+  call Bchksum(G%CoriolisBu, "G%CoriolisBu", G%HI, haloshift=hs, unscale=US%s_to_T)
+  call hchksum_pair("G%dF_d[xy]", G%dF_dx, G%dF_dy, G, halos=hs, unscale=US%s_to_T*US%m_to_L)
 
 end subroutine ice_grid_chksum
 

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1177,9 +1177,9 @@ subroutine set_ice_surface_state(Ice, IST, OSS, Rad, FIA, G, US, IG, fCS)
     call chksum(G%mask2dT(isc:iec,jsc:jec), "Intermed G%mask2dT")
 !   if (allocated(OSS%u_ocn_C) .and. allocated(OSS%v_ocn_C)) &
 !     call uvchksum(OSS%u_ocn_C, "OSS%u_ocn_C", &
-!                   OSS%v_ocn_C, "OSS%v_ocn_C", G%HI, haloshift=1, scale=US%L_T_to_m_s)
+!                   OSS%v_ocn_C, "OSS%v_ocn_C", G%HI, haloshift=1, unscale=US%L_T_to_m_s)
 !   if (allocated(OSS%u_ocn_B)) &
-!     call Bchksum(OSS%u_ocn_B, "OSS%u_ocn_B", G%HI, haloshift=1, scale=US%L_T_to_m_s)
+!     call Bchksum(OSS%u_ocn_B, "OSS%u_ocn_B", G%HI, haloshift=1, unscale=US%L_T_to_m_s)
 !   if (allocated(OSS%v_ocn_B)) &
 !     call Bchksum(OSS%v_ocn_B, "OSS%v_ocn_B", G%HI, haloshift=1)
     call chksum(G%sin_rot(isc:iec,jsc:jec), "G%sin_rot")


### PR DESCRIPTION
  Renamed the `scale` argument to the various checksum calls used by SIS2 to `unscale`, and added `unscale` optional arguments to the various `check_redundant()` routines.  Both of these changes bring SIS2 into line with what is used now in MOM6 to facilitate the tighter integration of SIS2 and MOM6.  All calls to checksums had the name of the scale optional argument changed, and several calls to the `check_redundant()` routines now have `unscale` arguments.  In addition, descriptions of the units of about 55 real SIS2 variables were added, mostly by copying comments directly from the corresponding MOM6 routines.  All answers are bitwise identical, but there is a change in the name of an optional argument to a number of publicly visible routines.