### PR TITLE
Remove redundant snow-to-ice diagnostics and remove diagnostic ranges

### DIFF
--- a/src/SIS2_ice_thm.F90
+++ b/src/SIS2_ice_thm.F90
@@ -1008,7 +1008,7 @@ end subroutine ice_check
 subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
                            snow, rain, evap, tmlt, bmlt, NkIce, npassive, TrLay, &
                            heat_to_ocn, h2o_ice_to_ocn, h2o_ocn_to_ice, evap_from_ocn, &
-                           snow_to_ice, s2i_i, s2i_s, salt_to_ice, ITV, US, CS, ablation, &
+                           snow_to_ice, salt_to_ice, ITV, US, CS, ablation, &
                            ablation_i, ablation_s, enthalpy_evap, enthalpy_melt, enthalpy_freeze, &
                            evap_i, evap_s)
   ! mw/new - melt pond - added first two arguments & rain
@@ -1036,8 +1036,6 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
   real, intent(  out) :: h2o_ocn_to_ice !< liquid water flux from ocean [R Z ~> kg m-2]
   real, intent(  out) :: evap_from_ocn  !< evaporation flux from ocean [R Z ~> kg m-2]
   real, intent(  out) :: snow_to_ice !< snow below waterline becomes ice [R Z ~> kg m-2]
-  real, intent(  out) :: s2i_i       !< snow below waterline becomes ice (ice flux) [R Z ~> kg m-2]
-  real, intent(  out) :: s2i_s       !< snow below waterline becomes ice (snow flux) [R Z ~> kg m-2]
   real, intent(  out) :: salt_to_ice !< Net flux of salt to the ice [R Z S ~> gSalt m-2].
   type(ice_thermo_type), intent(in) :: ITV !< The ice thermodynamic parameter structure.
   type(unit_scale_type), intent(in) :: US  !< A structure with unit conversion factors
@@ -1104,7 +1102,6 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
 
   evap_from_ocn = 0.0 ! for excess evap-melt
   h2o_ocn_to_ice = 0.0 ; h2o_ice_to_ocn = 0.0 ; snow_to_ice  = 0.0
-  s2i_i = 0.0 ; s2i_s = 0.0
   h2o_to_pond = 0.0
   h2o_from_pond = 0.0
   salt_to_ice = 0.0
@@ -1307,7 +1304,6 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
     snow_to_ice = min(m_submerged - mtot_ice, m_lay(0)) ! need ice from snow
 
     m_lay(0) = m_lay(0) - snow_to_ice
-    s2i_s = s2i_s - snow_to_ice
 
     ! Add ice to the topmost layer and dilute its salinity.
     Enthalpy(1) = (m_lay(1)*Enthalpy(1) + snow_to_ice*Enthalpy(0)) / &
