### PR TITLE
Set range and units for 19 nondimensional diagnostics

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -255,8 +255,8 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                'Downward shortwave heat flux at the bottom of the atmosphere', &
                units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_albedo  = register_SIS_diag_field('ice_model', 'ALB', diag%axesT1, Time, &
-               'Shortwave flux weighted surface albedo, or 1 if no SW', '0-1', &
-               missing_value=missing)
+               'Shortwave flux weighted surface albedo, or 1 if no SW', &
+               units="nondim", range=(/0.,1./))
   FIA%id_sw_vis   = register_SIS_diag_field('ice_model', 'SW_VIS', diag%axesT1, Time, &
                'visible shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_dir   = register_SIS_diag_field('ice_model', 'SW_DIR', diag%axesT1, Time, &
@@ -403,42 +403,44 @@ subroutine ice_diags_fast_init(Rad, G, IG, diag, Time, component)
   Rad%id_lwdn  = register_SIS_diag_field(trim(comp_name),'LWDN', diag%axesT1, Time, &
              'downward longwave flux', 'W/m^2', missing_value=missing)
 
-  Rad%id_alb      = register_SIS_diag_field(trim(comp_name),'ALB',diag%axesT1, Time, &
-               'surface albedo','0-1', missing_value=missing )
-  Rad%id_coszen   = register_SIS_diag_field(trim(comp_name),'coszen',diag%axesT1, Time, &
-               'cosine of the solar zenith angle for the next radiation step','-1:1', missing_value=missing )
-  Rad%id_sw_abs_sfc= register_SIS_diag_field(trim(comp_name),'sw_abs_sfc',diag%axesT1, Time, &
-               'SW frac. abs. at the ice surface','0-1', missing_value=missing )
-  Rad%id_sw_abs_snow= register_SIS_diag_field(trim(comp_name),'sw_abs_snow',diag%axesT1, Time, &
-               'SW frac. abs. in snow','0-1', missing_value=missing )
+  Rad%id_alb      = register_SIS_diag_field(trim(comp_name), 'ALB', diag%axesT1, Time, &
+               'surface albedo', units="nondim", range=(/0.,1./) )
+  Rad%id_coszen   = register_SIS_diag_field(trim(comp_name), 'coszen', diag%axesT1, Time, &
+               'cosine of the solar zenith angle for the next radiation step', &
+               units="nondim", range=(/-1.,1./) )
+  Rad%id_sw_abs_sfc= register_SIS_diag_field(trim(comp_name), 'sw_abs_sfc', diag%axesT1, Time, &
+               'SW frac. abs. at the ice surface', units="nondim", range=(/0.,1./) )
+  Rad%id_sw_abs_snow= register_SIS_diag_field(trim(comp_name), 'sw_abs_snow', diag%axesT1, Time, &
+               'SW frac. abs. in snow', units="nondim", range=(/0.,1./) )
 
   call safe_alloc_ids_1d(Rad%id_sw_abs_ice, nLay)
   do n=1,nLay
     write(nstr, '(I4)') n ; nstr = adjustl(nstr)
     Rad%id_sw_abs_ice(n) = register_SIS_diag_field(trim(comp_name),'sw_abs_ice'//trim(nstr), &
-                 diag%axesT1, Time, 'SW frac. abs. in ice layer '//trim(nstr), &
-                 '0:1', missing_value=missing )
+                 diag%axesT1, Time, 'SW fraction absorbed in ice layer '//trim(nstr), &
+                 units="nondim", range=(/0.,1./) )
   enddo
