### PR TITLE
Add CMOR names for 22 SIS2 diagnostics

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -227,7 +227,10 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_snofl    = register_SIS_diag_field('ice_model', 'SNOWFL', diag%axesT1, Time, &
                'rate of snow fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_rain     = register_SIS_diag_field('ice_model', 'RAIN', diag%axesT1, Time, &
-               'rate of rain fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
+               'rate of rain fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing, &
+               cmor_field_name='sipr', &
+               cmor_standard_name='rainfall_flux', &
+               cmor_long_name='Rainfall Rate over Sea Ice')
   FIA%id_runoff   = register_SIS_diag_field('ice_model', 'RUNOFF', diag%axesT1, Time, &
                'liquid runoff', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_calving  = register_SIS_diag_field('ice_model', 'CALVING', diag%axesT1, Time, &
@@ -239,21 +242,30 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_evap     = register_SIS_diag_field('ice_model', 'EVAP',diag%axesT1, Time, &
                'evaporation', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   IOF%id_saltf    = register_SIS_diag_field('ice_model', 'SALTF', diag%axesT1, Time, &
-               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing)
+               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing, &
+               cmor_field_name='siflsaltbot', &
+               cmor_standard_name='downward_sea_ice_basal_salt_flux', &
+               cmor_long_name='Salt Flux from Sea Ice')
+
   FIA%id_tmelt    = register_SIS_diag_field('ice_model', 'TMELT', diag%axesT1, Time, &
                'upper surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
   FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT', diag%axesT1, Time, &
                'bottom surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
   FIA%id_bheat    = register_SIS_diag_field('ice_model', 'BHEAT', diag%axesT1, Time, &
-               'ocean to ice heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'ocean to ice heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
+               cmor_field_name='siflsensbot', &
+               cmor_standard_name='upward_sea_ice_basal_heat_flux', &
+               cmor_long_name='Net Upward Sensible Heat Flux under Sea Ice')
 
   if (coupler_type_initialized(IOF%tr_flux_ocn_top)) &
     call coupler_type_set_diags(IOF%tr_flux_ocn_top, 'ice_model', diag%axesT1%handles, Time)
 
-
   FIA%id_sw_dn   = register_SIS_diag_field('ice_model', 'SWDN', diag%axesT1, Time, &
                'Downward shortwave heat flux at the bottom of the atmosphere', &
-               'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
+               'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
+               cmor_field_name='siflswdtop', &
+               cmor_standard_name='surface_downwelling_shortwave_flux_in_air', &
+               cmor_long_name='Downwelling Shortwave Flux over Sea Ice')
   FIA%id_albedo  = register_SIS_diag_field('ice_model', 'ALB', diag%axesT1, Time, &
                'Shortwave flux weighted surface albedo, or 1 if no SW', '0-1', &
                missing_value=missing)
@@ -399,10 +411,16 @@ subroutine ice_diags_fast_init(Rad, G, IG, diag, Time, component)
   nLay = IG%NkIce
 
   Rad%id_swdn  = register_SIS_diag_field(trim(comp_name),'SWDN', diag%axesT1, Time, &
-             'downward shortwave flux', 'W/m^2', missing_value=missing)
+             'downward shortwave flux', 'W/m^2', missing_value=missing, &
+             cmor_field_name='siflswdtop', &
+             cmor_standard_name='surface_downwelling_shortwave_flux_in_air', &
+             cmor_long_name='Downwelling Shortwave Flux over Sea Ice')
   Rad%id_lwdn  = register_SIS_diag_field(trim(comp_name),'LWDN', diag%axesT1, Time, &
-             'downward longwave flux', 'W/m^2', missing_value=missing)
-
+             'downward longwave flux', 'W/m^2', missing_value=missing, &
+             cmor_field_name='sifllwdtop', &
+             cmor_standard_name='surface_downwelling_longwave_flux_in_air', &
+             cmor_long_name='Downwelling Longwave Flux over Sea Ice')
+             
   Rad%id_alb      = register_SIS_diag_field(trim(comp_name),'ALB',diag%axesT1, Time, &
                'surface albedo','0-1', missing_value=missing )
   Rad%id_coszen   = register_SIS_diag_field(trim(comp_name),'coszen',diag%axesT1, Time, &

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -227,7 +227,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_snofl    = register_SIS_diag_field('ice_model', 'SNOWFL', diag%axesT1, Time, &
                'rate of snow fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   FIA%id_rain     = register_SIS_diag_field('ice_model', 'RAIN', diag%axesT1, Time, &
-               'rate of rain fall', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing, &
+               'rate of rain fall', units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, missing_value=missing, &
                cmor_field_name='sipr', &
                cmor_standard_name='rainfall_flux', &
                cmor_long_name='Rainfall Rate over Sea Ice')
@@ -242,7 +242,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_evap     = register_SIS_diag_field('ice_model', 'EVAP',diag%axesT1, Time, &
                'evaporation', 'kg/(m^2*s)', conversion=US%RZ_T_to_kg_m2s, missing_value=missing)
   IOF%id_saltf    = register_SIS_diag_field('ice_model', 'SALTF', diag%axesT1, Time, &
-               'ice to ocean salt flux', 'kg/(m^2*s)', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing, &
+               'ice to ocean salt flux', units='kg m-2 s-1', conversion=US%S_to_ppt*US%RZ_T_to_kg_m2s, missing_value=missing, &
                cmor_field_name='siflsaltbot', &
                cmor_standard_name='downward_sea_ice_basal_salt_flux', &
                cmor_long_name='Salt Flux from Sea Ice')
@@ -252,7 +252,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   FIA%id_bmelt    = register_SIS_diag_field('ice_model', 'BMELT', diag%axesT1, Time, &
                'bottom surface melting energy flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing)
   FIA%id_bheat    = register_SIS_diag_field('ice_model', 'BHEAT', diag%axesT1, Time, &
-               'ocean to ice heat flux', 'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
+               'ocean to ice heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
                cmor_field_name='siflsensbot', &
                cmor_standard_name='upward_sea_ice_basal_heat_flux', &
                cmor_long_name='Net Upward Sensible Heat Flux under Sea Ice')
@@ -262,7 +262,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
 
   FIA%id_sw_dn   = register_SIS_diag_field('ice_model', 'SWDN', diag%axesT1, Time, &
                'Downward shortwave heat flux at the bottom of the atmosphere', &
-               'W/m^2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
+               units='W m-2', conversion=US%QRZ_T_to_W_m2, missing_value=missing, &
                cmor_field_name='siflswdtop', &
                cmor_standard_name='surface_downwelling_shortwave_flux_in_air', &
                cmor_long_name='Downwelling Shortwave Flux over Sea Ice')
@@ -411,12 +411,12 @@ subroutine ice_diags_fast_init(Rad, G, IG, diag, Time, component)
   nLay = IG%NkIce
 
   Rad%id_swdn  = register_SIS_diag_field(trim(comp_name),'SWDN', diag%axesT1, Time, &
-             'downward shortwave flux', 'W/m^2', missing_value=missing, &
+             'downward shortwave flux', units='W m-2', missing_value=missing, &
              cmor_field_name='siflswdtop', &
              cmor_standard_name='surface_downwelling_shortwave_flux_in_air', &
              cmor_long_name='Downwelling Shortwave Flux over Sea Ice')
   Rad%id_lwdn  = register_SIS_diag_field(trim(comp_name),'LWDN', diag%axesT1, Time, &
-             'downward longwave flux', 'W/m^2', missing_value=missing, &
+             'downward longwave flux', units='W m-2', missing_value=missing, &
              cmor_field_name='sifllwdtop', &
              cmor_standard_name='surface_downwelling_longwave_flux_in_air', &
              cmor_long_name='Downwelling Longwave Flux over Sea Ice')

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -585,7 +585,7 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_ci_hifreq  = register_diag_field('ice_model', 'CI_hf', diag%axesT1, Time, &
             'Summed concentration of ice at t-points', 'nondim', missing_value=missing)
   CS%id_stren_hifreq = register_diag_field('ice_model','STRENGTH_hf' ,diag%axesT1, Time, &
-            'ice strength', 'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing, &
+            'ice strength', units='Pa m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing, &
             cmor_field_name='sicompstren', &
             cmor_standard_name='compressive_strength_of_sea_ice', &
             cmor_long_name='Compressive Sea Ice Strength')

--- a/src/SIS_dyn_cgrid.F90
+++ b/src/SIS_dyn_cgrid.F90
@@ -403,16 +403,28 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
             'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing)
   CS%id_fix   = register_diag_field('ice_model', 'FI_X', diag%axesCu1, Time,   &
             'ice internal stress - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforceintstrx', &
+            cmor_standard_name='sea_ice_x_internal_stress', &
+            cmor_long_name='Internal Stress Term in Force Balance (X-Component)')
   CS%id_fiy   = register_diag_field('ice_model', 'FI_Y', diag%axesCv1, Time,   &
             'ice internal stress - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforceintstry', &
+            cmor_standard_name='sea_ice_y_internal_stress', &
+            cmor_long_name='Internal Stress Term in Force Balance (Y-Component)')
   CS%id_fcx   = register_diag_field('ice_model', 'FC_X', diag%axesCu1, Time,   &
             'Coriolis force - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforcecoriolx', &
+            cmor_standard_name='sea_ice_x_force_per_unit_area_due_to_coriolis_effect', &
+            cmor_long_name='Coriolis Force Term in Force Balance (X-Component)')
   CS%id_fcy   = register_diag_field('ice_model', 'FC_Y', diag%axesCv1, Time,   &
             'Coriolis force - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforcecorioly', &
+            cmor_standard_name='sea_ice_y_force_per_unit_area_due_to_coriolis_effect', &
+            cmor_long_name='Coriolis Force Term in Force Balance (Y-Component)')
   CS%id_Coru   = register_diag_field('ice_model', 'Cor_ui', diag%axesCu1, Time,&
             'Coriolis ice acceleration - x component', &
             'm s-2', conversion=US%L_T_to_m_s*US%s_to_T, &
@@ -424,11 +436,17 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_fpx   = register_diag_field('ice_model', 'FP_X', diag%axesCu1, Time,   &
             'Pressure force - x component', &
             'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforcetiltx', &
+            cmor_standard_name='sea_ice_x_force_per_unit_area_due_to_sea_surface_tilt', &
+            cmor_long_name='Sea-Surface Tilt Term in Force Balance (X-Component)')
   CS%id_fpy   = register_diag_field('ice_model', 'FP_Y', diag%axesCv1, Time,   &
             'Pressure force - y component', &
             'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='siforcetilty', &
+            cmor_standard_name='sea_ice_y_force_per_unit_area_due_to_sea_surface_tilt', &
+            cmor_long_name='Sea-Surface Tilt Term in Force Balance (Y-Component)')
   CS%id_PFu   = register_diag_field('ice_model', 'Pfa_ui', diag%axesCu1, Time, &
             'Pressure-force ice acceleration - x component', &
             'm s-2',  conversion=US%L_T_to_m_s*US%s_to_T, &
@@ -440,11 +458,17 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_fwx   = register_diag_field('ice_model', 'FW_X', diag%axesCu1, Time,   &
             'water stress on ice - x component', &
             'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='sistrxubot', &
+            cmor_standard_name='upward_x_stress_at_sea_ice_base', &
+            cmor_long_name='X-Component of Ocean Stress on Sea Ice')
   CS%id_fwy   = register_diag_field('ice_model', 'FW_Y', diag%axesCv1, Time,   &
             'water stress on ice - y component', &
             'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-            missing_value=missing, interp_method='none')
+            missing_value=missing, interp_method='none', &
+            cmor_field_name='sistryubot', &
+            cmor_standard_name='upward_y_stress_at_sea_ice_base', &
+            cmor_long_name='Y-Component of Ocean Stress on Sea Ice')
   CS%id_flfx  = register_diag_field('ice_model', 'FLF_X', diag%axesCu1, Time,   &
             'land-fast bottom stress on ice - x component', &
             'Pa',  conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
@@ -549,13 +573,22 @@ subroutine SIS_C_dyn_init(Time, G, US, param_file, diag, CS, ntrunc)
   CS%id_sh_s_hifreq = register_diag_field('ice_model', 'sh_s_hf', diag%axesB1, Time, &
             'ice shearing rate', 's-1', conversion=US%s_to_T, missing_value=missing)
   CS%id_sigi_hifreq  = register_diag_field('ice_model','sigI_hf' ,diag%axesT1, Time, &
-            'first stress invariant', 'none', missing_value=missing)
+            'first stress invariant', 'none', missing_value=missing, &
+            cmor_field_name='sistressave', &
+            cmor_standard_name='sea_ice_average_normal_horizontal_stress', &
+            cmor_long_name='Average Normal Stress in Sea Ice')
   CS%id_sigii_hifreq = register_diag_field('ice_model','sigII_hf' ,diag%axesT1, Time, &
-            'second stress invariant', 'none', missing_value=missing)
+            'second stress invariant', 'none', missing_value=missing, &
+            cmor_field_name='sistressmax', &
+            cmor_standard_name='maximum_over_coordinate_rotation_of_sea_ice_horizontal_shear_stress', &
+            cmor_long_name='Maximum Shear Stress in Sea Ice')
   CS%id_ci_hifreq  = register_diag_field('ice_model', 'CI_hf', diag%axesT1, Time, &
             'Summed concentration of ice at t-points', 'nondim', missing_value=missing)
   CS%id_stren_hifreq = register_diag_field('ice_model','STRENGTH_hf' ,diag%axesT1, Time, &
-            'ice strength', 'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing)
+            'ice strength', 'Pa*m', conversion=US%RZ_to_kg_m2*US%L_T_to_m_s**2, missing_value=missing, &
+            cmor_field_name='sicompstren', &
+            cmor_standard_name='compressive_strength_of_sea_ice', &
+            cmor_long_name='Compressive Sea Ice Strength')
 
   CS%id_siu = register_diag_field('ice_model', 'siu', diag%axesT1, Time, &
             'ice velocity - x component', 'm/s', missing_value=missing,  &

--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -2499,17 +2499,30 @@ subroutine SIS_dyn_trans_init(Time, G, US, IG, param_file, diag, CS, output_dir,
   if (CS%Cgrid_dyn) then
     CS%id_fax = register_diag_field('ice_model', 'FA_X', diag%axesCu1, Time, &
                'Air stress on ice on C-grid - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-                missing_value=missing, interp_method='none')
+                missing_value=missing, interp_method='none', &
+                cmor_field_name='sistrxdtop', &
+                cmor_standard_name='surface_downward_x_stress', &
+                cmor_long_name='X-Component of Atmospheric Stress on Sea Ice')
+
     CS%id_fay = register_diag_field('ice_model', 'FA_Y', diag%axesCv1, Time, &
                'Air stress on ice on C-grid - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               missing_value=missing, interp_method='none', &
+               cmor_field_name='sistrydtop', &
+               cmor_standard_name='surface_downward_y_stress', &
+               cmor_long_name='Y-Component of Atmospheric Stress on Sea Ice')
   else
     CS%id_fax = register_diag_field('ice_model', 'FA_X', diag%axesB1, Time, &
                'air stress on ice - x component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               missing_value=missing, interp_method='none', &
+                cmor_field_name='sistrxdtop', &
+                cmor_standard_name='surface_downward_x_stress', &
+                cmor_long_name='X-Component of Atmospheric Stress on Sea Ice')
     CS%id_fay = register_diag_field('ice_model', 'FA_Y', diag%axesB1, Time, &
                'air stress on ice - y component', 'Pa', conversion=US%RZ_T_to_kg_m2s*US%L_T_to_m_s, &
-               missing_value=missing, interp_method='none')
+               missing_value=missing, interp_method='none', &
+               cmor_field_name='sistrydtop', &
+               cmor_standard_name='surface_downward_y_stress', &
+               cmor_long_name='Y-Component of Atmospheric Stress on Sea Ice')
   endif
 
   call register_ice_state_diagnostics(Time, IG, US, param_file, diag, CS%IDs)

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -326,7 +326,10 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_ext = register_diag_field('ice_model', 'EXT', diag%axesT1, Time, &
                'ice modeled', '0 or 1', missing_value=missing)
   IDs%id_cn       = register_diag_field('ice_model', 'CN', diag%axesTc, Time, &
-               'ice concentration', '0-1', missing_value=missing)
+               'ice concentration', '0-1', missing_value=missing, &
+               cmor_field_name='siitdconc', &
+               cmor_standard_name='sea_ice_area_fraction', &
+               cmor_long_name='Sea-Ice Area Percentages in Ice Thickness Categories')
   IDs%id_hp       = register_diag_field('ice_model', 'HP', diag%axesT1, Time, &
                'pond thickness', 'm-pond', missing_value=missing) ! mw/new
   IDs%id_hs       = register_diag_field('ice_model', 'HS', diag%axesT1, Time, &
@@ -357,7 +360,11 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_t_iceav = register_diag_field('ice_model', 'T_bulkice', diag%axesT1, Time, &
                'Volume-averaged ice temperature', 'C', conversion=US%C_to_degC, missing_value=missing)
   IDs%id_s_iceav = register_diag_field('ice_model', 'S_bulkice', diag%axesT1, Time, &
-               'Volume-averaged ice salinity', 'g/kg', conversion=US%S_to_ppt, missing_value=missing)
+               'Volume-averaged ice salinity', 'g/kg', conversion=US%S_to_ppt, missing_value=missing, &
+               cmor_field_name='sisali', &
+               cmor_standard_name='sea_ice_salinity', &
+               cmor_long_name='Sea-Ice Salinity')
+
   call safe_alloc_ids_1d(IDs%id_t, nLay)
   call safe_alloc_ids_1d(IDs%id_sal, nLay)
   do n=1,nLay

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -360,7 +360,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_t_iceav = register_diag_field('ice_model', 'T_bulkice', diag%axesT1, Time, &
                'Volume-averaged ice temperature', 'C', conversion=US%C_to_degC, missing_value=missing)
   IDs%id_s_iceav = register_diag_field('ice_model', 'S_bulkice', diag%axesT1, Time, &
-               'Volume-averaged ice salinity', 'g/kg', conversion=US%S_to_ppt, missing_value=missing, &
+               'Volume-averaged ice salinity', units='g kg-1', conversion=US%S_to_ppt, missing_value=missing, &
                cmor_field_name='sisali', &
                cmor_standard_name='sea_ice_salinity', &
                cmor_long_name='Sea-Ice Salinity')

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1252,13 +1252,13 @@ subroutine SIS_transport_init(Time, G, IG, US, param_file, diag, CS, continuity_
   call SIS_tracer_advect_init(Time, G, param_file, diag, CS%SIS_thick_adv_CSp, scheme=scheme)
 
   CS%id_ix_trans = register_diag_field('ice_model', 'IX_TRANS', diag%axesCu1, Time, &
-               'x-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
+               'x-direction ice transport', units='kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
                missing_value=missing, interp_method='none', &
                cmor_field_name='sidmasstranx', &
                cmor_standard_name='sea_ice_x_transport', &
                cmor_long_name='X-Component of Sea-Ice Mass Transport')
   CS%id_iy_trans = register_diag_field('ice_model', 'IY_TRANS', diag%axesCv1, Time, &
-               'y-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
+               'y-direction ice transport', units='kg s-1', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
                missing_value=missing, interp_method='none', &
                cmor_field_name='sidmasstrany', &
                cmor_standard_name='sea_ice_y_transport', &

--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -1253,10 +1253,16 @@ subroutine SIS_transport_init(Time, G, IG, US, param_file, diag, CS, continuity_
 
   CS%id_ix_trans = register_diag_field('ice_model', 'IX_TRANS', diag%axesCu1, Time, &
                'x-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
-               missing_value=missing, interp_method='none')
+               missing_value=missing, interp_method='none', &
+               cmor_field_name='sidmasstranx', &
+               cmor_standard_name='sea_ice_x_transport', &
+               cmor_long_name='X-Component of Sea-Ice Mass Transport')
   CS%id_iy_trans = register_diag_field('ice_model', 'IY_TRANS', diag%axesCv1, Time, &
                'y-direction ice transport', 'kg/s', conversion=US%RZ_T_to_kg_m2s*US%L_to_m**2, &
-               missing_value=missing, interp_method='none')
+               missing_value=missing, interp_method='none', &
+               cmor_field_name='sidmasstrany', &
+               cmor_standard_name='sea_ice_y_transport', &
+               cmor_long_name='Y-Component of Sea-Ice Mass Transport')
   CS%id_xprt = register_diag_field('ice_model', 'XPRT', diag%axesT1, Time, &
                'frozen water transport convergence', 'kg/(m^2*yr)', conversion=US%RZ_to_kg_m2, &
                missing_value=missing)


### PR DESCRIPTION
This PR adds CMOR names for 22 existing SIS2 diagnostics, based on the SIMIP CMIP7 naming conventions. SIS2 users can now save these diagnostics using CMOR names or the original SIS2 names (or both). This PR makes use of the newly added CMOR name functionality in SIS_diag_mediator (thanks @Hallberg-NOAA). Solutions are bitwise identical.