### PR TITLE
+Signed OBC%segnum_u and OBC%segnum_v in SIS2

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -161,7 +161,7 @@ type SIS_slow_CS
   type(total_sfc_flux_type), pointer :: XSF => NULL()  !< A structure of the excess
                             !! fluxes between the atmosphere and the ice or ocean
                             !! relative to those stored in TSF.
-  type(isponge_CS), pointer :: isponge_CSp => NULL() !< A pointer to the control structure containing 
+  type(isponge_CS), pointer :: isponge_CSp => NULL() !< A pointer to the control structure containing
                                                      ! ice relaxation (sponge) arrays, variables
 
 end type SIS_slow_CS

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -497,7 +497,8 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
           call cpu_clock_end(iceClocka)
 
-          if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
+          if (CS%debug) call uvchksum("After ice_dynamics [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, &
+                                      G, unscale=US%L_T_to_m_s)
 
           call cpu_clock_begin(iceClockb)
           call pass_vector(IST%u_ice_C, IST%v_ice_C, G%Domain, stagger=CGRID_NE)
@@ -558,7 +559,8 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
           endif
           call cpu_clock_end(iceClocka)
 
-          if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, G, unscale=US%L_T_to_m_s)
+          if (CS%debug) call Bchksum_pair("After dynamics [uv]_ice_B", IST%u_ice_B, IST%v_ice_B, &
+                                          G, unscale=US%L_T_to_m_s)
 
           call cpu_clock_begin(iceClockb)
           call pass_vector(IST%u_ice_B, IST%v_ice_B, G%Domain, stagger=BGRID_NE)
@@ -616,7 +618,8 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
       ! Do ice mass transport and related tracer transport.  This updates the category-decomposed ice state.
       call cpu_clock_begin(iceClock8)
       ! The code timed by iceClock8 is the non-merged_cont equivalent to complete_IST_transport.
-      if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, unscale=US%L_T_to_m_s)
+      if (CS%debug) call uvchksum("Before ice_transport [uv]_ice_C", IST%u_ice_C, IST%v_ice_C, G, &
+                                  unscale=US%L_T_to_m_s)
       call enable_SIS_averaging(dt_slow_dyn_sec, Time_cycle_start + real_to_time(nds*dt_slow_dyn_sec), CS%diag)
 
       call ice_cat_transport(CS%CAS, IST%TrReg, dt_slow_dyn, CS%adv_substeps, G, US, IG, CS%SIS_transport_CSp, &

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1631,7 +1631,6 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
 
   real    :: ps_vel ! part_size interpolated to a velocity point [nondim].
   integer :: i, j, k, isc, iec, jsc, jec, ncat
-  integer :: l_seg
   logical :: local_open_u_BC, local_open_v_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -1698,29 +1697,25 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
       !$OMP parallel do default(shared) private(ps_vel)
       do j=jsc,jec
         do I=Isc-1,iec
-          l_seg = OBC%segnum_u(I,j)
           ps_vel = 1.0 ; if (G%mask2dCu(I,j)>0.0) ps_vel = 0.5*(part_size(i+1,j,0) + part_size(i,j,0))
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%open) then
-              if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
-                ps_vel = part_size(i,j,0)
-              else
-                ps_vel = part_size(i+1,j,0)
-              endif
-          endif ; endif
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+            if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) &
+              ps_vel = part_size(i,j,0)
+          elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+            if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) &
+              ps_vel = part_size(i+1,j,0)
+          endif
           IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * windstr_x_water(I,j)
         enddo
         do k=1,ncat ; do I=isc-1,iec ; if (G%mask2dCu(I,j)>0.0) then
-          l_seg = OBC%segnum_u(I,j)
           ps_vel = 0.5 * (part_size(i+1,j,k) + part_size(i,j,k))
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%open) then
-              if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
-                ps_vel = part_size(i,j,k)
-              else
-                ps_vel = part_size(i+1,j,k)
-              endif
-          endif ; endif
+          if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+            if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) &
+              ps_vel = part_size(i,j,k)
+          elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+            if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) &
+              ps_vel = part_size(i+1,j,k)
+          endif
           IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + ps_vel * str_ice_oce_x(I,j)
         endif ; enddo ; enddo
       enddo
@@ -1741,29 +1736,25 @@ subroutine set_ocean_top_stress_Cgrid(IOF, windstr_x_water, windstr_y_water, &
       !$OMP parallel do default(shared) private(ps_vel)
       do J=jsc-1,jec
         do i=isc,iec
-          l_seg = OBC%segnum_v(i,J)
           ps_vel = 1.0 ; if (G%mask2dCv(i,J)>0.0) ps_vel = 0.5*(part_size(i,j+1,0) + part_size(i,j,0))
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%open) then
-              if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
-                ps_vel = part_size(i,j,0)
-              else
-                ps_vel = part_size(i,j+1,0)
-              endif
-          endif ; endif
+          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
+            if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) &
+              ps_vel = part_size(i,j,0)
+          elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+            if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) &
+              ps_vel = part_size(i,j+1,0)
+          endif
           IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * windstr_y_water(i,J)
         enddo
         do k=1,ncat ; do i=isc,iec ; if (G%mask2dCv(i,J)>0.0) then
-          l_seg = OBC%segnum_v(i,J)
           ps_vel = 0.5 * (part_size(i,j+1,k) + part_size(i,j,k))
-          if (l_seg /= OBC_NONE) then
-            if (OBC%segment(l_seg)%open) then
-              if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
-                ps_vel = part_size(i,j,k)
-              else
-                ps_vel = part_size(i,j+1,k)
-              endif
-          endif ; endif
+          if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
+            if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) &
+              ps_vel = part_size(i,j,k)
+          elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+            if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) &
+              ps_vel = part_size(i,j+1,k)
+          endif
           IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + ps_vel * str_ice_oce_y(i,J)
         endif ; enddo ; enddo
       enddo
@@ -1912,7 +1903,6 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
 
   real    :: ps_ice, ps_ocn ! ice_free and ice_cover interpolated to a velocity point [nondim].
   integer :: i, j, k, isc, iec, jsc, jec
-  integer :: l_seg
   logical :: local_open_u_BC, local_open_v_BC
   type(OBC_segment_type), pointer :: segment => NULL()
 
@@ -1969,21 +1959,21 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
       !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
       do j=jsc,jec ; do I=Isc-1,iec
         ps_ocn = 1.0 ; ps_ice = 0.0
-        l_seg = OBC%segnum_u(I,j)
         if (G%mask2dCu(I,j)>0.0) then
           ps_ocn = 0.5*(ice_free(i+1,j) + ice_free(i,j))
           ps_ice = 0.5*(ice_cover(i+1,j) + ice_cover(i,j))
         endif
