### PR TITLE
*Fix negative zero maximum CFL

### DIFF
--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -438,6 +438,7 @@ subroutine write_ice_statistics(IST, day, n, G, US, IG, CS, message, check_colum
     enddo ; enddo
   endif
   call max_across_PEs(max_CFL)
+  if (max_CFL == 0.0) max_CFL = abs(max_CFL) ! This is to deal with negative zeros.
 
   ! Set combinations of scalign factors that rescale back to MKS units for output
   area_scale = US%L_to_m**2


### PR DESCRIPTION
  SIS2 reports the global maximum CFL in the seaice.stats files, but in the first timestep when all velocities are zero, it is reporting a maximum CFL of -0.000 with the gnu and Nvidia compilers.  This single-line commit replaces any negative zero maximum CFL returned by `max_across_PEs()` with its absolute value so that only non-negative maximum CFL values are returned.  All solutions are bitwise identical, but this does change the entries in the seaice.stats files so it may appear to fail automated regression testing in some cases.

  This commit addresses the problem in SIS2 that is noted in https://github.com/NOAA-GFDL/SIS2/issues/230, but it does not address the underlying question of why this bizarre behavior is happening in the first place.