@@ -1317,7 +1313,6 @@ subroutine ice_resize_SIS2(a_ice, m_pond, m_lay, Enthalpy, Sice_therm, Salin, &
       TrLay(1,tr) = TrLay(1,tr) * m_lay(1) / (m_lay(1) + snow_to_ice)
     enddo
     m_lay(1) = m_lay(1) + snow_to_ice
-    s2i_i = s2i_i + snow_to_ice
   else
     snow_to_ice = 0.0
   endif

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -281,8 +281,8 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
                cmor_standard_name='surface_downwelling_shortwave_flux_in_air', &
                cmor_long_name='Downwelling Shortwave Flux over Sea Ice')
   FIA%id_albedo  = register_SIS_diag_field('ice_model', 'ALB', diag%axesT1, Time, &
-               'Shortwave flux weighted surface albedo, or 1 if no SW', &
-               units="nondim", range=(/0.,1./))
+               'Shortwave flux weighted surface albedo, or 1 if no SW [0,1]', &
+               units="nondim" )
   FIA%id_sw_vis   = register_SIS_diag_field('ice_model', 'SW_VIS', diag%axesT1, Time, &
                'visible shortwave heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)
   FIA%id_sw_dir   = register_SIS_diag_field('ice_model', 'SW_DIR', diag%axesT1, Time, &
@@ -443,43 +443,41 @@ subroutine ice_diags_fast_init(Rad, G, IG, diag, Time, component)
              cmor_long_name='Downwelling Longwave Flux over Sea Ice')
  
   Rad%id_alb      = register_SIS_diag_field(trim(comp_name), 'ALB', diag%axesT1, Time, &
-               'surface albedo', units="nondim", range=(/0.,1./) )
+               'surface albedo [0,1]', units="nondim" )
   Rad%id_coszen   = register_SIS_diag_field(trim(comp_name), 'coszen', diag%axesT1, Time, &
-               'cosine of the solar zenith angle for the next radiation step', &
-               units="nondim", range=(/-1.,1./) )
+               'cosine of the solar zenith angle for the next radiation step [-1,1]', &
+               units="nondim" )
   Rad%id_sw_abs_sfc= register_SIS_diag_field(trim(comp_name), 'sw_abs_sfc', diag%axesT1, Time, &
-               'SW frac. abs. at the ice surface', units="nondim", range=(/0.,1./) )
+               'SW frac. abs. at the ice surface [0,1]', units="nondim" )
   Rad%id_sw_abs_snow= register_SIS_diag_field(trim(comp_name), 'sw_abs_snow', diag%axesT1, Time, &
-               'SW frac. abs. in snow', units="nondim", range=(/0.,1./) )
+               'SW frac. abs. in snow [0,1]', units="nondim" )
 
   call safe_alloc_ids_1d(Rad%id_sw_abs_ice, nLay)
   do n=1,nLay
     write(nstr, '(I4)') n ; nstr = adjustl(nstr)
     Rad%id_sw_abs_ice(n) = register_SIS_diag_field(trim(comp_name),'sw_abs_ice'//trim(nstr), &
-                 diag%axesT1, Time, 'SW fraction absorbed in ice layer '//trim(nstr), &
-                 units="nondim", range=(/0.,1./) )
+                 diag%axesT1, Time, 'SW fraction absorbed in ice layer '//trim(nstr)//' [0,1]', &
+                 units="nondim" )
   enddo
   Rad%id_sw_pen= register_SIS_diag_field(trim(comp_name),'sw_pen', diag%axesT1, Time, &
-               'SW fraction penetrating the ice surface', &
-               units="nondim", range=(/0.,1./) )
+               'SW fraction penetrating the ice surface [0,1]', units="nondim" )
   Rad%id_sw_abs_ocn= register_SIS_diag_field(trim(comp_name),'sw_abs_ocn', diag%axesT1, Time, &
-               'SW fraction sent to the ocean', units="nondim", range=(/0.,1./) )
-
+               'SW fraction sent to the ocean [0,1]', units="nondim" )
 
   Rad%id_alb_vis_dir = register_SIS_diag_field(trim(comp_name), 'alb_vis_dir', diag%axesT1, Time, &
-               'ice surface albedo vis_dir', units="nondim", range=(/0.,1./) )
+               'ice surface albedo vis_dir [0,1]', units="nondim" )
   Rad%id_alb_vis_dif = register_SIS_diag_field(trim(comp_name), 'alb_vis_dif', diag%axesT1, Time, &
-               'ice surface albedo vis_dif', units="nondim", range=(/0.,1./) )
+               'ice surface albedo vis_dif [0,1]', units="nondim" )
   Rad%id_alb_nir_dir = register_SIS_diag_field(trim(comp_name), 'alb_nir_dir', diag%axesT1, Time, &
-               'ice surface albedo nir_dir', units="nondim", range=(/0.,1./) )
+               'ice surface albedo nir_dir [0,1]', units="nondim" )
   Rad%id_alb_nir_dif = register_SIS_diag_field(trim(comp_name), 'alb_nir_dif', diag%axesT1, Time, &
-               'ice surface albedo nir_dif', units="nondim", range=(/0.,1./) )
+               'ice surface albedo nir_dif [0,1]', units="nondim" )
   Rad%id_tskin = register_SIS_diag_field(trim(comp_name),'Tskin', diag%axesTc, Time, &
                'Skin temperature', units='degC', conversion=G%US%C_to_degC)
   Rad%id_cn = register_SIS_diag_field(trim(comp_name),'CN_fast', diag%axesTc, Time, &
-               'Category concentration', units="nondim", range=(/0.,1./) )
+               'Category concentration [0,1]', units="nondim" )
   Rad%id_mi = register_SIS_diag_field(trim(comp_name),'MI_fast', diag%axesTc, Time, &
-               'Category concentration', units="nondim", range=(/0.,1./) )
+               'Category concentration [0,1]', units="nondim" )
 
 end subroutine ice_diags_fast_init
 