-  Rad%id_sw_pen= register_SIS_diag_field(trim(comp_name),'sw_pen',diag%axesT1, Time, &
-               'SW frac. pen. surf.','0:1', missing_value=missing )
-  Rad%id_sw_abs_ocn= register_SIS_diag_field(trim(comp_name),'sw_abs_ocn',diag%axesT1, Time, &
-               'SW frac. sent to the ocean','0:1', missing_value=missing )
+  Rad%id_sw_pen= register_SIS_diag_field(trim(comp_name),'sw_pen', diag%axesT1, Time, &
+               'SW fraction penetrating the ice surface', &
+               units="nondim", range=(/0.,1./) )
+  Rad%id_sw_abs_ocn= register_SIS_diag_field(trim(comp_name),'sw_abs_ocn', diag%axesT1, Time, &
+               'SW fraction sent to the ocean', units="nondim", range=(/0.,1./) )
 
 
-  Rad%id_alb_vis_dir = register_SIS_diag_field(trim(comp_name),'alb_vis_dir',diag%axesT1, Time, &
-               'ice surface albedo vis_dir','0-1', missing_value=missing )
-  Rad%id_alb_vis_dif = register_SIS_diag_field(trim(comp_name),'alb_vis_dif',diag%axesT1, Time, &
-               'ice surface albedo vis_dif','0-1', missing_value=missing )
-  Rad%id_alb_nir_dir = register_SIS_diag_field(trim(comp_name),'alb_nir_dir',diag%axesT1, Time, &
-               'ice surface albedo nir_dir','0-1', missing_value=missing )
-  Rad%id_alb_nir_dif = register_SIS_diag_field(trim(comp_name),'alb_nir_dif',diag%axesT1, Time, &
-               'ice surface albedo nir_dif','0-1', missing_value=missing )
+  Rad%id_alb_vis_dir = register_SIS_diag_field(trim(comp_name), 'alb_vis_dir', diag%axesT1, Time, &
+               'ice surface albedo vis_dir', units="nondim", range=(/0.,1./) )
+  Rad%id_alb_vis_dif = register_SIS_diag_field(trim(comp_name), 'alb_vis_dif', diag%axesT1, Time, &
+               'ice surface albedo vis_dif', units="nondim", range=(/0.,1./) )
+  Rad%id_alb_nir_dir = register_SIS_diag_field(trim(comp_name), 'alb_nir_dir', diag%axesT1, Time, &
+               'ice surface albedo nir_dir', units="nondim", range=(/0.,1./) )
+  Rad%id_alb_nir_dif = register_SIS_diag_field(trim(comp_name), 'alb_nir_dif', diag%axesT1, Time, &
+               'ice surface albedo nir_dif', units="nondim", range=(/0.,1./) )
   Rad%id_tskin = register_SIS_diag_field(trim(comp_name),'Tskin', diag%axesTc, Time, &
                'Skin temperature', units='degC', conversion=G%US%C_to_degC)
   Rad%id_cn = register_SIS_diag_field(trim(comp_name),'CN_fast', diag%axesTc, Time, &
-               'Category concentration','0-1', missing_value=missing )
+               'Category concentration', units="nondim", range=(/0.,1./) )
   Rad%id_mi = register_SIS_diag_field(trim(comp_name),'MI_fast', diag%axesTc, Time, &
-               'Category concentration','0-1', missing_value=missing )
+               'Category concentration', units="nondim", range=(/0.,1./) )
 
 end subroutine ice_diags_fast_init
 

--- a/src/SIS_diag_mediator.F90
+++ b/src/SIS_diag_mediator.F90
@@ -1027,8 +1027,7 @@ integer function register_SIS_diag_field(module_name, field_name, axes_in, init_
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
   real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
                                                           !! output files, in unscaled arbitrary units [a]
-  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in SIS?)
-                                                     !! in arbitrary units [a]
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable in arbitrary units [a]
   logical,          optional, intent(in) :: mask_variant !< If true a logical mask must be provided with
                                                          !! post_data calls (not used in SIS?)
   logical,          optional, intent(in) :: verbose !< If true, FMS is verbose (not used in SIS?)
@@ -1188,8 +1187,7 @@ logical function register_diag_field_expand_cmor(dm_id, module_name, field_name,
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
   real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
                                                           !! output files, in unscaled arbitrary units [a]
-  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in SIS?)
-                                                     !! in arbitrary units [a]
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable in arbitrary units [a]
   logical,          optional, intent(in) :: mask_variant !< If true a logical mask must be provided
                                                          !! with post_data calls (not used in SIS?)
   logical,          optional, intent(in) :: verbose !< If true, FMS is verbose (not used in SIS?)
@@ -1298,8 +1296,7 @@ integer function register_diag_field_expand_axes(module_name, field_name, axes, 
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
   real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
                                                           !! output files, in unscaled arbitrary units [a]
-  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in SIS?)
-                                                     !! in arbitrary units [a]
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable in arbitrary units [a]
   logical,          optional, intent(in) :: mask_variant !< If true a logical mask must be provided
                                                          !! with post_data calls (not used in SIS?)
   logical,          optional, intent(in) :: verbose !< If true, FMS is verbose (not used in SIS?)
