### PR TITLE
Fix syntax in 84 unit descriptions

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -217,35 +217,35 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                  'cell area', 'sphere')
 
   FIA%id_sh       = register_SIS_diag_field('ice_model', 'SH', diag%axesT1, Time, &
-               'sensible heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'sensible heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_lh       = register_SIS_diag_field('ice_model', 'LH', diag%axesT1, Time, &
-               'latent heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'latent heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw       = register_SIS_diag_field('ice_model', 'SW', diag%axesT1, Time, &
-               'shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_lw       = register_SIS_diag_field('ice_model', 'LW', diag%axesT1, Time, &
-               'longwave heat flux over ice', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'longwave heat flux over ice', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_snofl    = register_SIS_diag_field('ice_model', 'SNOWFL', diag%axesT1, Time, &
-               'rate of snow fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'rate of snow fall', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   FIA%id_rain     = register_SIS_diag_field('ice_model', 'RAIN', diag%axesT1, Time, &
-               'rate of rain fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'rate of rain fall', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   FIA%id_runoff   = register_SIS_diag_field('ice_model', 'RUNOFF', diag%axesT1, Time, &
-               'liquid runoff', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'liquid runoff', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   FIA%id_calving  = register_SIS_diag_field('ice_model', 'CALVING', diag%axesT1, Time, &
-               'frozen runoff', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'frozen runoff', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   FIA%id_runoff_hflx  = register_SIS_diag_field('ice_model', 'RUNOFF_HFLX', diag%axesT1, Time, &
-               'liquid runoff sensible heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'liquid runoff sensible heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_calving_hflx = register_SIS_diag_field('ice_model', 'CALVING_HFLX', diag%axesT1, Time, &
-               'frozen runoff sensible heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'frozen runoff sensible heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_evap     = register_SIS_diag_field('ice_model', 'EVAP',diag%axesT1, Time, &
-               'evaporation', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'evaporation', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   IOF%id_saltf    = register_SIS_diag_field('ice_model', 'SALTF', diag%axesT1, Time, &
-               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing)
+               'ice to ocean salt flux', units='kg m-2 s-1', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s)
   FIA%id_tmelt    = register_SIS_diag_field('ice_model', 'TMELT', diag%axesT1, Time, &
-               'upper surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'upper surface melting energy flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT', diag%axesT1, Time, &
-               'bottom surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'bottom surface melting energy flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_bheat    = register_SIS_diag_field('ice_model', 'BHEAT', diag%axesT1, Time, &
-               'ocean to ice heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'ocean to ice heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
 
   if (coupler_type_initialized(IOF%tr_flux_ocn_top)) &
     call coupler_type_set_diags(IOF%tr_flux_ocn_top, 'ice_model', diag%axesT1%handles, Time)
@@ -253,59 +253,59 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
 
   FIA%id_sw_dn   = register_SIS_diag_field('ice_model', 'SWDN', diag%axesT1, Time, &
                'Downward shortwave heat flux at the bottom of the atmosphere', &
-               'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_albedo  = register_SIS_diag_field('ice_model', 'ALB', diag%axesT1, Time, &
                'Shortwave flux weighted surface albedo, or 1 if no SW', '0-1', &
                missing_value=missing)
   FIA%id_sw_vis   = register_SIS_diag_field('ice_model', 'SW_VIS', diag%axesT1, Time, &
-               'visible shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'visible shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_dir   = register_SIS_diag_field('ice_model', 'SW_DIR', diag%axesT1, Time, &
-               'direct shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'direct shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_dif   = register_SIS_diag_field('ice_model', 'SW_DIF', diag%axesT1, Time, &
-               'diffuse shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'diffuse shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_vis_dir = register_SIS_diag_field('ice_model', 'SW_VIS_DIR', diag%axesT1, Time, &
-               'visible direct shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'visible direct shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_vis_dif = register_SIS_diag_field('ice_model', 'SW_VIS_DIF', diag%axesT1, Time, &
-               'visible diffuse shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'visible diffuse shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_nir_dir = register_SIS_diag_field('ice_model', 'SW_NIR_DIR', diag%axesT1, Time, &
-               'near IR direct shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'near IR direct shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_nir_dif = register_SIS_diag_field('ice_model', 'SW_NIR_DIF', diag%axesT1, Time, &
-               'near IR diffuse shortwave heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'near IR diffuse shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
 
   if (allocated(FIA%flux_sh0)) then
-    FIA%id_evap0  = register_SIS_diag_field('ice_model', 'EVAP_T0',diag%axesTc0, Time, &
-               'evaporation at 0 degC', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
-    FIA%id_lw0  = register_SIS_diag_field('ice_model', 'LW_T0',diag%axesTc0, Time, &
+    FIA%id_evap0  = register_SIS_diag_field('ice_model', 'EVAP_T0', diag%axesTc0, Time, &
+               'evaporation at 0 degC', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
+    FIA%id_lw0  = register_SIS_diag_field('ice_model', 'LW_T0', diag%axesTc0, Time, &
                'net downward longwave heat flux over ice at 0 degC', &
-               'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               units='W m-2', conversion=US%QRZ_T_to_W_m2)
     FIA%id_sh0  = register_SIS_diag_field('ice_model', 'SH_T0', diag%axesTc0, Time, &
-               'sensible heat flux at 0 degC', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'sensible heat flux at 0 degC', units='W m-2', conversion=US%QRZ_T_to_W_m2)
     FIA%id_devdt  = register_SIS_diag_field('ice_model', 'dEVAP_dT', diag%axesTc0, Time, &
                'partial derivative of evaporation with ice skin temperature', &
-               'kg/(m^2*s*K)', conversion=US%RZ_T_to_kg_m2s*US%degC_to_C, missing_value=missing)
-    FIA%id_dlwdt = register_SIS_diag_field('ice_model', 'dLW_dT',diag%axesTc0, Time, &
+               units='kg m-2 s-1 K-1', conversion=US%RZ_T_to_kg_m2s*US%degC_to_C)
+    FIA%id_dlwdt = register_SIS_diag_field('ice_model', 'dLW_dT', diag%axesTc0, Time, &
                'partial derivative of net downward longwave heat flux with ice skin temperature', &
-               'W/(m^2*K)', conversion=US%QRZ_T_to_W_m2*US%degC_to_C, missing_value=missing)
+               units='W m-2 K-1', conversion=US%QRZ_T_to_W_m2*US%degC_to_C)
     FIA%id_dshdt = register_SIS_diag_field('ice_model', 'dSH_dT', diag%axesTc0, Time, &
                'partial derivative of sensible heat flux with ice skin temperature', &
-               'W/(m^2*K)', conversion=US%QRZ_T_to_W_m2*US%degC_to_C, missing_value=missing)
+               units='W m-2 K-1', conversion=US%QRZ_T_to_W_m2*US%degC_to_C)
     FIA%id_tsfc_cat =register_SIS_diag_field('ice_model', 'TS_CAT', diag%axesTc0, Time, &
-               'surface temperature by category', 'C', conversion=US%C_to_degC, missing_value=missing)
+               'surface temperature by category', units='degC', conversion=US%C_to_degC)
   endif
   FIA%id_evap_cat  = register_SIS_diag_field('ice_model', 'EVAP_CAT', diag%axesTc0, Time, &
-             'evaporation by category', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
-  FIA%id_lw_cat  = register_SIS_diag_field('ice_model', 'LW_CAT',diag%axesTc0, Time, &
-             'longwave heat flux by category', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+             'evaporation by category', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
+  FIA%id_lw_cat  = register_SIS_diag_field('ice_model', 'LW_CAT', diag%axesTc0, Time, &
+             'longwave heat flux by category', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sh_cat  = register_SIS_diag_field('ice_model', 'SH_CAT', diag%axesTc0, Time, &
-             'sensible heat flux by category', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+             'sensible heat flux by category', units='W m-2', conversion=US%QRZ_T_to_W_m2)
 
 
   FIA%id_tsfc     = register_SIS_diag_field('ice_model', 'TS', diag%axesT1, Time, &
-               'surface temperature', 'C', conversion=US%C_to_degC, missing_value=missing)
+               'surface temperature', units='degC', conversion=US%C_to_degC)
   FIA%id_sitemptop= register_SIS_diag_field('ice_model', 'sitemptop', diag%axesT1, Time, &
-               'surface temperature', 'C', conversion=US%C_to_degC, missing_value=missing)
+               'surface temperature', units='degC', conversion=US%C_to_degC)
   FIA%id_sitemptop_CMOR = register_SIS_diag_field('ice_model', 'sitemptop_CMOR', diag%axesT1, Time, &
-               'Surface Temperature of Sea ice', 'Kelvin', conversion=US%C_to_degC, missing_value=missing, &
+               'Surface Temperature of Sea ice', units='Kelvin', conversion=US%C_to_degC, &
                standard_name="SeaIceSurfaceTemperature")
 
   ! diagnostics for quantities produced outside the ice model
@@ -313,30 +313,30 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
              'sea level pressure', units='Pa', conversion=US%RLZ_T2_to_Pa)
   ! diagnostics for quantities produced outside the ice model
   OSS%id_sst   = register_SIS_diag_field('ice_model', 'SST', diag%axesT1, Time, &
-             'sea surface temperature', 'deg-C', conversion=US%C_to_degC, missing_value=missing)
+             'sea surface temperature', units='degC', conversion=US%C_to_degC)
   OSS%id_sss   = register_SIS_diag_field('ice_model', 'SSS', diag%axesT1, Time, &
-             'sea surface salinity', 'psu', conversion=US%S_to_ppt, missing_value=missing)
+             'sea surface salinity', units='psu', conversion=US%S_to_ppt)
   OSS%id_ssh   = register_SIS_diag_field('ice_model', 'SSH', diag%axesT1, Time, &
-             'sea surface height', 'm', conversion=US%Z_to_m, missing_value=missing)
+             'sea surface height', units='m', conversion=US%Z_to_m)
 
   if (Cgrid_dyn) then
     OSS%id_uo     = register_SIS_diag_field('ice_model', 'UO', diag%axesCu1, Time, &
-               'surface current - x component', 'm/s', conversion=US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'surface current - x component', units='m s-1', conversion=US%L_T_to_m_s, &
+               interp_method='none')
     OSS%id_vo     = register_SIS_diag_field('ice_model', 'VO', diag%axesCv1, Time, &
-               'surface current - y component', 'm/s', conversion=US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'surface current - y component', units='m s-1', conversion=US%L_T_to_m_s, &
+               interp_method='none')
   else
     OSS%id_uo     = register_SIS_diag_field('ice_model', 'UO', diag%axesB1, Time, &
-               'surface current - x component', 'm/s', conversion=US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'surface current - x component', units='m s-1', conversion=US%L_T_to_m_s, &
+               interp_method='none')
     OSS%id_vo     = register_SIS_diag_field('ice_model', 'VO', diag%axesB1, Time, &
-               'surface current - y component', 'm/s', conversion=US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               'surface current - y component', units='m s-1', conversion=US%L_T_to_m_s, &
+               interp_method='none')
   endif
 
   OSS%id_frazil   = register_SIS_diag_field('ice_model', 'FRAZIL', diag%axesT1, Time, &
-               'energy flux of frazil formation', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'energy flux of frazil formation', units='W m-2', conversion=US%QRZ_T_to_W_m2)
 
   if (coupler_type_initialized(OSS%tr_fields)) &
     call coupler_type_set_diags(OSS%tr_fields, 'ice_model', diag%axesT1%handles, Time)
@@ -434,7 +434,7 @@ subroutine ice_diags_fast_init(Rad, G, IG, diag, Time, component)
   Rad%id_alb_nir_dif = register_SIS_diag_field(trim(comp_name),'alb_nir_dif',diag%axesT1, Time, &
                'ice surface albedo nir_dif','0-1', missing_value=missing )
   Rad%id_tskin = register_SIS_diag_field(trim(comp_name),'Tskin', diag%axesTc, Time, &
-               'Skin temperature', 'degC', conversion=G%US%C_to_degC, missing_value=missing )
+               'Skin temperature', units='degC', conversion=G%US%C_to_degC)
   Rad%id_cn = register_SIS_diag_field(trim(comp_name),'CN_fast', diag%axesTc, Time, &
                'Category concentration','0-1', missing_value=missing )
   Rad%id_mi = register_SIS_diag_field(trim(comp_name),'MI_fast', diag%axesTc, Time, &

--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -160,11 +160,11 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
 
 
   CS%id_sigi  = register_diag_field('ice_model','SIGI' ,diag%axesT1, Time,     &
-            'first stress invariant', 'none', missing_value=missing)
+            'first stress invariant', units='nondim')
   CS%id_sigii = register_diag_field('ice_model','SIGII' ,diag%axesT1, Time,    &
-            'second stress invariant', 'none', missing_value=missing)
+            'second stress invariant', units='nondim')
   CS%id_stren = register_diag_field('ice_model','STRENGTH' ,diag%axesT1, Time, &
-            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
+            'ice strength', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_fix   = register_diag_field('ice_model', 'FI_X', diag%axesB1, Time,    &
             'ice internal stress - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
             interp_method='none')
@@ -184,11 +184,9 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
             'water stress on ice - y component', units='Pa', conversion=-US%RLZ_T2_to_Pa, &
             interp_method='none')
   CS%id_ui    = register_diag_field('ice_model', 'UI', diag%axesB1, Time,      &
-            'ice velocity - x component', 'm/s', conversion=US%L_T_to_m_s,     &
-            missing_value=missing, interp_method='none')
+            'ice velocity - x component', units='m s-1', conversion=US%L_T_to_m_s, interp_method='none')
   CS%id_vi    = register_diag_field('ice_model', 'VI', diag%axesB1, Time,      &
-            'ice velocity - y component', 'm/s', conversion=US%L_T_to_m_s,     &
-            missing_value=missing, interp_method='none')
+            'ice velocity - y component', units='m s-1', conversion=US%L_T_to_m_s, interp_method='none')
 
 end subroutine SIS_B_dyn_init
 

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -393,14 +393,14 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%u_file = -1 ; CS%v_file = -1 ; CS%cols_written = 0
 
   CS%id_sigi  = register_diag_field('ice_model','SIGI' ,diag%axesT1, Time,     &
-            'first stress invariant', 'none', missing_value=missing)
+            'first stress invariant', units='nondim')
   CS%id_sigii = register_diag_field('ice_model','SIGII' ,diag%axesT1, Time,    &
-            'second stress invariant', 'none', missing_value=missing)
+            'second stress invariant', units='nondim')
   CS%id_stren = register_diag_field('ice_model','STRENGTH' ,diag%axesT1, Time, &
-            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
+            'ice strength', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_stren0 = register_diag_field('ice_model','STREN_0' ,diag%axesT1, Time, &
             'ice strength at start of rheology', &
-            units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
+            units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_fix   = register_diag_field('ice_model', 'FI_X', diag%axesCu1, Time,   &
             'ice internal stress - x component', units='Pa', conversion=US%RLZ_T2_to_Pa, &
             interp_method='none')
@@ -444,31 +444,29 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
             'land-fast bottom stress on ice - y component', &
             units='Pa', conversion=US%RLZ_T2_to_Pa, interp_method='none')
   CS%id_ui    = register_diag_field('ice_model', 'UI', diag%axesCu1, Time,     &
-            'ice velocity - x component', 'm/s', missing_value=missing,        &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - x component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_vi    = register_diag_field('ice_model', 'VI', diag%axesCv1, Time,     &
-            'ice velocity - y component', 'm/s', missing_value=missing,        &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - y component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_ui_east    = register_diag_field('ice_model', 'ui_east', diag%axesT1, Time,     &
-            'ice velocity - east component', 'm/s', missing_value=missing,        &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - east component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_vi_north    = register_diag_field('ice_model', 'vi_north', diag%axesT1, Time,     &
-            'ice velocity - north component', 'm/s', missing_value=missing,        &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - north component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_mis  = register_diag_field('ice_model', 'MIS_tot', diag%axesT1, Time,  &
-            'Mass of ice and snow at t-points', 'kg m-2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+            'Mass of ice and snow at t-points', units='kg m-2', conversion=US%RZ_to_kg_m2)
   CS%id_ci0  = register_diag_field('ice_model', 'CI_tot', diag%axesT1, Time,   &
-            'Initial summed concentration of ice at t-points', 'nondim',       &
-            missing_value=missing)
+            'Initial summed concentration of ice at t-points', units='nondim')
   CS%id_ci  = register_diag_field('ice_model', 'CI_proj', diag%axesT1, Time,   &
-            'Projected summed concentration of ice at t-points', 'nondim',     &
-            missing_value=missing)
+            'Projected summed concentration of ice at t-points', units='nondim')
   CS%id_miu = register_diag_field('ice_model', 'MI_U', diag%axesCu1, Time,   &
-            'Mass of ice and snow at u-points', 'kg m-2', conversion=US%RZ_to_kg_m2, &
-            missing_value=missing, interp_method='none')
+            'Mass of ice and snow at u-points', units='kg m-2', conversion=US%RZ_to_kg_m2, &
+            interp_method='none')
   CS%id_miv = register_diag_field('ice_model', 'MI_V', diag%axesCv1, Time,   &
-            'Mass of ice and snow at v-points', 'kg m-2', conversion=US%RZ_to_kg_m2, &
-            missing_value=missing, interp_method='none')
+            'Mass of ice and snow at v-points', units='kg m-2', conversion=US%RZ_to_kg_m2, &
+            interp_method='none')
 
   CS%id_fix_d   = register_diag_field('ice_model', 'FI_d_X', diag%axesCu1, Time,         &
             'ice divergence internal stress - x component', &
@@ -496,24 +494,22 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_str_s   = register_diag_field('ice_model', 'str_s', diag%axesB1, Time, &
             'ice shearing internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_sh_d   = register_diag_field('ice_model', 'sh_d', diag%axesT1, Time,   &
-            'ice divergence strain rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice divergence strain rate', units='s-1', conversion=US%s_to_T)
   CS%id_sh_t   = register_diag_field('ice_model', 'sh_t', diag%axesT1, Time,   &
-            'ice tension strain rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice tension strain rate', units='s-1', conversion=US%s_to_T)
   CS%id_sh_s   = register_diag_field('ice_model', 'sh_s', diag%axesB1, Time,   &
-            'ice shearing strain rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice shearing strain rate', units='s-1', conversion=US%s_to_T)
   CS%id_del_sh = register_diag_field('ice_model', 'del_sh', diag%axesT1, Time, &
-            'ice strain rate magnitude', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice strain rate magnitude', units='s-1', conversion=US%s_to_T)
   CS%id_del_sh_min = register_diag_field('ice_model', 'del_sh_min', diag%axesT1, Time, &
-            'minimum ice strain rate magnitude', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'minimum ice strain rate magnitude', units='s-1', conversion=US%s_to_T)
   CS%id_itheta = register_diag_field('ice_model', 'itheta', diag%axesT1, Time, &
-            'ice atan(shear/divergence)', 'rad', missing_value=missing)
+            'ice atan(shear/divergence)', units='radians')
 
   CS%id_ui_hifreq = register_diag_field('ice_model', 'ui_hf', diag%axesCu1, Time, &
-            'ice velocity - x component', 'm/s', missing_value=missing,        &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - x component', units='m s-1', conversion=US%L_T_to_m_s, interp_method='none')
   CS%id_vi_hifreq = register_diag_field('ice_model', 'vi_hf', diag%axesCv1, Time, &
-            'ice velocity - y component', 'm/s', missing_value=missing,        &
-            interp_method='none, conversion=US%L_T_to_m_s')
+            'ice velocity - y component', units='m s-1', conversion=US%L_T_to_m_s, interp_method='none')
   CS%id_str_d_hifreq = register_diag_field('ice_model', 'str_d_hf', diag%axesT1, Time, &
             'ice divergence internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_str_t_hifreq = register_diag_field('ice_model', 'str_t_hf', diag%axesT1, Time, &
@@ -521,28 +517,28 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_str_s_hifreq = register_diag_field('ice_model', 'str_s_hf', diag%axesB1, Time, &
             'ice shearing internal stress', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
   CS%id_sh_d_hifreq = register_diag_field('ice_model', 'sh_d_hf', diag%axesT1, Time, &
-            'ice divergence rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice divergence rate', units='s-1', conversion=US%s_to_T)
   CS%id_sh_t_hifreq = register_diag_field('ice_model', 'sh_t_hf', diag%axesT1, Time, &
-            'ice tension rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice tension rate', units='s-1', conversion=US%s_to_T)
   CS%id_sh_s_hifreq = register_diag_field('ice_model', 'sh_s_hf', diag%axesB1, Time, &
-            'ice shearing rate', 's-1', conversion=US%s_to_T, missing_value=missing)
+            'ice shearing rate', units='s-1', conversion=US%s_to_T)
   CS%id_sigi_hifreq  = register_diag_field('ice_model','sigI_hf' ,diag%axesT1, Time, &
-            'first stress invariant', 'none', missing_value=missing)
+            'first stress invariant', units='nondim')
   CS%id_sigii_hifreq = register_diag_field('ice_model','sigII_hf' ,diag%axesT1, Time, &
-            'second stress invariant', 'none', missing_value=missing)
+            'second stress invariant', units='nondim')
   CS%id_ci_hifreq  = register_diag_field('ice_model', 'CI_hf', diag%axesT1, Time, &
-            'Summed concentration of ice at t-points', 'nondim', missing_value=missing)
+            'Summed concentration of ice at t-points', units='nondim')
   CS%id_stren_hifreq = register_diag_field('ice_model','STRENGTH_hf' ,diag%axesT1, Time, &
-            'ice strength', units='Pa*m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
+            'ice strength', units='Pa m', conversion=US%RLZ_T2_to_Pa*US%L_to_m)
 
   CS%id_siu = register_diag_field('ice_model', 'siu', diag%axesT1, Time, &
-            'ice velocity - x component', 'm/s', missing_value=missing,  &
-            interp_method='none', conversion=US%L_T_to_m_s)
+            'ice velocity - x component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_siv = register_diag_field('ice_model', 'siv', diag%axesT1, Time, &
-            'ice velocity - y component', 'm/s', missing_value=missing,  &
-            interp_method='none', conversion=US%L_T_to_m_s)
+           'ice velocity - y component', units='m s-1', conversion=US%L_T_to_m_s, &
+            interp_method='none')
   CS%id_sispeed = register_diag_field('ice_model', 'sispeed', diag%axesT1, Time, &
-            'ice speed', 'm/s', missing_value=missing, conversion=US%L_T_to_m_s)
+            'ice speed', units='m s-1', conversion=US%L_T_to_m_s)
 
 end subroutine SIS_C_dyn_init
 

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -332,7 +332,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_hs       = register_diag_field('ice_model', 'HS', diag%axesT1, Time, &
                'snow thickness', 'm-snow', missing_value=missing)
   IDs%id_tsn      = register_diag_field('ice_model', 'TSN', diag%axesT1, Time, &
-               'snow layer temperature', 'C', conversion=US%C_to_degC,  missing_value=missing)
+               'snow layer temperature', units='degC', conversion=US%C_to_degC)
   IDs%id_hi       = register_diag_field('ice_model', 'HI', diag%axesT1, Time, &
                'ice thickness', 'm-ice', missing_value=missing)
   IDs%id_sitimefrac = register_diag_field('ice_model', 'sitimefrac', diag%axesT1, Time, &
@@ -340,8 +340,8 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_siconc = register_diag_field('ice_model', 'siconc', diag%axesT1, Time, &
                'ice concentration', '0-1', missing_value=missing)
   IDs%id_siconc_CMOR = register_diag_field('ice_model', 'siconc_CMOR', diag%axesT1, Time, &
-               'Sea-Ice Area Percentage', '%', missing_value=missing, &
-               standard_name="SeaIceAreaFraction", conversion=100.0)
+               'Sea-Ice Area Percentage', units='%', conversion=100.0, &
+               standard_name="SeaIceAreaFraction")
   IDs%id_sithick  = register_diag_field('ice_model', 'sithick', diag%axesT1, Time, &
                'ice thickness', 'm-ice', missing_value=missing)
   IDs%id_sivol  = register_diag_field('ice_model', 'sivol', diag%axesT1, Time, &
@@ -349,41 +349,41 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_sisnconc = register_diag_field('ice_model', 'sisnconc', diag%axesT1, Time, &
                'snow concentration', '0-1', missing_value=missing)
   IDs%id_sisnconc_CMOR = register_diag_field('ice_model', 'sisnconc_CMOR', diag%axesT1, Time, &
-               'Snow Area Percentage', '%', missing_value=missing, &
-               standard_name="SurfaceSnowAreaFraction", conversion=100.0)
+               'Snow Area Percentage', units='%', conversion=100.0, missing_value=missing, &
+               standard_name="SurfaceSnowAreaFraction")
   IDs%id_sisnthick= register_diag_field('ice_model', 'sisnthick', diag%axesT1, Time, &
                'snow thickness', 'm-snow', missing_value=missing)
 
   IDs%id_t_iceav = register_diag_field('ice_model', 'T_bulkice', diag%axesT1, Time, &
-               'Volume-averaged ice temperature', 'C', conversion=US%C_to_degC, missing_value=missing)
+               'Volume-averaged ice temperature', units='degC', conversion=US%C_to_degC)
   IDs%id_s_iceav = register_diag_field('ice_model', 'S_bulkice', diag%axesT1, Time, &
-               'Volume-averaged ice salinity', 'g/kg', conversion=US%S_to_ppt, missing_value=missing)
+               'Volume-averaged ice salinity', units='g kg-1', conversion=US%S_to_ppt)
   call safe_alloc_ids_1d(IDs%id_t, nLay)
   call safe_alloc_ids_1d(IDs%id_sal, nLay)
   do n=1,nLay
     write(nstr, '(I4)') n ; nstr = adjustl(nstr)
     IDs%id_t(n)   = register_diag_field('ice_model', 'T'//trim(nstr), &
                  diag%axesT1, Time, 'ice layer '//trim(nstr)//' temperature', &
-                 'C', conversion=US%C_to_degC, missing_value=missing)
+                 units='degC', conversion=US%C_to_degC)
     IDs%id_sal(n)   = register_diag_field('ice_model', 'Sal'//trim(nstr), &
                diag%axesT1, Time, 'ice layer '//trim(nstr)//' salinity', &
-               'g/kg', conversion=US%S_to_ppt, missing_value=missing)
+               units='g kg-1', conversion=US%S_to_ppt)
   enddo
 
   IDs%id_mi   = register_diag_field('ice_model', 'MI', diag%axesT1, Time, &
-               'ice + snow mass', 'kg/m^2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+               'ice + snow mass', units='kg m-2', conversion=US%RZ_to_kg_m2)
   IDs%id_simass = register_diag_field('ice_model', 'simass', diag%axesT1, Time, &
-               'ice mass', 'kg/m^2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+               'ice mass', units='kg m-2', conversion=US%RZ_to_kg_m2)
   IDs%id_simass_n = register_diag_field('ice_model', 'simass_n', diag%axesTc, Time, &
-               'ice mass in categories', 'kg/m^2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+               'ice mass in categories', units='kg m-2', conversion=US%RZ_to_kg_m2)
   IDs%id_siitdthick = register_diag_field('ice_model', 'siitdthick', diag%axesTc, Time, &
                'ice thickness in categories', 'm-ice', missing_value=missing)
   IDs%id_sisnmass = register_diag_field('ice_model', 'sisnmass', diag%axesT1, Time, &
-               'snow mass', 'kg/m^2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+               'snow mass', units='kg m-2', conversion=US%RZ_to_kg_m2)
   IDs%id_mib  = register_diag_field('ice_model', 'MIB', diag%axesT1, Time, &
-               'ice + snow + bergs mass', 'kg/m^2', conversion=US%RZ_to_kg_m2, missing_value=missing)
+               'ice + snow + bergs mass', units='kg m-2', conversion=US%RZ_to_kg_m2)
   IDs%id_e2m  = register_diag_field('ice_model','E2MELT' ,diag%axesT1, Time, &
-               'heat needed to melt ice', 'J/m^2', conversion=US%Q_to_J_kg*US%RZ_to_kg_m2, missing_value=missing)
+               'heat needed to melt ice', units='J m-2', conversion=US%Q_to_J_kg*US%RZ_to_kg_m2)
 
   call get_param(param_file, mdl, "DO_RIDGING", do_ridging, &
                  "If true, call the ridging routines.", default=.false., do_not_log=.true.)
@@ -391,7 +391,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
     IDs%id_rdgf = register_diag_field('ice_model', 'RDG_FRAC', diag%axesTc, Time, &
                    'ridged ice fraction', '0-1', missing_value=missing)
 !   IDs%id_rdg_h = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
-!                  'ice ridge height', 'm', conversion=US%m_to_Z, missing_value=missing)
+!                  'ice ridge height', units='m', conversion=US%m_to_Z)
   endif
 end subroutine register_ice_state_diagnostics
 

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1592,28 +1592,27 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                'frozen water local sink', 'kg/(m^2*yr)', missing_value=missing)
   CS%id_bsnk = register_diag_field('ice_model','BSNK',diag%axesT1, Time, &
                'frozen water local bottom sink', &
-               'kg/(m^2*yr)', conversion= 864e2*365.*US%RZ_T_to_kg_m2s, &
-               missing_value=missing)
+               units='kg m-2 yr-1', conversion=864e2*365.*US%RZ_T_to_kg_m2s)
   CS%id_sn2ic = register_diag_field('ice_model','SN2IC'  ,diag%axesT1,Time, &
                'rate of snow to ice conversion', 'kg/(m^2*s)', missing_value=missing)
   CS%id_net_melt = register_diag_field('ice_model','net_melt' ,diag%axesT1, Time, &
                'net mass flux from ice & snow to ocean due to melting & freezing', &
-               'kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   CS%id_CMOR_melt = register_diag_field('ice_model','fsitherm' ,diag%axesT1, Time, &
                'water_flux_into_sea_water_due_to_sea_ice_thermodynamics', &
-               'kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
 
   if (CS%do_ice_restore) then
     CS%id_qfres = register_diag_field('ice_model', 'QFLX_RESTORE_ICE', diag%axesT1, Time, &
-                 'Ice Restoring heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+                 'Ice Restoring heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   endif
   if (CS%do_ice_limit) then
     CS%id_qflim = register_diag_field('ice_model', 'QFLX_LIMIT_ICE', diag%axesT1, Time, &
-                 'Ice Limit heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+                 'Ice Limit heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   endif
   if (CS%nudge_sea_ice) then
     CS%id_fwnudge  = register_diag_field('ice_model','FW_NUDGE' ,diag%axesT1, Time, &
-               'nudging freshwater flux', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'nudging freshwater flux', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
   endif
 
   call SIS2_ice_thm_init(US, param_file, CS%ice_thm_CSp)

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -196,7 +196,7 @@ subroutine ice_cat_transport(CAS, TrReg, dt_slow, nsteps, G, US, IG, CS, uc, vc,
                                     h3=CAS%m_pond, uh3=uh_pond, vh3=vh_pond)
     else
       call continuity(uc, vc, mca0_ice, CAS%m_ice, uh_ice, vh_ice, dt_adv, &
-                      G, US, IG, CS%continuity_CSp, use_h_neg=.true.)  ! this is hard-coded here to preserve previous answers
+                      G, US, IG, CS%continuity_CSp, use_h_neg=.true.)  ! Hard-coded here to preserve previous answers
       call continuity(uc, vc, mca0_snow, CAS%m_snow, uh_snow, vh_snow, dt_adv, &
                       G, US, IG, CS%continuity_CSp, masking_uh=uh_ice, masking_vh=vh_ice, use_h_neg=h_neg_fix)
       call continuity(uc, vc, mca0_pond, CAS%m_pond, uh_pond, vh_pond, dt_adv, &
@@ -1252,21 +1252,20 @@ subroutine SIS_transport_init(Time, G, IG, US, param_file, diag, CS, continuity_
   call SIS_tracer_advect_init(Time, G, param_file, diag, CS%SIS_thick_adv_CSp, scheme=scheme)
 
   CS%id_ix_trans = register_diag_field('ice_model', 'IX_TRANS', diag%axesCu1, Time, &
-               'x-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
-               missing_value=missing, interp_method='none')
+               'x-direction ice transport', units='kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
+               interp_method='none')
   CS%id_iy_trans = register_diag_field('ice_model', 'IY_TRANS', diag%axesCv1, Time, &
-               'y-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
-               missing_value=missing, interp_method='none')
+               'y-direction ice transport', units='kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
+               interp_method='none')
   CS%id_xprt = register_diag_field('ice_model', 'XPRT', diag%axesT1, Time, &
-               'frozen water transport convergence', 'kg/(m^2*yr)', conversion=US%RZ_to_kg_m2, &
-               missing_value=missing)
+               'frozen water transport convergence', units='kg m-2 yr-1', conversion=US%RZ_to_kg_m2)
   CS%id_rdgr = register_diag_field('ice_model', 'RDG_RATE', diag%axesT1, Time, &
-               'ice ridging rate', '1/sec', conversion=US%s_to_T, missing_value=missing)
+               'ice ridging rate', units='s-1', conversion=US%s_to_T)
   CS%id_rdgh = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
-               'ice ridge height', 'm', conversion=US%m_to_Z, missing_value=missing)
+               'ice ridge height', units='m', conversion=US%m_to_Z)
 !### THESE DIAGNOSTICS DO NOT EXIST YET.
 !  CS%id_rdgo = register_diag_field('ice_model', 'RDG_OPEN', diag%axesT1, Time, &
-!               'rate of opening due to ridging', '1/s', conversion=US%s_to_T, missing_value=missing)
+!               'rate of opening due to ridging', units='s-1', conversion=US%s_to_T)
 !  CS%id_rdgv = register_diag_field('ice_model', 'RDG_VOSH', diag%axesT1, Time, &
 !               'volume shifted from level to ridged ice', 'm^3/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
 !                missing_value=missing)