--- a/src/SIS_ice_diags.F90
+++ b/src/SIS_ice_diags.F90
@@ -351,7 +351,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
                'ice extent, indicating cells with more than 15% sea ice cover', &
                units='nondim')
   IDs%id_cn       = register_diag_field('ice_model', 'CN', diag%axesTc, Time, &
-               'ice concentration', units="nondim", range=(/0.,1./), &
+               'ice concentration [0,1]', units="nondim", &
                cmor_field_name='siitdconc', &
                cmor_standard_name='sea_ice_area_fraction', &
                cmor_long_name='Sea-Ice Area Percentages in Ice Thickness Categories')
@@ -364,9 +364,9 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_hi       = register_diag_field('ice_model', 'HI', diag%axesT1, Time, &
                'ice thickness', units='m', conversion=US%Z_to_m)
   IDs%id_sitimefrac = register_diag_field('ice_model', 'sitimefrac', diag%axesT1, Time, &
-               'time fraction of ice cover', units="nondim", range=(/0.,1./) )
+               'time fraction of ice cover [0,1]', units="nondim" )
   IDs%id_siconc = register_diag_field('ice_model', 'siconc', diag%axesT1, Time, &
-               'ice concentration', units="nondim", range=(/0.,1./) )
+               'ice concentration [0,1]', units="nondim" )
   IDs%id_siconc_CMOR = register_diag_field('ice_model', 'siconc_CMOR', diag%axesT1, Time, &
                'Sea-Ice Area Percentage', units='%', conversion=100.0, &
                standard_name="SeaIceAreaFraction")
@@ -375,7 +375,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
   IDs%id_sivol  = register_diag_field('ice_model', 'sivol', diag%axesT1, Time, &
                'ice volume', units='m', conversion=US%Z_to_m)
   IDs%id_sisnconc = register_diag_field('ice_model', 'sisnconc', diag%axesT1, Time, &
-               'snow concentration', units="nondim", range=(/0.,1./) )
+               'snow concentration [0,1]', units="nondim" )
   IDs%id_sisnconc_CMOR = register_diag_field('ice_model', 'sisnconc_CMOR', diag%axesT1, Time, &
                'Snow Area Percentage', units='%', conversion=100.0, missing_value=missing, &
                standard_name="SurfaceSnowAreaFraction")
@@ -421,7 +421,7 @@ subroutine register_ice_state_diagnostics(Time, IG, US, param_file, diag, IDs)
                  "If true, call the ridging routines.", default=.false., do_not_log=.true.)
   if (do_ridging) then
     IDs%id_rdgf = register_diag_field('ice_model', 'RDG_FRAC', diag%axesTc, Time, &
-                   'ridged ice fraction', units="nondim", range=(/0.,1./) )
+                   'ridged ice fraction [0,1]', units="nondim" )
 !   IDs%id_rdg_h = register_diag_field('ice_model', 'RDG_HEIGHT', diag%axesTc, Time, &
 !                  'ice ridge height', units='m', conversion=US%m_to_Z)
   endif

--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -145,7 +145,7 @@ type slow_thermo_CS ; private
   integer :: id_lsrc_s=-1, id_lsnk_s=-1, id_bsnk_s=-1
   integer :: id_lsrc_c=-1, id_lsnk_c=-1
   integer :: id_tsnk_i=-1, id_bsrc_i=-1, id_net_i=-1, id_net_s=-1
-  integer :: id_net_c=-1, id_sn2ic_i=-1, id_sn2ic_s=-1
+  integer :: id_net_c=-1,  id_sn2ic_s=-1
   !!@}
 end type slow_thermo_CS
 
