### PR TITLE
Use rescaling to or from Pa with single factor

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -310,7 +310,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
 
   ! diagnostics for quantities produced outside the ice model
   FIA%id_slp   = register_SIS_diag_field('ice_model', 'SLP', diag%axesT1, Time, &
-             'sea level pressure', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, missing_value=missing)
+             'sea level pressure', units='Pa', conversion=US%RLZ_T2_to_Pa)
   ! diagnostics for quantities produced outside the ice model
   OSS%id_sst   = register_SIS_diag_field('ice_model', 'SST', diag%axesT1, Time, &
              'sea surface temperature', 'deg-C', conversion=US%C_to_degC, missing_value=missing)

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -113,7 +113,7 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
   call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
                  "A constant in the expression for the ice strength, "//&
                  "P* in Hunke & Dukowicz 1997.", &
-                 units="Pa", scale=US%kg_m3_to_R*US%m_s_to_L_T**2, default=2.75e4)
+                 units="Pa", scale=US%Pa_to_RL2_T2, default=2.75e4)
   call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
                  "A constant in the exponent of the expression for the "//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
@@ -142,7 +142,7 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
                  "A negligibly small magnitude below which ice stress tensor "//&
                  "components are set to 0.  A reasonable value might be "//&
                  "1e-15 kg m-1 s-1 times vel_underflow.", &