@@ -1476,8 +1473,7 @@ function register_scalar_field(module_name, field_name, init_time, diag_cs, &
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
   real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
                                                           !! output files, in unscaled arbitrary units [a]
-  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in SIS?)
-                                                     !! in arbitrary units [a]
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable in arbitrary units [a]
   logical,          optional, intent(in) :: do_not_log !< If true, do not log something (not used in SIS?)
   character(len=*), optional, intent(out):: err_msg !< String into which an error message might be
                                                          !! placed (not used in SIS?)
@@ -1591,8 +1587,7 @@ function register_static_field(module_name, field_name, axes, &
   character(len=*), optional, intent(in) :: standard_name !< Standardized name associated with a field
   real,             optional, intent(in) :: missing_value !< A value that indicates missing values in
                                                           !! output files, in unscaled arbitrary units [a]
-  real,             optional, intent(in) :: range(2) !< Valid range of a variable (not used in SIS?)
-                                                     !! in arbitrary units [a]
+  real,             optional, intent(in) :: range(2) !< Valid range of a variable in arbitrary units [a]
   logical,          optional, intent(in) :: mask_variant !< If true a logical mask must be provided with
                                                          !! post_data calls (not used in SIS?)
   logical,          optional, intent(in) :: do_not_log !< If true, do not log something (not used in SIS?)

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -326,7 +326,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_ext = register_diag_field('ice_model', 'EXT', diag%axesT1, Time, &
                'ice modeled', '0 or 1', missing_value=missing)
   IDs%id_cn       = register_diag_field('ice_model', 'CN', diag%axesTc, Time, &
-               'ice concentration', '0-1', missing_value=missing)
+               'ice concentration', units="nondim", range=(/0.,1./) )
   IDs%id_hp       = register_diag_field('ice_model', 'HP', diag%axesT1, Time, &
                'pond thickness', 'm-pond', missing_value=missing) ! mw/new
   IDs%id_hs       = register_diag_field('ice_model', 'HS', diag%axesT1, Time, &
@@ -336,9 +336,9 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_hi       = register_diag_field('ice_model', 'HI', diag%axesT1, Time, &
                'ice thickness', 'm-ice', missing_value=missing)
   IDs%id_sitimefrac = register_diag_field('ice_model', 'sitimefrac', diag%axesT1, Time, &
-               'time fraction of ice cover', '0-1', missing_value=missing)
+               'time fraction of ice cover', units="nondim", range=(/0.,1./) )
   IDs%id_siconc = register_diag_field('ice_model', 'siconc', diag%axesT1, Time, &
-               'ice concentration', '0-1', missing_value=missing)
+               'ice concentration', units="nondim", range=(/0.,1./) )
   IDs%id_siconc_CMOR = register_diag_field('ice_model', 'siconc_CMOR', diag%axesT1, Time, &
                'Sea-Ice Area Percentage', units='%', conversion=100.0, &
                standard_name="SeaIceAreaFraction")
@@ -347,7 +347,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_sivol  = register_diag_field('ice_model', 'sivol', diag%axesT1, Time, &
                'ice volume', 'm-ice', missing_value=missing)
   IDs%id_sisnconc = register_diag_field('ice_model', 'sisnconc', diag%axesT1, Time, &
-               'snow concentration', '0-1', missing_value=missing)
+               'snow concentration', units="nondim", range=(/0.,1./) )
   IDs%id_sisnconc_CMOR = register_diag_field('ice_model', 'sisnconc_CMOR', diag%axesT1, Time, &
                'Snow Area Percentage', units='%', conversion=100.0, missing_value=missing, &
                standard_name="SurfaceSnowAreaFraction")
@@ -389,7 +389,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
                  "If true, call the ridging routines.", default=.false., do_not_log=.true.)
   if (do_ridging) then
     IDs%id_rdgf = register_diag_field('ice_model', 'RDG_FRAC', diag%axesTc, Time, &
-                   'ridged ice fraction', '0-1', missing_value=missing)
+                   'ridged ice fraction', units="nondim", range=(/0.,1./) )
 !   IDs%id_rdg_h = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
 !                  'ice ridge height', units='m', conversion=US%m_to_Z)
   endif


### PR DESCRIPTION
  Set range and corrected the units for 19 nondimensional diagnostics and explicitly named the units arguments in these calls.  Also changed the descriptions of the range arguments to routines in `SIS_diag_mediator.F90` to no longer state that these arguments are unused in SIS2.  All answers are bitwise identical, but there are metadata changes in some diagnostic files,