@@ -614,10 +614,6 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
   ! but with a greater emphasis on enthalpy as the dominant state variable.
 
   real, dimension(SZI_(G),SZJ_(G),1:IG%CatIce) :: snow_to_ice ! The flux of snow to the ice [R Z ~> kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),0:IG%CatIce) :: snow_to_ice_i ! The ice flux of snow to the ice, including
-                                                                  ! open ocean category [R Z ~> kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),0:IG%CatIce) :: snow_to_ice_s ! The snow flux of snow to the ice, including
-                                                                  ! open ocean category [R Z ~> kg m-2]
   real, dimension(G%isc:G%iec,G%jsc:G%jec)   :: Obs_h_ice ! Observed ice thickness for qflux calculation
   real, dimension(G%isc:G%iec,G%jsc:G%jec)   :: Obs_cn_ice ! Observed total ice concentration [nondim]
   real, dimension(G%isc:G%iec,G%jsc:G%jec)   :: icec  ! Total ice concentration [nondim]
@@ -887,7 +883,6 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
   call cpu_clock_begin(iceClock5)
 
   snow_to_ice(:,:,:) = 0.0 ; net_melt(:,:) = 0.0
-  snow_to_ice_i(:,:,:) = 0.0 ; snow_to_ice_s(:,:,:) = 0.0
   bsnk(:,:) = 0.0
   bsnk_i(:,:) = 0.0
   bsnk_s(:,:) = 0.0
@@ -1003,7 +998,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
                    FIA%lprec_top(i,j,k)*dt_slow, FIA%evap_top(i,j,k)*dt_slow, &
                    FIA%tmelt(i,j,k), FIA%bmelt(i,j,k), NkIce, npassive, TrLay, &
                    heat_to_ocn, h2o_ice_to_ocn, h2o_ocn_to_ice, evap_from_ocn, &
-                   snow_to_ice(i,j,k), snow_to_ice_i(i,j,k), snow_to_ice_s(i,j,k), salt_to_ice, &
+                   snow_to_ice(i,j,k), salt_to_ice, &
                    IST%ITV, US, CS%ice_thm_CSp, bablt, bablt_i, bablt_s, enth_evap, &
                    enth_ice_to_ocn, enth_ocn_to_ice, evap_i, evap_s)
 
@@ -1486,8 +1481,8 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
     !$OMP parallel do default(shared)
     do j=jsc,jec ; do i=isc,iec
       s2i_agg = 0.0
-      do k=0,ncat
-        s2i_agg = s2i_agg + IST%part_size(i,j,k) * snow_to_ice_s(i,j,k)
+      do k=1,ncat
+        s2i_agg = s2i_agg + IST%part_size(i,j,k) - snow_to_ice(i,j,k)
       enddo
       tmp2d(i,j) = (min(h2o_change_s(i,j),0.0)*Idt_slow -  sisnmass_evap(i,j) - s2i_agg*Idt_slow)
     enddo ; enddo
@@ -1497,8 +1492,8 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
     !$OMP parallel do default(shared)
     do j=jsc,jec ; do i=isc,iec   
       s2i_agg = 0.0
-      do k=0,ncat
-        s2i_agg = s2i_agg + IST%part_size(i,j,k) * snow_to_ice_i(i,j,k)
+      do k=1,ncat
+        s2i_agg = s2i_agg + IST%part_size(i,j,k) * snow_to_ice(i,j,k)
       enddo
       tmp2d(i,j) = (max(h2o_change_i(i,j),0.0)*Idt_slow -  s2i_agg*Idt_slow - OSS%frazil(i,j)*ILatHtFus*Idt_slow) 
     enddo ; enddo
@@ -1522,10 +1517,8 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
   if (FIA%id_bheat>0) call post_data(FIA%id_bheat, OSS%bheat, CS%diag)
   if (CS%id_sn2ic>0) call post_avg(CS%id_sn2ic, snow_to_ice, IST%part_size(:,:,1:), CS%diag, G=G, &
                                     scale=Idt_slow)