--- a/src/SIS_types.F90
+++ b/src/SIS_types.F90
@@ -499,7 +499,7 @@ subroutine ice_state_register_restarts(IST, G, IG, US, Ice_restart)
     call register_restart_field(Ice_restart, 'part_size', IST%part_size, dim_3='cat0')
     if (allocated(IST%t_surf)) then
       call register_restart_field(Ice_restart, 't_surf_ice', IST%t_surf, &
-                                  mandatory=.false., units="deg K", conversion=US%C_to_degC)
+                                  mandatory=.false., units="Kelvin", conversion=US%C_to_degC)
     endif
     call register_restart_field(Ice_restart, 'h_pond', IST%mH_pond, &
                                 mandatory=.false., units="kg m-2", conversion=US%RZ_to_kg_m2)
@@ -516,7 +516,7 @@ subroutine ice_state_register_restarts(IST, G, IG, US, Ice_restart)
     call register_restart_field(Ice_restart, 'enth_ice', IST%enth_ice, &
                                 mandatory=.false., units="J kg-1", conversion=US%Q_to_J_kg)
     call register_restart_field(Ice_restart, 'sal_ice', IST%sal_ice, &
-                                mandatory=.false., units="g/kg", conversion=US%S_to_ppt)
+                                mandatory=.false., units="g kg-1", conversion=US%S_to_ppt)
 
     if (allocated(IST%snow_to_ocn)) then
       call register_restart_field(Ice_restart, 'snow_to_ocn', IST%snow_to_ocn, &
@@ -863,7 +863,8 @@ subroutine ice_rad_register_restarts(HI, IG, US, param_file, Rad, Ice_restart)
   call safe_alloc(Rad%coszen_lastrad, isd, ied, jsd, jed)
 
   call register_restart_field(Ice_restart, 'coszen', Rad%coszen_nextrad, mandatory=.false.)
-  call register_restart_field(Ice_restart, 'T_skin', Rad%t_skin, mandatory=.false., conversion=US%C_to_degC)
+  call register_restart_field(Ice_restart, 'T_skin', Rad%t_skin, mandatory=.false., &
+                              units="degC", conversion=US%C_to_degC)
 
 end subroutine ice_rad_register_restarts
 


### PR DESCRIPTION
  Corrected the syntax of 83 unit descriptions used in diagnostic registrations in 7 files and explicitly name the units arguments in 101 calls to `register_SIS_diag_field()`.  Also added a missing unit argument to one call to `register_restart_field()`.  All answers are bitwise identical, but there are metadata changes in some diagnostic and restart files.