### PR TITLE
+Fix dimensional rescaling of DT_ICE_DYNAMICS

### DIFF
--- a/src/SIS_tracer_advect.F90
+++ b/src/SIS_tracer_advect.F90
@@ -1849,10 +1849,11 @@ end subroutine advect_tracers_thicker
 
 !> Initialze allocate the control structure for the SIS_tracer_advect module
 !! and set its parameters
-subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
+subroutine SIS_tracer_advect_init(Time, G, US, param_file, diag, CS, scheme)
   type(time_type),     target, intent(in)    :: Time !< The sea-ice model's clock,
                                                      !! set with the current model time.
   type(SIS_hor_grid_type),     intent(in)    :: G    !< The horizontal grid type
+  type(unit_scale_type),       intent(in)    :: US  !< A structure with unit conversion factors
   type(param_file_type),       intent(in)    :: param_file !< A structure to parse for run-time parameters
   type(SIS_diag_ctrl), target, intent(inout) :: diag !< A structure that is used to regulate diagnostic output
   type(SIS_tracer_advect_CS),  pointer       :: CS   !< The control structure returned by a previous
@@ -1881,8 +1882,8 @@ subroutine SIS_tracer_advect_init(Time, G, param_file, diag, CS, scheme)
   call get_param(param_file, mdl, "DT_ICE_DYNAMICS", CS%dt, &
                  "The time step used for the slow ice dynamics, including "//&
                  "stepping the continuity equation and interactions between "//&
-                 "the ice mass field and velocities.", units="s", &
-                 default=-1.0, do_not_log=.true.)
+                 "the ice mass field and velocities.", &
+                 units="s", default=-1.0, scale=US%s_to_T, do_not_log=.true.)
   call get_param(param_file, mdl, "DEBUG", debug, default=.false.)
   call get_param(param_file, mdl, "DEBUG_SLOW_ICE", CS%debug, &
                  "If true, write out verbose debugging data on the slow ice PEs.", &

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1336,13 +1336,13 @@ subroutine SIS_transport_init(Time, G, IG, US, param_file, diag, CS, continuity_
 
   call SIS_continuity_init(Time, G, US, param_file, diag, CS%continuity_CSp, &
                            CS_cvr=cover_trans_CSp)
-  call SIS_tracer_advect_init(Time, G, param_file, diag, CS%SIS_tr_adv_CSp)
+  call SIS_tracer_advect_init(Time, G, US, param_file, diag, CS%SIS_tr_adv_CSp)
   if (CS%do_ridging) &
       call ice_ridging_init(G, IG, param_file, CS%ice_ridging_CSp, US)
 
   if (present(continuity_CSp)) continuity_CSp => CS%continuity_CSp
 
-  call SIS_tracer_advect_init(Time, G, param_file, diag, CS%SIS_thick_adv_CSp, scheme=scheme)
+  call SIS_tracer_advect_init(Time, G, US, param_file, diag, CS%SIS_thick_adv_CSp, scheme=scheme)
 
   CS%id_ix_trans = register_diag_field('ice_model', 'IX_TRANS', diag%axesCu1, Time, &
                'x-direction ice transport', units='kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &


### PR DESCRIPTION
  Added the missing dimensional rescaling factor for `DT_ICE_DYNAMICS` in `SIS_tracer_advect_init()`.  This commit could change answers in some case when dimensional rescaling of time is being tested in SIS2, but because this particular timestep is only used to determine the maximum number of iterations for the advection of ice thicknesses and tracers, and the maximum number of iterations is always at least 1, this appears to have gone undetected heretofore in the short tests with small CFL numbers that we have used for dimensional consistency testing in SIS2.  This change includes adding a new `unit_scale_type` argument to this same routine.  All answers are bitwise identical when `T_RESCALE_POWER` is 0 in SIS_input (as is always the case in production runs), but there is a new argument to a publicly visible interface.