-                 units="Pa m", default=0.0, scale=US%m_s_to_L_T**2*US%kg_m3_to_R*US%m_to_Z)
+                 units="Pa m", default=0.0, scale=US%Pa_to_RL2_T2*US%m_to_Z)
 
   call get_param(param_file, mdl, "DEBUG", debug, &
                  "If true, write out verbose debugging data.", default=.false., &
@@ -164,25 +164,25 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
   CS%id_sigii = register_diag_field('ice_model','SIGII' ,diag%axesT1, Time,    &
             'second stress invariant', 'none', missing_value=missing)
   CS%id_stren = register_diag_field('ice_model','STRENGTH' ,diag%axesT1, Time, &
-            'ice strength', 'Pa*m', missing_value=missing, conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_fix   = register_diag_field('ice_model', 'FI_X', diag%axesB1, Time,    &
-            'ice internal stress - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'ice internal stress - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fiy   = register_diag_field('ice_model', 'FI_Y', diag%axesB1, Time,    &
-            'ice internal stress - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'ice internal stress - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fcx   = register_diag_field('ice_model', 'FC_X', diag%axesB1, Time,    &
-            'coriolis force - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'coriolis force - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fcy   = register_diag_field('ice_model', 'FC_Y', diag%axesB1, Time,    &
-            'coriolis force - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'coriolis force - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fwx   = register_diag_field('ice_model', 'FW_X', diag%axesB1, Time,    &
-            'water stress on ice - x component', 'Pa', conversion=-US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'water stress on ice - x component', units='Pa', conversion=-US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fwy   = register_diag_field('ice_model', 'FW_Y', diag%axesB1, Time,    &
-            'water stress on ice - y component', 'Pa', conversion=-US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'water stress on ice - y component', units='Pa', conversion=-US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_ui    = register_diag_field('ice_model', 'UI', diag%axesB1, Time,      &
             'ice velocity - x component', 'm/s', conversion=US%L_T_to_m_s,     &
             missing_value=missing, interp_method='none')
@@ -432,7 +432,7 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
   if (CS%debug .or. CS%debug_redundant) then
     call Bchksum_pair("sld[xy] in SIS_B_dynamics", sldx, sldy, G, symmetric=.true., unscale=US%L_T_to_m_s)
     call Bchksum_pair("f[xy]at in SIS_B_dynamics", fxat, fyat, G, symmetric=.true., &
-                      unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                      unscale=US%RLZ_T2_to_Pa)
     call Bchksum_pair("[uv]i pre-steps SIS_B_dynamics", ui, vi, G, symmetric=.true., unscale=US%L_T_to_m_s)
     call Bchksum_pair("[uv]o in SIS_B_dynamics", uo, vo, G, symmetric=.true., unscale=US%L_T_to_m_s)
     call Bchksum_pair("d[yx]d[xy] in SIS_B_dynamics", dydx, dxdy, G, scalars=.true., unscale=US%L_to_m)
@@ -594,23 +594,23 @@ subroutine SIS_B_dynamics(ci, misp, mice, ui, vi, uo, vo, &
     enddo ; enddo
 
     if (CS%debug) then
-      call hchksum(CS%sig11, "sig11 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%sig22, "sig22 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%sig12, "sig12 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%sig11, "sig11 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RLZ_T2_to_Pa*US%L_to_m)
+      call hchksum(CS%sig22, "sig22 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RLZ_T2_to_Pa*US%L_to_m)
+      call hchksum(CS%sig12, "sig12 in SIS_B_dynamics", G%HI, haloshift=1, unscale=US%RLZ_T2_to_Pa*US%L_to_m)
 
-      call Bchksum(fxic, "fxic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyic, "fyic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fxoc, "fxoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyoc, "fyoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fxco, "fxco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call Bchksum(fyco, "fyco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call Bchksum(fxic, "fxic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
+      call Bchksum(fyic, "fyic in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
+      call Bchksum(fxoc, "fxoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
+      call Bchksum(fyoc, "fyoc in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
+      call Bchksum(fxco, "fxco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
+      call Bchksum(fyco, "fyco in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%RLZ_T2_to_Pa)
       call Bchksum(ui, "ui in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
       call Bchksum(vi, "vi in SIS_B_dynamics", G%HI, symmetric=.true., unscale=US%L_T_to_m_s)
     endif
     if (CS%debug_redundant) then
-      call check_redundant_B("fxic/fyic in SIS_B_dynamics steps",fxic, fyic, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call check_redundant_B("fxco in SIS_B_dynamics steps", fxco, fyco, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call check_redundant_B("fxoc in SIS_B_dynamics steps", fxoc, fyoc, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call check_redundant_B("fxic/fyic in SIS_B_dynamics steps",fxic, fyic, G, unscale=US%RLZ_T2_to_Pa)
+      call check_redundant_B("fxco in SIS_B_dynamics steps", fxco, fyco, G, unscale=US%RLZ_T2_to_Pa)
+      call check_redundant_B("fxoc in SIS_B_dynamics steps", fxoc, fyoc, G, unscale=US%RLZ_T2_to_Pa)
       call check_redundant_B("ui/vi in SIS_B_dynamics steps", ui, vi, G, unscale=US%L_T_to_m_s)
     endif
 
@@ -743,11 +743,11 @@ subroutine SIS_B_dyn_register_restarts(HI, param_file, CS, US, Ice_restart)
 
   if (associated(Ice_restart)) then
     call register_restart_field(Ice_restart, 'sig11', CS%sig11, mandatory=.false., &
-                                units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     call register_restart_field(Ice_restart, 'sig22', CS%sig22, mandatory=.false., &
-                                units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     call register_restart_field(Ice_restart, 'sig12', CS%sig12, mandatory=.false., &
-                                units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   endif
 end subroutine SIS_B_dyn_register_restarts
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -240,7 +240,7 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   call get_param(param_file, mdl, "ICE_STRENGTH_PSTAR", CS%p0, &
                  "A constant in the expression for the ice strength, "//&
                  "P* in Hunke & Dukowicz 1997.", &
-                 units="Pa", default=2.75e4, scale=US%kg_m3_to_R*US%m_s_to_L_T**2)
+                 units="Pa", default=2.75e4, scale=US%Pa_to_RL2_T2)
   call get_param(param_file, mdl, "ICE_STRENGTH_CSTAR", CS%c0, &
                  "A constant in the exponent of the expression for the "//&
                  "ice strength, c* in Hunke & Dukowicz 1997.", &
@@ -277,7 +277,7 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
                  "A negligibly small magnitude below which ice stress tensor "//&
                  "components are set to 0.  A reasonable value might be "//&
                  "1e-15 kg m-1 s-1 times vel_underflow.", &
-                 units="Pa m", default=0.0, scale=US%m_s_to_L_T**2*US%kg_m3_to_R*US%m_to_Z)
+                 units="Pa m", default=0.0, scale=US%Pa_to_RL2_T2*US%m_to_Z)
   call get_param(param_file, mdl, "CFL_TRUNCATE", CS%CFL_trunc, &
                  "The value of the CFL number that will cause ice velocity "//&
                  "components to be truncated; instability can occur past 0.5.", &
@@ -397,62 +397,52 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_sigii = register_diag_field('ice_model','SIGII' ,diag%axesT1, Time,    &
             'second stress invariant', 'none', missing_value=missing)
   CS%id_stren = register_diag_field('ice_model','STRENGTH' ,diag%axesT1, Time, &
-            'ice strength', 'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing)
+            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_stren0 = register_diag_field('ice_model','STREN_0' ,diag%axesT1, Time, &
             'ice strength at start of rheology', &
-            'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing)
+            units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_fix   = register_diag_field('ice_model', 'FI_X', diag%axesCu1, Time,   &
-            'ice internal stress - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'ice internal stress - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fiy   = register_diag_field('ice_model', 'FI_Y', diag%axesCv1, Time,   &
-            'ice internal stress - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'ice internal stress - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fcx   = register_diag_field('ice_model', 'FC_X', diag%axesCu1, Time,   &
-            'Coriolis force - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'Coriolis force - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_fcy   = register_diag_field('ice_model', 'FC_Y', diag%axesCv1, Time,   &
-            'Coriolis force - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            'Coriolis force - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+            interp_method='none')
   CS%id_Coru   = register_diag_field('ice_model', 'Cor_ui', diag%axesCu1, Time,&
             'Coriolis ice acceleration - x component', &
-            'm s-2', conversion=US%L_T_to_m_s*US%s_to_T, &
-            missing_value=missing, interp_method='none')
+            units='m s-2', conversion=US%L_T2_to_m_s2, interp_method='none')
   CS%id_Corv   = register_diag_field('ice_model', 'Cor_vi', diag%axesCv1, Time,&
             'Coriolis ice acceleration - y component', &
-            'm s-2', conversion=US%L_T_to_m_s*US%s_to_T, &
-            missing_value=missing, interp_method='none')
+            units='m s-2', conversion=US%L_T2_to_m_s2, interp_method='none')
   CS%id_fpx   = register_diag_field('ice_model', 'FP_X', diag%axesCu1, Time,   &
             'Pressure force - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fpy   = register_diag_field('ice_model', 'FP_Y', diag%axesCv1, Time,   &
             'Pressure force - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_PFu   = register_diag_field('ice_model', 'Pfa_ui', diag%axesCu1, Time, &
             'Pressure-force ice acceleration - x component', &
-            'm s-2',  conversion=US%L_T_to_m_s*US%s_to_T, &
-            missing_value=missing, interp_method='none')
+            units='m s-2',  conversion=US%L_T2_to_m_s2, interp_method='none')
   CS%id_PFv   = register_diag_field('ice_model', 'Pfa_vi', diag%axesCv1, Time, &
             'Pressure-force ice acceleration - y component', &
-            'm s-2',  conversion=US%L_T_to_m_s*US%s_to_T, &
-            missing_value=missing,  interp_method='none')
+            units='m s-2',  conversion=US%L_T2_to_m_s2, interp_method='none')
   CS%id_fwx   = register_diag_field('ice_model', 'FW_X', diag%axesCu1, Time,   &
             'water stress on ice - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fwy   = register_diag_field('ice_model', 'FW_Y', diag%axesCv1, Time,   &
             'water stress on ice - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_flfx  = register_diag_field('ice_model', 'FLF_X', diag%axesCu1, Time,   &
             'land-fast bottom stress on ice - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_flfy  = register_diag_field('ice_model', 'FLF_Y', diag%axesCv1, Time,   &
             'land-fast bottom stress on ice - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_ui    = register_diag_field('ice_model', 'UI', diag%axesCu1, Time,     &
             'ice velocity - x component', 'm/s', missing_value=missing,        &
             interp_method='none', conversion=US%L_T_to_m_s)
@@ -482,38 +472,29 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
 
   CS%id_fix_d   = register_diag_field('ice_model', 'FI_d_X', diag%axesCu1, Time,         &
             'ice divergence internal stress - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fiy_d   = register_diag_field('ice_model', 'FI_d_Y', diag%axesCv1, Time,         &
             'ice divergence internal stress - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fix_t   = register_diag_field('ice_model', 'FI_t_X', diag%axesCu1, Time,        &
             'ice tension internal stress - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fiy_t   = register_diag_field('ice_model', 'FI_t_Y', diag%axesCv1, Time,        &
             'ice tension internal stress - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fix_s   = register_diag_field('ice_model', 'FI_s_X', diag%axesCu1, Time,        &
             'ice shearing internal stress - x component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_fiy_s   = register_diag_field('ice_model', 'FI_s_Y', diag%axesCv1, Time,        &
             'ice shearing internal stress - y component', &
-            'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
 
   CS%id_str_d   = register_diag_field('ice_model', 'str_d', diag%axesT1, Time, &
-            'ice divergence internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice divergence internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_str_t   = register_diag_field('ice_model', 'str_t', diag%axesT1, Time, &
-            'ice tension internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice tension internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_str_s   = register_diag_field('ice_model', 'str_s', diag%axesB1, Time, &
-            'ice shearing internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice shearing internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_sh_d   = register_diag_field('ice_model', 'sh_d', diag%axesT1, Time,   &
             'ice divergence strain rate', 's-1', conversion=US%s_to_T, missing_value=missing)
   CS%id_sh_t   = register_diag_field('ice_model', 'sh_t', diag%axesT1, Time,   &
@@ -534,14 +515,11 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
             'ice velocity - y component', 'm/s', missing_value=missing,        &
             interp_method='none, conversion=US%L_T_to_m_s')
   CS%id_str_d_hifreq = register_diag_field('ice_model', 'str_d_hf', diag%axesT1, Time, &
-            'ice divergence internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice divergence internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_str_t_hifreq = register_diag_field('ice_model', 'str_t_hf', diag%axesT1, Time, &
-            'ice tension internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice tension internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_str_s_hifreq = register_diag_field('ice_model', 'str_s_hf', diag%axesB1, Time, &
-            'ice shearing internal stress', 'Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, &
-            missing_value=missing)
+            'ice shearing internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_sh_d_hifreq = register_diag_field('ice_model', 'sh_d_hf', diag%axesT1, Time, &
             'ice divergence rate', 's-1', conversion=US%s_to_T, missing_value=missing)
   CS%id_sh_t_hifreq = register_diag_field('ice_model', 'sh_t_hf', diag%axesT1, Time, &
@@ -555,7 +533,7 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_ci_hifreq  = register_diag_field('ice_model', 'CI_hf', diag%axesT1, Time, &
             'Summed concentration of ice at t-points', 'nondim', missing_value=missing)
   CS%id_stren_hifreq = register_diag_field('ice_model','STRENGTH_hf' ,diag%axesT1, Time, &
-            'ice strength', 'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing)
+            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
 
   CS%id_siu = register_diag_field('ice_model', 'siu', diag%axesT1, Time, &
             'ice velocity - x component', 'm/s', missing_value=missing,  &
@@ -1005,8 +983,8 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
 !$OMP end parallel
 
   if (CS%debug .or. CS%debug_redundant) then
-    call uvchksum("PF[uv] in SIS_C_dynamics", PFu, PFv, G, unscale=US%L_T_to_m_s*US%s_to_T)
-    call uvchksum("f[xy]at in SIS_C_dynamics", fxat, fyat, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call uvchksum("PF[uv] in SIS_C_dynamics", PFu, PFv, G, unscale=US%L_T2_to_m_s2)
+    call uvchksum("f[xy]at in SIS_C_dynamics", fxat, fyat, G, unscale=US%RLZ_T2_to_Pa)
     call uvchksum("[uv]i pre-steps SIS_C_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
     call uvchksum("[uv]o in SIS_C_dynamics", uo, vo, G, unscale=US%L_T_to_m_s)
   endif
@@ -1381,16 +1359,16 @@ subroutine SIS_C_dynamics(ci, mis, mice, ui, vi, uo, vo, fxat, fyat, &
     endif
 
     if (CS%debug_EVP .and. CS%debug) then
-      call hchksum(CS%str_d, "str_d in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
-      call hchksum(CS%str_t, "str_t in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+      call hchksum(CS%str_d, "str_d in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RLZ_T2_to_Pa*US%L_to_m)
+      call hchksum(CS%str_t, "str_t in SIS_C_dynamics", G%HI, haloshift=1, unscale=US%RLZ_T2_to_Pa*US%L_to_m)
       call Bchksum(CS%str_s, "str_s in SIS_C_dynamics", G%HI, &
-                   haloshift=0, symmetric=.true., unscale=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                   haloshift=0, symmetric=.true., unscale=US%RLZ_T2_to_Pa*US%L_to_m)
     endif
     if (CS%debug_EVP .and. (CS%debug .or. CS%debug_redundant)) then
-      call uvchksum("f[xy]ic in SIS_C_dynamics", fxic, fyic, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("f[xy]oc in SIS_C_dynamics", fxoc, fyoc, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("f[xy]lf in SIS_C_dynamics", fxlf, fylf, G, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-      call uvchksum("Cor_[uv] in SIS_C_dynamics", Cor_u, Cor_v, G, unscale=US%L_T_to_m_s*US%s_to_T)
+      call uvchksum("f[xy]ic in SIS_C_dynamics", fxic, fyic, G, unscale=US%RLZ_T2_to_Pa)
+      call uvchksum("f[xy]oc in SIS_C_dynamics", fxoc, fyoc, G, unscale=US%RLZ_T2_to_Pa)
+      call uvchksum("f[xy]lf in SIS_C_dynamics", fxlf, fylf, G, unscale=US%RLZ_T2_to_Pa)
+      call uvchksum("Cor_[uv] in SIS_C_dynamics", Cor_u, Cor_v, G, unscale=US%L_T2_to_m_s2)
       call uvchksum("[uv]i in SIS_C_dynamics", ui, vi, G, unscale=US%L_T_to_m_s)
     endif
     call SIS_diag_send_complete()
@@ -1883,7 +1861,7 @@ subroutine basal_stress_coeff_C(G, mi, ci, sea_lev, CS)
     enddo
   enddo
 !          call uvchksum("Tb_[uv] before SIS_C_dynamics", CS%Tb_u, CS%Tb_v, G, &
-!                         halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+!                         halos=1, unscale=US%RLZ_T2_to_Pa)
 
 end subroutine basal_stress_coeff_C
 
@@ -2097,15 +2075,15 @@ subroutine SIS_C_dyn_register_restarts(HI, param_file, CS, US, Ice_restart)
 
   if (associated(Ice_restart)) then
     call register_restart_field(Ice_restart, 'str_d', CS%str_d, mandatory=.false., &
-                                units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     call register_restart_field(Ice_restart, 'str_t', CS%str_t, mandatory=.false., &
-                                units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     if (HI%symmetric) then
       call register_restart_field(Ice_restart, 'sym_str_s', CS%str_s, position=CORNER, mandatory=.false., &
-                                  units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                  units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     else
       call register_restart_field(Ice_restart, 'str_s', CS%str_s, position=CORNER, mandatory=.false., &
-                                  units="Pa m", conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2)
+                                  units="Pa m", conversion=US%RLZ_T2_to_Pa*US%L_to_m)
     endif
   endif
 end subroutine SIS_C_dyn_register_restarts

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -258,14 +258,14 @@ subroutine update_icebergs(IST, OSS, IOF, FIA, icebergs_CS, dt_slow, G, US, IG, 
     ! This code reproduces a long-standing bug, in that the old ice-ocean
     ! stresses are being passed in place of the wind stresses on the icebergs.
     do j=jsc,jec ; do i=isc,iec
-      windstr_x(i,j) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*IOF%flux_u_ocn(i,j)
-      windstr_y(i,j) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*IOF%flux_v_ocn(i,j)
+      windstr_x(i,j) = US%RLZ_T2_to_Pa*IOF%flux_u_ocn(i,j)
+      windstr_y(i,j) = US%RLZ_T2_to_Pa*IOF%flux_v_ocn(i,j)
     enddo ; enddo
     stress_stagger = IOF%flux_uv_stagger
   else
     do j=jsc,jec ; do i=isc,iec
-      windstr_x(i,j) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*FIA%WindStr_ocn_x(i,j)
-      windstr_y(i,j) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*FIA%WindStr_ocn_y(i,j)
+      windstr_x(i,j) = US%RLZ_T2_to_Pa*FIA%WindStr_ocn_x(i,j)
+      windstr_y(i,j) = US%RLZ_T2_to_Pa*FIA%WindStr_ocn_y(i,j)
     enddo ; enddo
     stress_stagger = AGRID
   endif
@@ -479,7 +479,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
             call hchksum(ice_cover, "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
             call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
             call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                          halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          halos=1, unscale=US%RLZ_T2_to_Pa)
     !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
           endif
 
@@ -541,7 +541,7 @@ subroutine SIS_dynamics_trans(IST, OSS, FIA, IOF, dt_slow, CS, icebergs_CS, G, U
             call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
             call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
             call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                              unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              unscale=US%RLZ_T2_to_Pa)
           endif
 
           call cpu_clock_begin(iceClocka)
@@ -1011,7 +1011,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
         call hchksum(DS2d%ice_cover, "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
         call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
         call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                      halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                      halos=1, unscale=US%RLZ_T2_to_Pa)
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
@@ -1065,7 +1065,7 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
         call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
         call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
         call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                          unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          unscale=US%RLZ_T2_to_Pa)
       endif
 
       call cpu_clock_begin(iceClocka)
@@ -1254,7 +1254,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
         call hchksum(IST%part_size(:,:,1), "ice_cover before SIS_C_dynamics", G%HI, haloshift=1)
         call uvchksum("[uv]_ocn before SIS_C_dynamics", OSS%u_ocn_C, OSS%v_ocn_C, G, halos=1, unscale=US%L_T_to_m_s)
         call uvchksum("WindStr_[xy] before SIS_C_dynamics", WindStr_x_Cu, WindStr_y_Cv, G, &
-                      halos=1, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                      halos=1, unscale=US%RLZ_T2_to_Pa)
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
@@ -1304,7 +1304,7 @@ subroutine slab_ice_dyn_trans(IST, OSS, FIA, IOF, dt_slow, CS, G, US, IG, tracer
         call hchksum(OSS%sea_lev, "sea_lev before ice_dynamics", G%HI, haloshift=1, unscale=US%Z_to_m)
         call Bchksum_pair("[uv]_ocn before ice_dynamics", OSS%u_ocn_B, OSS%v_ocn_B, G, unscale=US%L_T_to_m_s)
         call Bchksum_pair("WindStr_[xy]_B before ice_dynamics", WindStr_x_B, WindStr_y_B, G, halos=1, &
-                          unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                          unscale=US%RLZ_T2_to_Pa)
       endif
 
       call cpu_clock_begin(iceClocka)
@@ -2498,18 +2498,18 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
   ! Stress diagnostics that are specific to the C-grid or B-grid dynamics of the ice model
   if (CS%Cgrid_dyn) then
     CS%id_fax = register_diag_field('ice_model', 'FA_X', diag%axesCu1, Time, &
-               'Air stress on ice on C-grid - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-                missing_value=missing, interp_method='none')
+               'Air stress on ice on C-grid - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+                interp_method='none')
     CS%id_fay = register_diag_field('ice_model', 'FA_Y', diag%axesCv1, Time, &
-               'Air stress on ice on C-grid - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'Air stress on ice on C-grid - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+               interp_method='none')
   else
     CS%id_fax = register_diag_field('ice_model', 'FA_X', diag%axesB1, Time, &
-               'air stress on ice - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'air stress on ice - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+               interp_method='none')
     CS%id_fay = register_diag_field('ice_model', 'FA_Y', diag%axesB1, Time, &
-               'air stress on ice - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'air stress on ice - y component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
+               interp_method='none')
   endif
 
   call register_ice_state_diagnostics(Time, IG, US, param_file, diag, CS%IDs)

--- a/src/SIS_fast_thermo.F90
+++ b/src/SIS_fast_thermo.F90
@@ -657,8 +657,8 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
     ! different index conventions than are used internally in this component.
     do k=0,ncat ; do i=isc,iec
       i2 = i+i_off ; j2 = j+j_off ; k2 = k+1
-      flux_u(i,j,k)  = US%kg_m2s_to_RZ_T*US%m_s_to_L_T*Atmos_boundary%u_flux(i2,j2,k2)
-      flux_v(i,j,k)  = US%kg_m2s_to_RZ_T*US%m_s_to_L_T*Atmos_boundary%v_flux(i2,j2,k2)
+      flux_u(i,j,k)  = US%Pa_to_RLZ_T2*Atmos_boundary%u_flux(i2,j2,k2)
+      flux_v(i,j,k)  = US%Pa_to_RLZ_T2*Atmos_boundary%v_flux(i2,j2,k2)
       flux_sh(i,j,k)  = US%W_m2_to_QRZ_T*Atmos_boundary%t_flux(i2,j2,k2)
       evap(i,j,k)  = US%kg_m2s_to_RZ_T*Atmos_boundary%q_flux(i2,j2,k2)
       flux_lw(i,j,k) = US%W_m2_to_QRZ_T*Atmos_boundary%lw_flux(i2,j2,k2)
@@ -685,8 +685,8 @@ subroutine do_update_ice_model_fast(Atmos_boundary, IST, sOSS, Rad, FIA, &
   enddo
 
   if (CS%debug_fast) then
-    call hchksum(flux_u(:,:,1:), "Mid do_fast flux_u", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(flux_v(:,:,1:), "Mid do_fast flux_v", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(flux_u(:,:,1:), "Mid do_fast flux_u", G%HI, unscale=US%RLZ_T2_to_Pa)
+    call hchksum(flux_v(:,:,1:), "Mid do_fast flux_v", G%HI, unscale=US%RLZ_T2_to_Pa)
     call hchksum(flux_sh(:,:,1:), "Mid do_fast flux_sh", G%HI, unscale=US%QRZ_T_to_W_m2)
     call hchksum(evap(:,:,1:), "Mid do_fast evap", G%HI, unscale=US%RZ_T_to_kg_m2s)
     call hchksum(flux_lw(:,:,1:), "Mid do_fast flux_lw", G%HI, unscale=US%QRZ_T_to_W_m2)

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -1963,15 +1963,15 @@ subroutine register_fast_to_slow_restarts(FIA, Rad, TSF, mpp_domain, US, Ice_res
   call register_restart_field(Ice_restart, 'flux_sw_top', FIA%flux_sw_top, dim_3="cat0", dim_4="band", &
                               mandatory=.false., units="W m-2", conversion=US%QRZ_T_to_W_m2)
   call register_restart_field(Ice_restart, 'WindStr_x', FIA%WindStr_x, &
-                              mandatory=.false., units="Pa", conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              mandatory=.false., units="Pa", conversion=US%RLZ_T2_to_Pa)
   call register_restart_field(Ice_restart, 'WindStr_y', FIA%WindStr_y, &
-                              mandatory=.false., units="Pa", conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              mandatory=.false., units="Pa", conversion=US%RLZ_T2_to_Pa)
   call register_restart_field(Ice_restart, 'WindStr_ocn_x', FIA%WindStr_ocn_x, &
-                              mandatory=.false., units="Pa", conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              mandatory=.false., units="Pa", conversion=US%RLZ_T2_to_Pa)
   call register_restart_field(Ice_restart, 'WindStr_ocn_y', FIA%WindStr_ocn_y, &
-                              mandatory=.false., units="Pa", conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              mandatory=.false., units="Pa", conversion=US%RLZ_T2_to_Pa)
   call register_restart_field(Ice_restart, 'p_atm_surf', FIA%p_atm_surf, &
-                              mandatory=.false., units="Pa", conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+                              mandatory=.false., units="Pa", conversion=US%RLZ_T2_to_Pa)
   call register_restart_field(Ice_restart, 'runoff', FIA%runoff, &
                               mandatory=.false., units="kg m-2 s-1", conversion=US%RZ_T_to_kg_m2s)
   call register_restart_field(Ice_restart, 'calving', FIA%calving, &
@@ -2230,12 +2230,12 @@ subroutine IOF_chksum(mesg, IOF, G, US, mech_fluxes, thermo_fluxes)
 
   endif
   if (do_mech) then
-    call hchksum(IOF%flux_u_ocn,      trim(mesg)//" IOF%flux_u_ocn",   G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(IOF%flux_v_ocn,      trim(mesg)//" IOF%flux_v_ocn",   G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-    call hchksum(IOF%pres_ocn_top,    trim(mesg)//" IOF%pres_ocn_top", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+    call hchksum(IOF%flux_u_ocn,      trim(mesg)//" IOF%flux_u_ocn",   G%HI, unscale=US%RLZ_T2_to_Pa)
+    call hchksum(IOF%flux_v_ocn,      trim(mesg)//" IOF%flux_v_ocn",   G%HI, unscale=US%RLZ_T2_to_Pa)
+    call hchksum(IOF%pres_ocn_top,    trim(mesg)//" IOF%pres_ocn_top", G%HI, unscale=US%RLZ_T2_to_Pa)
     call hchksum(IOF%mass_ice_sn_p,   trim(mesg)//" IOF%mass_ice_sn_p", G%HI, unscale=US%RZ_to_kg_m2)
     if (allocated(IOF%stress_mag)) &
-      call hchksum(IOF%stress_mag,    trim(mesg)//" IOF%stress_mag", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+      call hchksum(IOF%stress_mag,    trim(mesg)//" IOF%stress_mag", G%HI, unscale=US%RLZ_T2_to_Pa)
   endif
 
   if (do_thermo) then
@@ -2291,11 +2291,11 @@ subroutine FIA_chksum(mesg, FIA, G, US, check_ocean)
   call hchksum(FIA%bmelt, trim(mesg)//" FIA%bmelt", G%HI, unscale=US%QRZ_T_to_W_m2*US%T_to_s)
   call hchksum(FIA%sw_abs_ocn, trim(mesg)//" FIA%sw_abs_ocn", G%HI)
 
-  call hchksum(FIA%WindStr_x, trim(mesg)//" FIA%WindStr_x", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_y, trim(mesg)//" FIA%WindStr_y", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_ocn_x, trim(mesg)//" FIA%WindStr_ocn_x", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%WindStr_ocn_y, trim(mesg)//" FIA%WindStr_ocn_y", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
-  call hchksum(FIA%p_atm_surf, trim(mesg)//" FIA%p_atm_surf", G%HI, unscale=US%RZ_T_to_kg_m2s*US%L_T_to_m_s)
+  call hchksum(FIA%WindStr_x, trim(mesg)//" FIA%WindStr_x", G%HI, unscale=US%RLZ_T2_to_Pa)
+  call hchksum(FIA%WindStr_y, trim(mesg)//" FIA%WindStr_y", G%HI, unscale=US%RLZ_T2_to_Pa)
+  call hchksum(FIA%WindStr_ocn_x, trim(mesg)//" FIA%WindStr_ocn_x", G%HI, unscale=US%RLZ_T2_to_Pa)
+  call hchksum(FIA%WindStr_ocn_y, trim(mesg)//" FIA%WindStr_ocn_y", G%HI, unscale=US%RLZ_T2_to_Pa)
+  call hchksum(FIA%p_atm_surf, trim(mesg)//" FIA%p_atm_surf", G%HI, unscale=US%RLZ_T2_to_Pa)
   call hchksum(FIA%runoff, trim(mesg)//" FIA%runoff", G%HI, unscale=US%RZ_T_to_kg_m2s)
   call hchksum(FIA%calving, trim(mesg)//" FIA%calving", G%HI, unscale=US%RZ_T_to_kg_m2s)
   call hchksum(FIA%runoff_hflx, trim(mesg)//" FIA%runoff_hflx", G%HI, unscale=US%QRZ_T_to_W_m2)

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -220,8 +220,8 @@ subroutine update_ice_slow_thermo(Ice)
       !$OMP parallel do default(none) shared(Ice,sG,US,i_off,j_off) private(i2,j2)
       do j=sG%jsc,sG%jec ; do i=sG%isc,sG%iec
         i2 = i+i_off ; j2 = j+j_off
-        Ice%sCS%IOF%flux_u_ocn(i,j) = US%kg_m2s_to_RZ_T*US%m_s_to_L_T*Ice%flux_u(i2,j2)
-        Ice%sCS%IOF%flux_v_ocn(i,j) = US%kg_m2s_to_RZ_T*US%m_s_to_L_T*Ice%flux_v(i2,j2)
+        Ice%sCS%IOF%flux_u_ocn(i,j) = US%Pa_to_RLZ_T2*Ice%flux_u(i2,j2)
+        Ice%sCS%IOF%flux_v_ocn(i,j) = US%Pa_to_RLZ_T2*Ice%flux_v(i2,j2)
       enddo ; enddo
     endif
 
@@ -654,11 +654,11 @@ subroutine set_ocean_top_fluxes(Ice, IST, IOF, FIA, OSS, G, US, IG, sCS)
 !   It is possible that the ice mass and surface pressure will be needed after
 ! the thermodynamic step, in which case this should be uncommented.
 !  if (IOF%slp2ocean) then
-!     Ice%p_surf(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*FIA%p_atm_surf(i,j) - 1e5 ! SLP - 1 std. atmosphere [Pa].
+!     Ice%p_surf(i2,j2) = US%RLZ_T2_to_Pa*FIA%p_atm_surf(i,j) - 1e5 ! SLP - 1 std. atmosphere [Pa].
 !   else
 !     Ice%p_surf(i2,j2) = 0.0
 !   endif
-!   Ice%p_surf(i2,j2) = Ice%p_surf(i2,j2) + US%L_T_to_m_s**2*US%m_to_Z*G%g_Earth*Ice%mi(i2,j2)
+!   Ice%p_surf(i2,j2) = Ice%p_surf(i2,j2) + US%L_T2_to_m_s2*US%L_to_Z*G%g_Earth*Ice%mi(i2,j2)
   enddo ; enddo
   if (allocated(IOF%melt_nudge)) then
     do j=jsc,jec ; do i=isc,iec
@@ -755,21 +755,21 @@ subroutine set_ocean_top_dyn_fluxes(Ice, IOF, FIA, G, US, sCS)
   !$OMP parallel do default(shared) private(i2,j2)
   do j=jsc,jec ; do i=isc,iec
     i2 = i+i_off ; j2 = j+j_off! Use these to correct for indexing differences.
-    Ice%flux_u(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*IOF%flux_u_ocn(i,j)
-    Ice%flux_v(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*IOF%flux_v_ocn(i,j)
+    Ice%flux_u(i2,j2) = US%RLZ_T2_to_Pa*IOF%flux_u_ocn(i,j)
+    Ice%flux_v(i2,j2) = US%RLZ_T2_to_Pa*IOF%flux_v_ocn(i,j)
 
     if (IOF%slp2ocean) then
-      Ice%p_surf(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*FIA%p_atm_surf(i,j) - 1e5 ! SLP - 1 std. atmosphere [Pa].
+      Ice%p_surf(i2,j2) = US%RLZ_T2_to_Pa*FIA%p_atm_surf(i,j) - 1e5 ! SLP - 1 std. atmosphere [Pa].
     else
       Ice%p_surf(i2,j2) = 0.0
     endif
-    Ice%p_surf(i2,j2) = Ice%p_surf(i2,j2) + US%L_T_to_m_s**2*US%m_to_Z*G%g_Earth*Ice%mi(i2,j2)
+    Ice%p_surf(i2,j2) = Ice%p_surf(i2,j2) + US%L_T2_to_m_s2*US%L_to_Z*G%g_Earth*Ice%mi(i2,j2)
   enddo ; enddo
   if (associated(Ice%stress_mag) .and. allocated(IOF%stress_mag)) then
     i_off = LBOUND(Ice%stress_mag,1) - G%isc ; j_off = LBOUND(Ice%stress_mag,2) - G%jsc
     !$OMP parallel do default(shared) private(i2,j2)
     do j=jsc,jec ; do i=isc,iec ; i2 = i+i_off ; j2 = j+j_off
-      Ice%stress_mag(i2,j2) = US%RZ_T_to_kg_m2s*US%L_T_to_m_s*IOF%stress_mag(i,j)
+      Ice%stress_mag(i2,j2) = US%RLZ_T2_to_Pa*IOF%stress_mag(i,j)
     enddo ; enddo
   endif
 
@@ -1311,7 +1311,7 @@ subroutine set_fast_ocean_sfc_properties( Atmos_boundary, Ice, IST, Rad, FIA, &
   do j=jsc,jec ; do i=isc,iec
     i3 = i+io_A ; j3 = j+jo_A
     Rad%coszen_nextrad(i,j) = Atmos_boundary%coszen(i3,j3,1)
-    FIA%p_atm_surf(i,j) = US%kg_m2s_to_RZ_T*US%m_s_to_L_T*Atmos_boundary%p(i3,j3,1)
+    FIA%p_atm_surf(i,j) = US%Pa_to_RLZ_T2*Atmos_boundary%p(i3,j3,1)
     if (Rad%coszen_nextrad(i,j) /= Rad%coszen_lastrad(i,j)) coszen_changed = .true.
   enddo ; enddo
 


### PR DESCRIPTION
  Use the rescaling combinations `US%RLZ_T2_to_Pa`, `US%Pa_to_RL2_T2`, `US%Pa_to_RLZ_T2` and `US%L_T2_to_m_s2` in 111 places in 7 files for greater clarity of purpose and fewer calculations.  Also changed to explicitly name the units arguments to `register_SIS_diag_field()` in 41 of these to aid in consistency testing.  All answers are bitwise identical.