-  if (CS%id_sn2ic_i>0) call post_avg(CS%id_sn2ic_i, snow_to_ice_i, IST%part_size, CS%diag, G=G, &
-                                    scale=Idt_slow)
-  if (CS%id_sn2ic_s>0) call post_avg(CS%id_sn2ic_s, snow_to_ice_s, IST%part_size, CS%diag, G=G, &
-                                    scale=Idt_slow)
+  if (CS%id_sn2ic_s>0) call post_avg(CS%id_sn2ic_s, snow_to_ice, IST%part_size(:,:,1:), CS%diag, G=G, &
+                                    scale=-Idt_slow)
   if (CS%id_qflim>0) call post_data(CS%id_qflim, qflx_lim_ice, CS%diag)
   if (CS%id_qfres>0) call post_data(CS%id_qfres, qflx_res_ice, CS%diag)
   if (CS%id_net_melt>0) call post_data(CS%id_net_melt, net_melt, CS%diag)
@@ -1789,18 +1782,17 @@ subroutine SIS_slow_thermo_init(Time, G, US, IG, param_file, diag, CS, tracer_fl
                'Sea-Ice Area Fraction Tendency Due to Thermodynamics', &
                units='s-1', conversion=US%RZ_T_to_kg_m2s, &
                cmor_standard_name='tendency_of_sea_ice_area_fraction_due_to_thermodynamics')
-  CS%id_sn2ic_i = register_diag_field('ice_model','sidmassgrowthsi', diag%axesT1,Time, &
+  CS%id_sn2ic = register_diag_field('ice_model','SN2IC', diag%axesT1,Time, &
                'Sea-Ice Mass Change Through Snow-to-Ice Conversion', &
                units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, &
-               cmor_standard_name='tendency_of_sea_ice_amount_due_to_conversion_of_snow_to_sea_ice')
+               cmor_field_name='sidmassgrowthsi', &
+               cmor_standard_name='tendency_of_sea_ice_amount_due_to_conversion_of_snow_to_sea_ice', &
+               cmor_long_name='Sea-Ice Mass Change Through Snow-to-Ice Conversion')
   CS%id_sn2ic_s = register_diag_field('ice_model','sisndmasssi', diag%axesT1,Time, &
                'Snow Mass Rate of Change Through Snow-to-Ice Conversion', &
                units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s, &
-               cmor_standard_name='tendency_of_surface_snow_amount_due_to_conversion_of_snow_to_sea_ice')
-
-  CS%id_sn2ic = register_diag_field('ice_model','SN2IC'  ,diag%axesT1,Time, &
-               'rate of snow to ice conversion', &
-               units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)
+               cmor_standard_name='tendency_of_surface_snow_amount_due_to_conversion_of_snow_to_sea_ice', &
+               cmor_long_name='Snow Mass Change Through Snow-to-Ice Conversion')
   CS%id_net_melt = register_diag_field('ice_model','net_melt' ,diag%axesT1, Time, &
                'net mass flux from ice & snow to ocean due to melting & freezing', &
                units='kg m-2 s-1', conversion=US%RZ_T_to_kg_m2s)


### PR DESCRIPTION
This PR contains two separate commits. Solutions are bitwise identical, but this PR will change the metadata of certain diagnostics.

The first commit address redundant snow-to-ice diagnostics. In particular, the diagnostic `sidmassgrowthsi` is identical to `SN2IC`. Thus, the diagnostic `sidmassgrowthsi` has been removed and this cmor name has been added to the registration of the `SN2IC` diagnostic. The variable `sn2i_i` in `ice_resize_SIS2` has correspondingly been removed, as it is unnecessary.

Similarly, the diagnostic `sisndmasssi` is equal to the negative of `SN2IC`. This diagnostic has been retained, but the variable  `sn2i_s` in `ice_resize_SIS2` has been removed as it is unnecessary.

The second commit addresses [SIS2 Issue 248](https://github.com/NOAA-GFDL/SIS2/issues/248). This removes range specifications from 19 SIS2 diagnostics, as this was generating large numbers of warning messages. The range information has been retained by adding the appropriate ranges into the diagnostic long name.