### PR TITLE
+get_param unit description cleanup

### DIFF
--- a/src/SIS_dyn_bgrid.F90
+++ b/src/SIS_dyn_bgrid.F90
@@ -155,9 +155,8 @@ subroutine SIS_B_dyn_init(Time, G, US, param_file, diag, CS)
                  debuggingParam=.true.)
   call get_param(param_file, mdl, "AIR_WATER_STRESS_TURN_ANGLE", CS%blturn, &
                  "An angle by which to rotate the velocities at the air-water "//&
-                 "boundary in calculating stresses.", units="degrees", &
-                 default=0.0)
-
+                 "boundary in calculating stresses.", &
+                 units="degrees", default=0.0)
 
   CS%id_sigi  = register_diag_field('ice_model','SIGI' ,diag%axesT1, Time,     &
             'first stress invariant', units='nondim')

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -207,8 +207,8 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   call get_param(param_file, mdl, "DT_RHEOLOGY", CS%dt_Rheo, &
                  "The sub-cycling time step for iterating the rheology "//&
                  "and ice momentum equations. If DT_RHEOLOGY is negative, "//&
-                 "the time step is set via NSTEPS_DYN.", units="seconds", &
-                 default=-1.0, scale=US%s_to_T)
+                 "the time step is set via NSTEPS_DYN.", &
+                 units="seconds", default=-1.0, scale=US%s_to_T)
   CS%evp_sub_steps = -1
   if (CS%dt_Rheo <= 0.0) &
     call get_param(param_file, mdl, "NSTEPS_DYN", CS%evp_sub_steps, &

--- a/src/SIS_open_boundary.F90
+++ b/src/SIS_open_boundary.F90
@@ -330,7 +330,7 @@ subroutine open_boundary_config(G, US, param_file, OBC)
                  do_not_log=.not.debug_OBC, debuggingParam=.true.)
     call get_param(param_file, mdl, "OBC_SILLY_VEL", OBC%silly_u, &
                  "A silly value of velocities used outside of open boundary "//&
-                 "conditions for debugging.", units="m/s", default=0.0, scale=US%m_s_to_L_T, &
+                 "conditions for debugging.", units="m s-1", default=0.0, scale=US%m_s_to_L_T, &
                  do_not_log=.not.debug_OBC, debuggingParam=.true.)
     reentrant_x = .false.
     call get_param(param_file, mdl, "REENTRANT_X", reentrant_x, default=.true.)

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1460,7 +1460,7 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "is based on work by Torge Martin.", default=.false.)
   call get_param(param_file, mdl, "ICE_BULK_SALINITY", CS%ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", &
-                 units="g/kg", default=4.0, scale=US%ppt_to_S)
+                 units="g kg-1", default=4.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", CS%ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
@@ -1503,12 +1503,12 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                  "The rate of cooling of ice-free water that should be ice "//&
                  "covered in order to constrained the ice concentration to "//&
                  "track observations.  A suggested value is ~10000 W m-2.", &