-        if (l_seg /= OBC_NONE) then
-          if (OBC%segment(l_seg)%open) then
-            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+        if (OBC%segnum_u(I,j) > 0) then !  OBC_DIRECTION_E
+            if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
               ps_ocn = ice_free(i,j)
               ps_ice = ice_cover(i,j)
-            else
-              ps_ocn = ice_free(i+1,j)
-              ps_ice = ice_cover(i+1,j)
             endif
-        endif ; endif
+        elseif (OBC%segnum_u(I,j) < 0) then !  OBC_DIRECTION_W
+          if (OBC%segment(abs(OBC%segnum_u(I,j)))%open) then
+            ps_ocn = ice_free(i+1,j)
+            ps_ice = ice_cover(i+1,j)
+          endif
+        endif
         IOF%flux_u_ocn(I,j) = IOF%flux_u_ocn(I,j) + &
             (ps_ocn * windstr_x_water(I,j) + ps_ice * str_ice_oce_x(I,j))
       enddo ; enddo
@@ -2002,22 +1992,22 @@ subroutine set_ocean_top_stress_C2(IOF, windstr_x_water, windstr_y_water, &
     if (local_open_v_BC) then
       !$OMP parallel do default(shared) private(ps_ocn, ps_ice)
       do J=jsc-1,jec ; do i=isc,iec
-        l_seg = OBC%segnum_v(i,J)
         ps_ocn = 1.0 ; ps_ice = 0.0
-        if (G%mask2dCv(i,J)>0.0) then
+        if (G%mask2dCv(i,J) > 0.0) then
           ps_ocn = 0.5*(ice_free(i,j+1) + ice_free(i,j))
           ps_ice = 0.5*(ice_cover(i,j+1) + ice_cover(i,j))
         endif
-        if (l_seg /= OBC_NONE) then
-          if (OBC%segment(l_seg)%open) then
-            if (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
-              ps_ocn = ice_free(i,j)
-              ps_ice = ice_cover(i,j)
-            else
-              ps_ocn = ice_free(i,j+1)
-              ps_ice = ice_cover(i,j+1)
-            endif
-        endif ; endif
+        if (OBC%segnum_v(i,J) > 0) then !  OBC_DIRECTION_N
+          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
+            ps_ocn = ice_free(i,j)
+            ps_ice = ice_cover(i,j)
+          endif
+        elseif (OBC%segnum_v(i,J) < 0) then !  OBC_DIRECTION_S
+          if (OBC%segment(abs(OBC%segnum_v(i,J)))%open) then
+            ps_ocn = ice_free(i,j+1)
+            ps_ice = ice_cover(i,j+1)
+          endif
+        endif
         IOF%flux_v_ocn(i,J) = IOF%flux_v_ocn(i,J) + &
             (ps_ocn * windstr_y_water(i,J) + ps_ice * str_ice_oce_y(i,J))
       enddo ; enddo

--- a/src/SIS_open_boundary.F90
+++ b/src/SIS_open_boundary.F90
@@ -30,14 +30,11 @@ integer, parameter         :: MAX_OBC_FIELDS = 100  !< Maximum number of data fi
 !> Open boundary segment data from files (mostly).
 type, public :: OBC_segment_data_type
   integer :: fid                            !< handle from FMS associated with segment data on disk
-  integer :: fid_dz                         !< handle from FMS associated with segment thicknesses on disk
-  character(len=8)                :: name   !< a name identifier for the segment data
-  real, allocatable :: buffer_src(:,:,:)    !< buffer for segment data located at cell faces
-  integer                         :: nk_src !< Number of vertical levels in the source data
-  real, allocatable :: dz_src(:,:,:)        !< vertical grid cell spacing of the incoming segment
-                                            !! data, set in [Z ~> m]
-  real, allocatable :: buffer_dst(:,:,:)    !< buffer src data remapped to the target vertical grid
-  real              :: value                !< constant value if fid is equal to -1
+  character(len=8)  :: name                 !< a name identifier for the segment data
+  integer           :: nk_src               !< Number of vertical levels in the source data
+  real              :: value                !< A constant value for the inflow concentration if not read
+                                            !! from file, in the internal units of a field, such as [S ~> ppt]
+                                            !! for salinity.
 end type OBC_segment_data_type
 
 
@@ -166,9 +163,15 @@ type, public :: ice_OBC_type
   type(OBC_segment_type), allocatable :: segment(:)   !< List of segment objects.
 
   ! Which segment object describes the current point.
-  integer, allocatable :: segnum_u(:,:) !< Segment number of u-points.
-  integer, allocatable :: segnum_v(:,:) !< Segment number of v-points.
+  integer, allocatable :: segnum_u(:,:) !< The absolute value gives the segment number of any OBCs at u-points,
+                                        !! while the sign indicates whether they are Eastern (> 0) or Western (< 0)
+                                        !! OBCs, with 0 for velocities that are not on an OBC.
+  integer, allocatable :: segnum_v(:,:) !< The absolute value gives the segment number of any OBCs at v-points,
+                                        !! while the sign indicates whether they are Northern (> 0) or Southern (< 0)
+                                        !! OBCs, with 0 for velocities that are not on an OBC.
   logical :: OBC_pe                     !< Is there an open boundary on this tile?
+  logical :: u_OBCs_on_PE   !< True if there are any u-point OBCs on this PE, including in its halos.
+  logical :: v_OBCs_on_PE   !< True if there are any v-point OBCs on this PE, including in its halos.
   type(OBC_registry_type), pointer :: OBC_Reg => NULL()  !< Registry type for boundaries
   real, allocatable :: tres_x(:,:,:,:)   !< Array storage of tracer reservoirs for restarts [conc L ~> conc m]
   real, allocatable :: tres_y(:,:,:,:)   !< Array storage of tracer reservoirs for restarts [conc L ~> conc m]
@@ -181,7 +184,7 @@ end type ice_OBC_type
 !> Control structure for open boundaries that read from files.
 !! Probably lots to update here.
 type, public :: file_OBC_CS ; private
-  real :: tide_flow = 3.0e6         !< Placeholder for now...
+  logical :: OBC_file_used = .false.     !< Placeholder for now to avoid an empty type.
 end type file_OBC_CS
 
 !> Type to carry something (what??) for the OBC registry.
@@ -350,8 +353,10 @@ subroutine open_boundary_config(G, US, param_file, OBC)
       OBC%segment(l)%Velocity_nudging_timescale_out = 0.0
       OBC%segment(l)%num_fields = 0
     enddo
-    allocate(OBC%segnum_u(G%IsdB:G%IedB,G%jsd:G%jed), source=OBC_NONE)
-    allocate(OBC%segnum_v(G%isd:G%ied,G%JsdB:G%JedB), source=OBC_NONE)
+    allocate(OBC%segnum_u(G%IsdB:G%IedB,G%jsd:G%jed), source=0)
+    allocate(OBC%segnum_v(G%isd:G%ied,G%JsdB:G%JedB), source=0)
+    OBC%u_OBCs_on_PE = .false.
+    OBC%v_OBCs_on_PE = .false.
 
     do l = 1, OBC%number_of_segments
       write(segment_param_str(1:15),"('OBC_SEGMENT_',i3.3)") l
@@ -368,6 +373,9 @@ subroutine open_boundary_config(G, US, param_file, OBC)
              "Unable to interpret "//segment_param_str//" = "//trim(segment_str))
       endif
     enddo
+    ! ! Set arrays indicating the segment number and segment direction, and also store the
+    ! ! range of indices within which various orientations of OBCs can be found on this PE.
+    ! call set_segnum_signs(OBC, G)
 
     ! Moved this earlier because time_interp_external_init needs to be called
     ! before anything that uses time_interp_external (such as initialize_segment_data)
@@ -458,7 +466,7 @@ subroutine setup_segment_indices(G, seg, Is_obc, Ie_obc, Js_obc, Je_obc)
   integer, intent(in) :: Js_obc !< Q-point global j-index of start of segment
   integer, intent(in) :: Je_obc !< Q-point global j-index of end of segment
   ! Local variables
-  integer :: IsgB, IegB, JsgB, JegB
+  integer :: IsgB, IegB, JsgB, JegB  ! Global corner point indices at the ends of the OBC segments
   integer :: isg, ieg, jsg, jeg
 
   ! Isg, Ieg will be I*_obc in global space
@@ -600,7 +608,7 @@ subroutine setup_u_point_obc(OBC, G, US, segment_str, l_seg, PF, reentrant_y)
     OBC%segment(l_seg)%direction = OBC_DIRECTION_E
   elseif (Je_obc<Js_obc) then
     OBC%segment(l_seg)%direction = OBC_DIRECTION_W
-    j=js_obc;js_obc=je_obc;je_obc=j
+    j = js_obc ; js_obc = je_obc ; je_obc = j
   endif
 
   OBC%segment(l_seg)%on_pe = .false.
@@ -681,6 +689,8 @@ subroutine setup_u_point_obc(OBC, G, US, segment_str, l_seg, PF, reentrant_y)
   do j=G%HI%jsd, G%HI%jed
     if (j>Js_obc .and. j<=Je_obc) then
       OBC%segnum_u(I_obc,j) = l_seg
+      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) OBC%segnum_u(I_obc,j) = -l_seg
+      OBC%u_OBCs_on_PE = .true.
     endif
   enddo
   OBC%segment(l_seg)%Is_obc = I_obc
@@ -693,8 +703,7 @@ subroutine setup_u_point_obc(OBC, G, US, segment_str, l_seg, PF, reentrant_y)
     OBC%segment(l_seg)%values_needed = .true.
 end subroutine setup_u_point_obc
 
-!> Parse an OBC_SEGMENT_%%% string starting with "J=" and configure placement
-!and type of OBC accordingly
+!> Parse an OBC_SEGMENT_%%% string starting with "J=" and configure placement and type of OBC accordingly
 subroutine setup_v_point_obc(OBC, G, US, segment_str, l_seg, PF, reentrant_x)
   type(ice_OBC_type),   intent(inout) :: OBC !< Open boundary control structure
   type(dyn_horgrid_type),  intent(in) :: G   !< Ocean grid structure
@@ -801,6 +810,8 @@ subroutine setup_v_point_obc(OBC, G, US, segment_str, l_seg, PF, reentrant_x)
   do i=G%HI%isd, G%HI%ied
     if (i>Is_obc .and. i<=Ie_obc) then
       OBC%segnum_v(i,J_obc) = l_seg
+      if (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) OBC%segnum_v(i,J_obc) = -l_seg
+      OBC%v_OBCs_on_PE = .true.
     endif
   enddo
   OBC%segment(l_seg)%Is_obc = Is_obc
@@ -830,43 +841,43 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv, US)
   if (.not.associated(OBC)) return
 
   do n=1,OBC%number_of_segments
-    segment=>OBC%segment(n)
+    segment => OBC%segment(n)
     if (.not. segment%on_pe) cycle
     if (segment%is_E_or_W) then
       ! Sweep along u-segments and delete the OBC for blocked points.
       ! Also, mask all points outside.
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
-        if (G%mask2dCu(I,j) == 0) OBC%segnum_u(I,j) = OBC_NONE
+        if (G%mask2dCu(I,j) == 0) OBC%segnum_u(I,j) = 0 ! Same as OBC_NONE
         if (segment%direction == OBC_DIRECTION_W) then
-          G%mask2dT(i,j) = 0
+          G%mask2dT(i,j) = 0.0
         else
-          G%mask2dT(i+1,j) = 0
+          G%mask2dT(i+1,j) = 0.0
         endif
       enddo
       do J=segment%HI%JsdB+1,segment%HI%JedB-1
         if (segment%direction == OBC_DIRECTION_W) then
-          G%mask2dCv(i,J) = 0
+          G%mask2dCv(i,J) = 0.0
         else
-          G%mask2dCv(i+1,J) = 0
+          G%mask2dCv(i+1,J) = 0.0
         endif
       enddo
     else
       ! Sweep along v-segments and delete the OBC for blocked points.
       J=segment%HI%JsdB
       do i=segment%HI%isd,segment%HI%ied
-        if (G%mask2dCv(i,J) == 0) OBC%segnum_v(i,J) = OBC_NONE
+        if (G%mask2dCv(i,J) == 0) OBC%segnum_v(i,J) = 0 ! Same as OBC_NONE
         if (segment%direction == OBC_DIRECTION_S) then
-          G%mask2dT(i,j) = 0
+          G%mask2dT(i,j) = 0.0
         else
-          G%mask2dT(i,j+1) = 0
+          G%mask2dT(i,j+1) = 0.0
         endif
       enddo
       do I=segment%HI%IsdB+1,segment%HI%IedB-1
         if (segment%direction == OBC_DIRECTION_S) then
-          G%mask2dCu(I,j) = 0
+          G%mask2dCu(I,j) = 0.0
         else
-          G%mask2dCu(I,j+1) = 0
+          G%mask2dCu(I,j+1) = 0.0
         endif
       enddo
     endif
@@ -876,8 +887,7 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv, US)
     segment=>OBC%segment(n)
     if (.not. segment%on_pe .or. .not. segment%specified) cycle
     if (segment%is_E_or_W) then
-      ! Sweep along u-segments and for %specified BC points reset the u-point
-      ! area which was masked out
+      ! Sweep along u-segments and for %specified BC points reset the u-point area which was masked out
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
         if (segment%direction == OBC_DIRECTION_E) then
@@ -887,14 +897,15 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv, US)
         endif
       enddo
     else