-                 units = "W m-2", default=0.0, scale=US%W_m2_to_QRZ_T, &
+                 units="W m-2", default=0.0, scale=US%W_m2_to_QRZ_T, &
                  do_not_log=.not.CS%nudge_sea_ice)
   call get_param(param_file, mdl, "NUDGE_SEA_ICE_TOLERANCE", CS%nudge_conc_tol, &
                  "The tolerance for mismatch in the sea ice concentations "//&
                  "before nudging begins to be applied.  Values of order 0.1 "//&
-                 "should work well.", units = "nondim", default=0.0, &
+                 "should work well.", units="nondim", default=0.0, &
                  do_not_log=.not.CS%nudge_sea_ice)
   call get_param(param_file, mdl, "NUDGE_SEA_ICE_STABILITY", CS%nudge_stab_fac, &
                  "A factor that determines whether the buoyancy flux "//&

--- a/src/SIS_state_initialization.F90
+++ b/src/SIS_state_initialization.F90
@@ -297,11 +297,11 @@ subroutine ice_state_thermo_init(IST, Ice, G, IG, US, PF, init_Time, just_read_p
 
   call get_param(PF, mdl, "ICE_BULK_SALINITY", ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", &
-                 units = "g/kg", default=4.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="g kg-1", default=4.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(PF, mdl, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
-                 units = "nondim", default=0.0, do_not_log=.true.)
+                 units="nondim", default=0.0, do_not_log=.true.)
   if ((ice_bulk_salin < 0.0) .or. (ice_rel_salin > 0.0)) ice_bulk_salin = 0.0
 
   S_col(:) = 0.0
@@ -949,11 +949,11 @@ subroutine read_archaic_thermo_restarts(Ice, IST, G, IG, US, PF, dirs, restart_f
 
   call get_param(PF, mdl, "ICE_BULK_SALINITY", ice_bulk_salin, &
                  "The fixed bulk salinity of sea ice.", &
-                 units="g/kg", default=4.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="g kg-1", default=4.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(PF, mdl, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
-                 units = "nondim", default=0.0, do_not_log=.true.)
+                 units="nondim", default=0.0, do_not_log=.true.)
   if ((ice_bulk_salin < 0.0) .or. (ice_rel_salin > 0.0)) ice_bulk_salin = 0.0
 
   restart_path = trim(dirs%restart_input_dir)//trim(restart_file)

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -1706,8 +1706,6 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
     str_x, str_y, stress_mag ! Temporary stress arrays
 
   real :: g_Earth        !   The gravitational acceleration [L2 Z-1 T-2 ~> m s-2].
-  real :: ice_bulk_salin ! The globally constant sea ice bulk salinity [S ~> gSalt kg-1] = [S ~> ppt]
-                         ! that is used to calculate the ocean salt flux.
   real :: ice_rel_salin  ! The initial bulk salinity of sea-ice relative to the
                          ! salinity of the water from which it formed [nondim].
   real :: coszen_IC      ! A constant value that is used to initialize
@@ -1873,7 +1871,7 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
 
   call get_param(param_file, mdl, "G_EARTH", g_Earth, &
                  "The gravitational acceleration of the Earth.", &
-                 units="m s-2", default = 9.80, scale=US%m_s_to_L_T**2*US%Z_to_m)
+                 units="m s-2", default=9.80, scale=US%m_s_to_L_T**2*US%Z_to_m)
 
   call get_param(param_file, mdl, "MOMENTUM_ROUGH_ICE", mom_rough_ice, &
                  "The default momentum roughness length scale for the ocean.", &
@@ -1934,14 +1932,10 @@ subroutine ice_model_init(Ice, Time_Init, Time, Time_step_fast, Time_step_slow, 
                  "If true, the sea ice is being given wind stresses with "//&
                  "the atmospheric sign convention, and need to have their sign changed.", &
                  default=.true.)
-  call get_param(param_file, mdl, "ICE_BULK_SALINITY", ice_bulk_salin, &
-                 "The fixed bulk salinity of sea ice.", units = "g/kg", &
-                 default=4.0, do_not_log=.true.)
   call get_param(param_file, mdl, "ICE_RELATIVE_SALINITY", ice_rel_salin, &
                  "The initial salinity of sea ice as a fraction of the "//&
                  "salinity of the seawater from which it formed.", &
-                 units = "nondim", default=0.0, do_not_log=.true.)
-  if ((ice_bulk_salin < 0.0) .or. (ice_rel_salin > 0.0)) ice_bulk_salin = 0.0
+                 units="nondim", default=0.0, do_not_log=.true.)
 
   call get_param(param_file, mdl, "APPLY_SLP_TO_OCEAN", slp2ocean, &
                  "If true, apply the atmospheric sea level pressure to the ocean.", &

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -52,10 +52,10 @@ type, public :: ice_ridging_CS ; private
                               !! rebin for us.
   real :: mu_rdg = 3.0 !< e-folding scale of ridged ice, new_rdg_partic (m^0.5)
   real :: area_underflow = 0.0 !< a non-dimesional fractional area underflow limit for the sea-ice
-                               !! ridging scheme. This is defaulted to zero, but a reasonable
+                               !! ridging scheme [nondim]. This is defaulted to zero, but a reasonable
                                !! value might be 10^-26 which for a km square grid cell
                                !! would equate to an Angstrom scale ice patch.
-  real :: Cs_frac = 0.25       !< fraction of shear energy contrbtng to ridging
+  real :: Cs_frac = 0.25       !< fraction of shear energy contributing to ridging [nondim]
 end type ice_ridging_CS
 
 contains
@@ -89,7 +89,7 @@ subroutine ice_ridging_init(G, IG, PF, CS, US)
     call get_param(PF, mdl, "RIDGE_AREA_UNDERFLOW", CS%area_underflow, &
                    "A fractional area limit below which ice fraction is set to zero "//&
                    "A reasonable default value for a km scale grid cell is 10^-24.",&
-                   units="none", default=0.0)
+                   units="nondim", default=0.0)
   endif
   call get_param(PF, mdl, "ICEPACK_CLEANUP", CS%do_cleanup, &
                  "Tell icepack_step_ridge to call itd_cleanup for us.", default=.false.)


### PR DESCRIPTION
  Cleaned up various aspects of the units arguments to `get_param()` calls to follow the patterns used elsewhere in the SIS2 and MOM6 code.  These include:

  - 2 instances where the units arguments were moved to be on the same line as the default arguments.
  - 6 instances where "m/s" or "g/kg" were changed to "m s-1" or "g kg-1" to align with CMIP standard syntax.
  - 8 instances where there was extra space around the name assignment of an argument (e.g., changing 'units = ...' to 'units=...').
  - 1 instance where the units of "none" were changed to "nondim"

In addition, an unused and unlogged call to read ICE_BULK_SALNITY was eliminated from ice_model_init.  All solutions are bitwise identical, but there are minor formatting changes to the units logged in the SIS_parameter_doc files for some variables.