-      ! Sweep along v-segments and for %specified BC points reset the v-point
-      ! area which was masked out
+      ! Sweep along v-segments and for %specified BC points reset the v-point area which was masked out
       J=segment%HI%JsdB
       do i=segment%HI%isd,segment%HI%ied
         if (segment%direction == OBC_DIRECTION_S) then
           areaCv(i,J) = G%areaT(i,j+1) ! Both of these are in [L2 ~> m2]
         else      ! North
           areaCu(i,J) = G%areaT(i,j)   ! Both of these are in [L2 ~> m2]
+          !### The line above is a bug, it should be:
+          ! areaCv(i,J) = G%areaT(i,j)   ! Both of these are in [L2 ~> m2]
         endif
       enddo
     endif
@@ -912,18 +923,19 @@ subroutine open_boundary_impose_land_mask(OBC, G, areaCu, areaCv, US)
     if (segment%is_E_or_W) then
       I=segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
-        if (OBC%segnum_u(I,j) /= OBC_NONE) any_U = .true.
+        if (OBC%segnum_u(I,j) /= 0) any_U = .true.
       enddo
     else
       J=segment%HI%JsdB
       do i=segment%HI%isd,segment%HI%ied
-        if (OBC%segnum_v(i,J) /= OBC_NONE) any_V = .true.
+        if (OBC%segnum_v(i,J) /= 0) any_V = .true.
       enddo
     endif
   enddo
 
-  OBC%OBC_pe = .true.
-  if (.not.(any_U .or. any_V)) OBC%OBC_pe = .false.
+  OBC%u_OBCs_on_PE = any_U
+  OBC%v_OBCs_on_PE = any_V
+  OBC%OBC_pe = (any_U .or. any_V)
 
 end subroutine open_boundary_impose_land_mask
 
@@ -939,14 +951,12 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   ! Local variables
   integer :: isd, ied, IsdB, IedB, jsd, jed, JsdB, JedB, n
   integer :: i, j
-  integer :: l_seg
   logical :: fatal_error = .False.
   real    :: min_depth ! The minimum depth for ocean points [Z ~> m]
   integer, parameter :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
-  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
   real, allocatable, dimension(:,:) :: color, color2  ! For sorting inside from outside,
-                                                      ! two different ways
+                                                      ! two different ways [nondim]
 
   if (.not. associated(OBC)) return
 
@@ -982,50 +992,38 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   enddo
 
   do j=G%jsd,G%jed ; do i=G%IsdB+1,G%IedB-1
-    l_seg = OBC%segnum_u(I,j)
-    if (l_seg == OBC_NONE) cycle
-
-    if (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+    if (OBC%segnum_u(I,j) < 0) then      !  OBC_DIRECTION_W
       if (color(i,j) == 0.0) color(i,j) = cout
       if (color(i+1,j) == 0.0) color(i+1,j) = cin
-    elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+    elseif (OBC%segnum_u(I,j) > 0) then  !  OBC_DIRECTION_E
       if (color(i,j) == 0.0) color(i,j) = cin
       if (color(i+1,j) == 0.0) color(i+1,j) = cout
     endif
   enddo ; enddo
   do J=G%JsdB+1,G%JedB-1 ; do i=G%isd,G%ied
-    l_seg = OBC%segnum_v(i,J)
-    if (l_seg == OBC_NONE) cycle
-
-    if (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+    if (OBC%segnum_v(i,J) < 0) then      ! OBC_DIRECTION_S
       if (color(i,j) == 0.0) color(i,j) = cout
       if (color(i,j+1) == 0.0) color(i,j+1) = cin
-    elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+    elseif (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
       if (color(i,j) == 0.0) color(i,j) = cin
       if (color(i,j+1) == 0.0) color(i,j+1) = cout
     endif
   enddo ; enddo
 
   do J=G%JsdB+1,G%JedB-1 ; do i=G%isd,G%ied
-    l_seg = OBC%segnum_v(i,J)
-    if (l_seg == OBC_NONE) cycle
-
-    if (OBC%segment(l_seg)%direction == OBC_DIRECTION_S) then
+    if (OBC%segnum_v(i,J) < 0) then      ! OBC_DIRECTION_S
       if (color2(i,j) == 0.0) color2(i,j) = cout
       if (color2(i,j+1) == 0.0) color2(i,j+1) = cin
-    elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_N) then
+    elseif (OBC%segnum_v(i,J) > 0) then  ! OBC_DIRECTION_N
       if (color2(i,j) == 0.0) color2(i,j) = cin
       if (color2(i,j+1) == 0.0) color2(i,j+1) = cout
     endif
   enddo ; enddo
   do j=G%jsd,G%jed ; do i=G%IsdB+1,G%IedB-1
-    l_seg = OBC%segnum_u(I,j)
-    if (l_seg == OBC_NONE) cycle
-
-    if (OBC%segment(l_seg)%direction == OBC_DIRECTION_W) then
+    if (OBC%segnum_u(I,j) < 0) then      !  OBC_DIRECTION_W
       if (color2(i,j) == 0.0) color2(i,j) = cout
       if (color2(i+1,j) == 0.0) color2(i+1,j) = cin
-    elseif (OBC%segment(l_seg)%direction == OBC_DIRECTION_E) then
+    elseif (OBC%segnum_u(I,j) > 0) then  !  OBC_DIRECTION_E
       if (color2(i,j) == 0.0) color2(i,j) = cin
       if (color2(i+1,j) == 0.0) color2(i+1,j) = cout
     endif
@@ -1041,7 +1039,7 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
       fatal_error = .True.
       write(mesg,'("SIS_open_boundary: problem with OBC segments specification at ",I5,",",I5," during\n", &
           "the masking of the outside grid points.")') i, j
-      call MOM_error(WARNING,"MOM register_tracer: "//mesg, all_print=.true.)
+      call MOM_error(WARNING,"SIS mask_outside_OBCs: "//mesg, all_print=.true.)
     endif
     if (color(i,j) == cout) G%bathyT(i,j) = min_depth
   enddo ; enddo

--- a/src/SIS_open_boundary.F90
+++ b/src/SIS_open_boundary.F90
@@ -172,6 +172,16 @@ type, public :: ice_OBC_type
   logical :: OBC_pe                     !< Is there an open boundary on this tile?
   logical :: u_OBCs_on_PE   !< True if there are any u-point OBCs on this PE, including in its halos.
   logical :: v_OBCs_on_PE   !< True if there are any v-point OBCs on this PE, including in its halos.
+  logical :: v_N_OBCs_on_PE !< True if there are any northern v-point OBCs on this PE, including in its halos.
+  logical :: v_S_OBCs_on_PE !< True if there are any southern v-point OBCs on this PE, including in its halos.
+  logical :: u_E_OBCs_on_PE !< True if there are any eastern u-point OBCs on this PE, including in its halos.
+  logical :: u_W_OBCs_on_PE !< True if there are any western u-point OBCs on this PE, including in its halos.
+  !>@{ Index ranges on the local PE for the open boundary conditions in various directions
+  integer :: Is_u_W_obc, Ie_u_W_obc, js_u_W_obc, je_u_W_obc
+  integer :: Is_u_E_obc, Ie_u_E_obc, js_u_E_obc, je_u_E_obc
+  integer :: is_v_S_obc, ie_v_S_obc, Js_v_S_obc, Je_v_S_obc
+  integer :: is_v_N_obc, ie_v_N_obc, Js_v_N_obc, Je_v_N_obc
+  !>@}
   type(OBC_registry_type), pointer :: OBC_Reg => NULL()  !< Registry type for boundaries
   real, allocatable :: tres_x(:,:,:,:)   !< Array storage of tracer reservoirs for restarts [conc L ~> conc m]
   real, allocatable :: tres_y(:,:,:,:)   !< Array storage of tracer reservoirs for restarts [conc L ~> conc m]
@@ -373,9 +383,9 @@ subroutine open_boundary_config(G, US, param_file, OBC)
              "Unable to interpret "//segment_param_str//" = "//trim(segment_str))
       endif
     enddo
-    ! ! Set arrays indicating the segment number and segment direction, and also store the
-    ! ! range of indices within which various orientations of OBCs can be found on this PE.
-    ! call set_segnum_signs(OBC, G)
+    ! Set arrays indicating the segment number and segment direction, and also store the
+    ! range of indices within which various orientations of OBCs can be found on this PE.
+    call set_segnum_signs(OBC, G)
 
     ! Moved this earlier because time_interp_external_init needs to be called
     ! before anything that uses time_interp_external (such as initialize_segment_data)
@@ -430,6 +440,80 @@ subroutine open_boundary_config(G, US, param_file, OBC)
   endif
 
 end subroutine open_boundary_config
+
+
+!> This subroutine sets the sign of the OBC%segnum_u and OBC%segnum_v arrays to indicate the
+!! direction of the faces - positive for logically eastern or northern OBCs and neagative
+!! for logically western or southern OBCs, or zero on non-OBC points.  Also store information
+!! about which orientations of OBCs ar on this PE and the range of indices within which the
+!! various orientations of OBCs can be found on this PE.
+subroutine set_segnum_signs(OBC, G)
+  type(ice_OBC_type),     intent(inout) :: OBC !< Open boundary control structure, perhaps on a rotated grid.
+  type(dyn_horgrid_type), intent(in)    :: G   !< Ocean grid structure used by OBC
+
+  integer :: i, j
+
+  OBC%u_OBCs_on_PE = .false. ; OBC%v_OBCs_on_PE = .false.
+  do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
+    OBC%segnum_u(I,j) = abs(OBC%segnum_u(I,j))
+    if (abs(OBC%segnum_u(I,j)) > 0) then
+      OBC%u_OBCs_on_PE = .true.
+      if (OBC%segment(abs(OBC%segnum_u(I,j)))%direction == OBC_DIRECTION_W) &
+        OBC%segnum_u(I,j) = -abs(OBC%segnum_u(I,j))
+    endif
+  enddo ; enddo
+  do J=G%JsdB,G%JedB ; do i=G%isd,G%ied
+    OBC%segnum_v(i,J) = abs(OBC%segnum_v(i,J))
+    if (abs(OBC%segnum_v(i,J)) > 0) then
+      OBC%v_OBCs_on_PE = .true.
+      if (OBC%segment(abs(OBC%segnum_v(i,J)))%direction == OBC_DIRECTION_S) &
+        OBC%segnum_v(i,J) = -abs(OBC%segnum_v(i,J))
+    endif
+  enddo ; enddo
+
+  ! Determine the maximum and minimum index range for various directions of OBC points on this PE
+  ! by first setting these one point outside of the wrong side of the domain.
+  OBC%Is_u_W_obc = G%IedB + 1 ; OBC%Ie_u_W_obc = G%IsdB - 1
+  OBC%js_u_W_obc = G%jed + 1 ; OBC%je_u_W_obc = G%jsd - 1
+  OBC%Is_u_E_obc = G%IedB + 1 ; OBC%Ie_u_E_obc = G%IsdB - 1
+  OBC%js_u_E_obc = G%jed + 1 ; OBC%je_u_E_obc = G%jsd - 1
+  OBC%is_v_S_obc = G%ied + 1 ; OBC%ie_v_S_obc = G%isd - 1
+  OBC%Js_v_S_obc = G%JedB + 1 ; OBC%Je_v_S_obc = G%JsdB - 1
+  OBC%is_v_N_obc = G%ied + 1 ; OBC%ie_v_N_obc = G%isd - 1
+  OBC%Js_v_N_obc = G%JedB + 1 ; OBC%Je_v_N_obc = G%JsdB - 1
+  OBC%v_N_OBCs_on_PE = .false. ; OBC%v_S_OBCs_on_PE = .false.
+  OBC%u_E_OBCs_on_PE = .false. ; OBC%u_W_OBCs_on_PE = .false.
+  ! Note that the loop ranges are reduced because outward facing OBCs can not be applied at edge points.
+  do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB-1
+    if (OBC%segnum_u(I,j) < 0) then ! This point has OBC_DIRECTION_W.
+      OBC%Is_u_W_obc = min(I, OBC%Is_u_W_obc) ; OBC%Ie_u_W_obc = max(I, OBC%Ie_u_W_obc)
+      OBC%js_u_W_obc = min(j, OBC%js_u_W_obc) ; OBC%je_u_W_obc = max(j, OBC%je_u_W_obc)
+      OBC%u_W_OBCs_on_PE = .true.
+    endif
+  enddo ; enddo
+  do j=G%jsd,G%jed ; do I=G%IsdB+1,G%IedB
+    if (OBC%segnum_u(I,j) > 0) then ! This point has OBC_DIRECTION_E.
+      OBC%Is_u_E_obc = min(I, OBC%Is_u_E_obc) ; OBC%Ie_u_E_obc = max(I, OBC%Ie_u_E_obc)
+      OBC%js_u_E_obc = min(j, OBC%js_u_E_obc) ; OBC%je_u_E_obc = max(j, OBC%je_u_E_obc)
+      OBC%u_E_OBCs_on_PE = .true.
+    endif
+  enddo ; enddo
+  do J=G%JsdB,G%JedB-1 ; do i=G%isd,G%ied
+    if (OBC%segnum_v(i,J) < 0)  then ! This point has OBC_DIRECTION_S.
+      OBC%is_v_S_obc = min(i, OBC%is_v_S_obc) ; OBC%ie_v_S_obc = max(i, OBC%ie_v_S_obc)
+      OBC%Js_v_S_obc = min(J, OBC%Js_v_S_obc) ; OBC%Je_v_S_obc = max(J, OBC%Je_v_S_obc)
+      OBC%v_S_OBCs_on_PE = .true.
+    endif
+  enddo ; enddo
+  do J=G%JsdB+1,G%JedB ; do i=G%isd,G%ied
+    if (OBC%segnum_v(i,J) > 0) then ! This point has OBC_DIRECTION_N.
+      OBC%is_v_N_obc = min(i, OBC%is_v_N_obc) ; OBC%ie_v_N_obc = max(i, OBC%ie_v_N_obc)
+      OBC%Js_v_N_obc = min(J, OBC%Js_v_N_obc) ; OBC%Je_v_N_obc = max(J, OBC%Je_v_N_obc)
+      OBC%v_N_OBCs_on_PE = .true.
+    endif
+  enddo ; enddo
+
+end subroutine set_segnum_signs
 
 
 !> helper function for finding out about OBCs

--- a/src/SIS_sponge.F90
+++ b/src/SIS_sponge.F90
@@ -1,11 +1,11 @@
 !> Implements relaxation regions in SIS2 model
 !> for sea ice concentration (partial area) and thickness by categories
-!> The algorithm can be used to impose open boundary conditions 
-!> for sea ice thickness and partial area in regional SIS2 applications, 
+!> The algorithm can be used to impose open boundary conditions
+!> for sea ice thickness and partial area in regional SIS2 applications,
 !> or for correcting the fields within the domain.
 !>
 !> Dmitry Dukhovskoy NOAA OAR PSL 2025
-!> 
+!>
 module SIS_sponge
 
 !! Module to read in Time of the ice fields, ice concentration, ice thickness, relaxation time scale
@@ -70,7 +70,7 @@ end type f2d
 type, public :: f3d
   real, allocatable, dimension(:,:,:) :: fld3
 end type f3d
- 
+
 !> This control structure holds memory and parameters for the SIS_sponge module
 type, public :: isponge_CS ; private
   logical, public :: use_isponge = .false.  !< If true, ice tracer fields may be relaxed somewhere in the domain
@@ -83,7 +83,7 @@ type, public :: isponge_CS ; private
   real, pointer    :: Iresttime_col(:) => NULL() !< The inverse restoring time of each column [T-1 ~> s-1].
 
   type(p3d) :: var(MAX_FIELDS_RLX_)     !< Pointers to the fields that will be relaxed
-  type(p2d) :: Ref_val(MAX_FIELDS_RLX_) !< Relaxation values - The values to which the fields are 
+  type(p2d) :: Ref_val(MAX_FIELDS_RLX_) !< Relaxation values - The values to which the fields are
                                         ! relaxed distributed by ice cats (linear_index, ice_cat)
   type(f2d) :: Old_val(MAX_FIELDS_RLX_) !< Keep old values of relaxed fields prior to relaxation
                                         !! debug only, will need to get rid off later
@@ -97,7 +97,7 @@ contains
 
 !> This subroutine sets the inverse restoration time (Idamp) for sea ice fields and
 !! the values towards which an arbitrary
-!! number of tracers should be restored within the relaxation zone. 
+!! number of tracers should be restored within the relaxation zone.
 subroutine initialize_icerelax_file(param_file, G, IG, CS, US, IST, Time)
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
   type(SIS_hor_grid_type), intent(in) :: G          !< The horizontal grid type
@@ -121,7 +121,7 @@ subroutine initialize_icerelax_file(param_file, G, IG, CS, US, IST, Time)
   integer :: year     !< The current model year
   integer :: day      !< The current model year-day
   integer :: second   !< The second of the day
-  integer :: mon, hr, minute, itick  !< Time variables 
+  integer :: mon, hr, minute, itick  !< Time variables
   integer :: verbosity   !< MOM verbosity level
   real    :: max_rlxrate !< The strongest relaxation over the domain [T ~> s]
   real    :: rho_ice     !< The nominal density of sea ice [R ~> kg m-3]
@@ -173,7 +173,7 @@ subroutine initialize_icerelax_file(param_file, G, IG, CS, US, IST, Time)
     call get_date(Time, year, mon, day, hr, minute, second, itick)
     write(mesg,'("SIS Time:",i6,2("/",i2.2),1x,3(":",i2.2),"; max(Irelax)=",D13.4," s-1")') &
         year, mon, day, hr, minute, second, max_rlxrate
-    call SIS_mesg(mesg, verb_msg) 
+    call SIS_mesg(mesg, verb_msg)
   endif
 
   call initialize_isponge(param_file, Irelax, G, IG, CS)
@@ -186,10 +186,10 @@ subroutine initialize_icerelax_file(param_file, G, IG, CS, US, IST, Time)
 !
 
   call get_SIS2_thermo_coefs(IST%ITV, rho_ice=rho_ice)
-  call SIS_mesg('initialize_icerelax_file: Calling set_up_isponge_field: mH_ice', verb_msg) 
+  call SIS_mesg('initialize_icerelax_file: Calling set_up_isponge_field: mH_ice', verb_msg)
   call set_up_isponge_field(filename, ithck_var, Time, 1, IG%CatIce, G, IG, US, IST%mH_ice, CS, &
        'mH_ice', rlx_long_name='ice_thickness', rlx_unit='kg m-2', scale=US%m_to_Z * rho_ice)
-  call SIS_mesg('initialize_icerelax_file: Calling set_up_isponge_field: part_size', verb_msg) 
+  call SIS_mesg('initialize_icerelax_file: Calling set_up_isponge_field: part_size', verb_msg)
   call set_up_isponge_field(filename, iarea_var, Time, 0, IG%CatIce, G, IG, US, IST%part_size, CS, &
          'part_size', rlx_long_name='partial_area', rlx_unit='none')
 
@@ -198,7 +198,7 @@ end subroutine initialize_icerelax_file
 !> This subroutine determines the number of points which are within ice relaxation region in
 !! this computational domain.  Only points that have positive values of
 !! Iresttime and which mask2dT indicates are ocean points are included as the
-!! relaxation points.  
+!! relaxation points.
 subroutine initialize_isponge(param_file, Iresttime, G, IG, CS, time_var_rlx, sponge_ongrid)
   type(SIS_hor_grid_type), intent(in) :: G          !< The horizontal grid type
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters
@@ -278,7 +278,7 @@ end subroutine initialize_isponge
 
 !> This subroutine stores the reference (target) profile for the SIS variable whose
 !! address is given by f_ptr. Reference profile = values towards which the
-!! SIS field is being relaxed to. 
+!! SIS field is being relaxed to.
 !! Current version assumes 2D input fields.
 subroutine set_up_isponge_field(filename, fieldname, Time, kdS, kdE, G, IG, US, f_ptr, CS, &
                                 rlxfld_name, rlx_long_name, rlx_unit, scale)
@@ -293,14 +293,14 @@ subroutine set_up_isponge_field(filename, fieldname, Time, kdS, kdE, G, IG, US, 
   type(unit_scale_type),   intent(in) :: US         !< A structure with unit conversion factors
   real, dimension(SZI_(G), SZJ_(G), kdS:kdE), &
                    target, intent(in) :: f_ptr      !< a pointer to the field which will be relaxed [various]
-                                                    !! note: IST%part_size(isd:ied, jsd:jed, 0:CatIce) 
+                                                    !! note: IST%part_size(isd:ied, jsd:jed, 0:CatIce)
   type(isponge_CS),     pointer       :: CS         !< A pointer to the control structure for this module that
                                                     !! is set by a previous call to initialize_sponge.
   character(*),            intent(in) :: rlxfld_name   !< Name of the relaxed field
   character(len=*),        optional,  &
                            intent(in) :: rlx_long_name !< The long name of the tracer field
                                                        !! if not given, use the sp_name
-  character(len=*),        optional,  &        
+  character(len=*),        optional,  &
                            intent(in) :: rlx_unit      !< The unit of the tracer field
                                                        !! if not given, use 'none'
   real,          optional, intent(in) :: scale !< A factor by which to rescale the input data, including any
@@ -396,12 +396,12 @@ subroutine apply_isponge(dt_slow, CS, G, IG, IST, US, OSS, Time)
   real :: damp         !< The timestep times the local damping coefficient [nondim].
   real :: I1pdamp      !< I1pdamp is 1/(1 + damp). [nondim]
   real :: dt           !< time step [s]
-  real :: s_ice_bulk   !< ice bulk S for filling S values in the newly created ice 
+  real :: s_ice_bulk   !< ice bulk S for filling S values in the newly created ice
   real, allocatable :: sice(:), tfi(:)  ! Arrays for ice salinity and freezing temperature
   real :: enth_ice     !< The enthalpy of ice [Q ~> J kg-1]
-  real :: Tfrz         !< The freezeing temperature of sea water [C ~> degC] 
+  real :: Tfrz         !< The freezeing temperature of sea water [C ~> degC]
   real :: coeff        !< conversion coefficient from unscaled to scaled units
-  real :: enth_Tfrz    !< Ice enthalpy at the freezing temperature for a given ice salinity  
+  real :: enth_Tfrz    !< Ice enthalpy at the freezing temperature for a given ice salinity
   character(len=40)  :: mdl = "apply_isponge"  ! This subroutine's name.
   character(len=256) :: mesg
   character(len=15)  :: fld_name
@@ -460,7 +460,7 @@ subroutine apply_isponge(dt_slow, CS, G, IG, IST, US, OSS, Time)
 
   ! Convert input 2D fields --> 3D ice thicknesses and concentration by categories
   ! Input hice is aggregated ice volume per m2, i.e. hice=voli=sum(hice(k)*cice(k))
-  ! In each category: 
+  ! In each category:
   ! scale ice thickness m --> kg m-2 and unscale US%m_to_Z
   call distribute_ice2cats(CS, IG, G)
 
@@ -469,7 +469,7 @@ subroutine apply_isponge(dt_slow, CS, G, IG, IST, US, OSS, Time)
     damp = dt * CS%Iresttime_col(col); I1pdamp = 1.0 / (1.0 + damp)
     do k=1,IG%CatIce
       do m=1,CS%fldno
-        CS%Old_val(m)%fld(col,k) = CS%var(m)%p(i,j,k)  
+        CS%Old_val(m)%fld(col,k) = CS%var(m)%p(i,j,k)
         CS%var(m)%p(i,j,k) = I1pdamp * &
            (CS%var(m)%p(i,j,k) + CS%Ref_val(m)%p(col,k)*damp)
       enddo
@@ -533,12 +533,12 @@ end subroutine local_to_global_indx
 
 !> Redistribute input target 2D hice and iconc into ice thickness categories
 !! Thick-to-thin algorithm:
-!! Assign all ice initially to the thickest ice category 
+!! Assign all ice initially to the thickest ice category
 !! based on original ice thickness (hice).
-!! Redistribute a small volume of ice from the thickest 
+!! Redistribute a small volume of ice from the thickest
 !! category into the thinner categories.
 !! This avoids 0s ice concentration and thickness.
-!! Check that the total ice volume and concentration are conserved 
+!! Check that the total ice volume and concentration are conserved
 !! during the distribution.
 subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
   type(isponge_CS),        pointer     :: CS       !< A pointer that is set to point to the ice sponge control
@@ -555,26 +555,26 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
   integer :: m, i, j, k, col         !< Dummy indices
   integer :: iiG, jjG                !< Global indices
   integer :: CatIce                  !< The number of sea ice categories.
-  integer :: icat0                   !< Ice thickness category where to assign original 
-                                     !! hice and cice to begin distrbution 
+  integer :: icat0                   !< Ice thickness category where to assign original
+                                     !! hice and cice to begin distrbution
 
-  real, allocatable, dimension(:,:) :: cice2d, hice2d !< 2D arrays for input target ice area 
+  real, allocatable, dimension(:,:) :: cice2d, hice2d !< 2D arrays for input target ice area
                                                       !! and volume per unit area [m3*m-2]
   real, allocatable, dimension(:) :: hLim_vals    !< Ice thickness categories [m]
   real, allocatable, dimension(:) :: hcat, ccat   !< 1D arrays for thkn and conc in each ice category
   real, allocatable, dimension(:) :: volcat       !< Ice volume per unit area in each category [m3*m-2]
   real :: scale_cf            !< Scaling factor applied to the input ice target relaxation fields
   real :: Iscale              !< Inverse scale to "unscale" the data
-  real :: hice, cice          !< Target relax. aggregated ice volume/area [m3*m-2] and partial area 
+  real :: hice, cice          !< Target relax. aggregated ice volume/area [m3*m-2] and partial area
   real :: hice_k              !< Ice thkn in category k [m]
   real :: hice_tot, cice_tot  !< Aggregated ice volume per unit area and partial area
   real :: eps0                !< Error allowed for hice, cice after redistribution
-  real :: ck_min              !< The minimum ice concentration used in the 
+  real :: ck_min              !< The minimum ice concentration used in the
                               !! lower categories (wrt icat0) to distribute hice/cice
   real :: ccat_k, hcat_k, dch_k !< Ice concentration, volume, volume change in category k
-  real :: cnew                !< Updated partial area in the thickest category 
+  real :: cnew                !< Updated partial area in the thickest category
   real :: rmm                 !< Dummy variable
-  real :: htot_min            !< The minimum ice volume [m3*m-2]  required 
+  real :: htot_min            !< The minimum ice volume [m3*m-2]  required
                               !! to distribute over the ice cats (1,icat0)
   real :: part_water          !< Partial area of open water
   character(len=40)  :: mdl = "distribute_ice2cats"  ! This module's name`
@@ -643,7 +643,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
       call SIS_mesg(mesg, all_print=.true.)
       write(mesg,'(A," error: icat0 ",i2," hice=",f12.4," cice=",f12.4," hice_k=",f12.6)') &
             trim(mdl), hice, cice, hice_k
-      call SIS_error(FATAL, trim(mesg)) 
+      call SIS_error(FATAL, trim(mesg))
     endif
 
     ! Adjust min conc in cats for low partial areas
@@ -656,7 +656,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
       do m=1,CS%fldno ; do k=1,CatIce
         select case (trim(CS%var(m)%fld_name))
           case('mH_ice')
-            CS%Ref_val(m)%p(col,k) = 0.0 
+            CS%Ref_val(m)%p(col,k) = 0.0
           case('part_size')
             CS%Ref_val(m)%p(col,k) = 0.0
             if (k == 1) CS%Ref_val(m)%p(col,0) = 1.0  ! open water fraction size
@@ -671,7 +671,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
     hcat(icat0) = hice_k ; ccat(icat0) = cice ; volcat(icat0) = hice
     iiG = isdG + (i-1) ; jjG = jsdG + (j-1)
 
-    ! Sanity check: Ensure that the initial sea ice distribution conserves 
+    ! Sanity check: Ensure that the initial sea ice distribution conserves
     ! total ice volume and concentration.
     call check_hcice(hcat, ccat, hice, cice, iiG, jjG, str=' Initial ice distr. :')
 
@@ -702,7 +702,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
     enddo ; enddo
 
     ! Partial area of open water:
-    do m=1,CS%fldno 
+    do m=1,CS%fldno
       select case (trim(CS%var(m)%fld_name))
         case('part_size')
           part_water = 1.0 - sum(CS%Ref_val(m)%p(col,1:CatIce))
@@ -710,7 +710,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
           part_water = min(1.0, part_water)
           CS%Ref_val(m)%p(col,0) = part_water
       end select
-    enddo 
+    enddo
 
     ! Check that the mean ice thickn and total conc. are conserved:
     hcat = 0.0 ; ccat = 0.0
@@ -728,7 +728,7 @@ subroutine distribute_ice2cats(CS, IG, G, scaled, eps_err)
           ccat(k) = CS%Ref_val(m)%p(col,k)
       end select
     enddo ; enddo
-  
+
     call check_hcice(hcat, ccat, hice, cice, iiG, jjG, str=' After ice distr. :')
 
   enddo   !< do col
@@ -765,7 +765,7 @@ subroutine check_hcice(hcat, ccat, hice, cice, iG, jG, str)
   call partial_area_total(ccat(1:CatIce), cice_tot)
   call ice_thkn_total(ccat(1:CatIce), hcat, hice_tot)
 
-  if (abs(hice_tot-hice) > eps_err) err_hice=.true. 
+  if (abs(hice_tot-hice) > eps_err) err_hice=.true.
   if (abs(cice_tot-cice) > eps_err) err_cice=.true.
 
   ! Provide Error information
@@ -783,7 +783,7 @@ subroutine check_hcice(hcat, ccat, hice, cice, iG, jG, str)
 
 end subroutine check_hcice
 
-!> Find ice thickness category for given ice thickness (m) 
+!> Find ice thickness category for given ice thickness (m)
 function find_icat(hice_k, hLim_vals) result (icat0)
   integer          :: icat0         !< The ice thkn category where hice_k belongs
   real, intent(in) :: hLim_vals(:)  !< ice thkn cats, not scaled [m]
@@ -810,7 +810,7 @@ function find_icat(hice_k, hLim_vals) result (icat0)
 
 end function find_icat
 
-!> The subroutine computes aggregated partial area 
+!> The subroutine computes aggregated partial area
 !! given a 1D array of cice(1:CatIce) partial areas by cats.
 subroutine partial_area_total(cice_cat, cice_tot)
   real, intent(in)    :: cice_cat(:)   !< 1D array of partial areas by cats.
@@ -826,7 +826,7 @@ subroutine partial_area_total(cice_cat, cice_tot)
 
 end subroutine partial_area_total
 
-!> The subroutine computes the aggregated ice volume per unit area [m3*m-2], 
+!> The subroutine computes the aggregated ice volume per unit area [m3*m-2],
 !! which is also equal to the grid cell mean ice thickness,
 !! for 1D arrays of thiknesses and partial area by cats.
 subroutine ice_thkn_total(cice_cat, hice_cat, hice_tot)
@@ -851,5 +851,5 @@ subroutine SIS_sponge_end(CS)
   deallocate(CS)
 end subroutine SIS_sponge_end
 
-end module SIS_sponge 
+end module SIS_sponge
 


### PR DESCRIPTION
  This PR consists of a pair of commits that uses signed OBC segment numbers in SIS2 to simplify some of the OBC code in a way that is closely analogous to the recent changes in MOM6.  A third commit cleans up some existing problems with trailing white space and lines that are longer than 120 characters.

  The first commit sets the sign of `OBC%segnum_u` and `OBC%segnum_v` to indicate the direction of open boundary currents at the u- and v- velocity faces, with positive values at logically eastern and northern boundary condition faces and negative values at western and southern boundary condition faces.  This new information is used to set open boundary condition properties in `set_ocean_top_stress_Cgrid()`, `set_ocean_top_stress_C2()` and `mask_outside_OBCs()`,  while also using the absolute value is to recover the previous answers. Also added the new elements u_OBCs_on_PE and v_OBCs_on_PE to the ocean_OBC_type.  Four unused elements of the SIS2 OBC_segment_data_type (`fid_dz`, `buffer_src`, `dz_src` and `buffer_dst`) were eliminated; in MOM6 they are used to do vertical regridding on input data, but this does not apply to the sea-ice code.  Several SIS_open_boundary.F90 comments were modified to mirror their counterparts in MOM_open_boundary.F90.

  The second commit adds 16 integer elements to the `ocean_OBC_type` to indicate the ranges of indices over which various directions of open boundary conditions are found in the data and computational domain of the local PE. Also added 4 logical elements that indicate whether each of the 4 orientations of OBCs are fond on the local PE.  These are now all being set, along with the direction-indicating signs of `segnum_u` and `segnum_v` in the new subroutine `set_segnum_signs()`, which is a near copy of the MOM_open_boundary.F90 version.

  All answers are bitwise identical with both of these commits, but there are 16 new integer elements and 6 new logical elements in a transparent public type, and an important change to two elements of the publicly visible transparent `ocean_OBC_type`.  The specific commits in this PR are:

 - NOAA-GFDL/SIS2@5dc816c Correct overly long lines and trailing whitespace
 - NOAA-GFDL/SIS2@2eb53aa +Add set_segnum_signs and OBC loop ranges on PE
 - NOAA-GFDL/SIS2@8c6fa14 +Signed OBC%segnum_u and OBC%segnum_v in SIS2
