### PR TITLE
Fix unpack_ocean_ice_boundary_calved_shelf_bergs 

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -453,11 +453,8 @@ subroutine unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, OIB)
   !$OMP                          private(i2,j2)
   do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j) > 0.0) then
     i2 = i+i_off ; j2 = j+j_off
-    if (OIB%calving(i2,j2)>0.0) then
-      if (FIA%calving(i,j)>0.0) call SIS_error(FATAL,"Overlap in calving from snow discharge and ice shelf!")
-      FIA%calving(i,j) = US%kg_m2s_to_RZ_T*OIB%calving(i2,j2)
-      FIA%calving_hflx(i,j) = US%W_m2_to_QRZ_T*OIB%calving_hflx(i2,j2)
-    endif
+    FIA%calving(i,j) = FIA%calving(i,j) + US%kg_m2s_to_RZ_T*OIB%calving(i2,j2)
+    FIA%calving_hflx(i,j) = FIA%calving_hflx(i,j) + US%W_m2_to_QRZ_T*OIB%calving_hflx(i2,j2)
   endif ; enddo ; enddo
 
   if (Ice%sCS%debug) then

--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -435,15 +435,15 @@ subroutine unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, OIB)
 
   integer :: i, j, k, m, n, i2, j2, k2, isc, iec, jsc, jec, i_off, j_off
 
-  if (.not.associated(Ice%fCS)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS must be associated in unpack_ocean_ice_boundary_calved_shelf_bergs.")
-  if (.not.associated(Ice%fCS%FIA)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS%FIA must be associated in unpack_ocean_ice_boundary_calved_shelf_berg.")
-  if (.not.associated(Ice%fCS%G)) call SIS_error(FATAL, &
-      "The pointer to Ice%fCS%G must be associated in unpack_ocean_ice_boundary_calved_shelf_berg.")
+  if (.not.associated(Ice%sCS)) call SIS_error(FATAL, &
+      "The pointer to Ice%sCS must be associated in unpack_ocean_ice_boundary_calved_shelf_bergs.")
+  if (.not.associated(Ice%sCS%FIA)) call SIS_error(FATAL, &
+      "The pointer to Ice%sCS%FIA must be associated in unpack_ocean_ice_boundary_calved_shelf_berg.")
+  if (.not.associated(Ice%sCS%G)) call SIS_error(FATAL, &
+      "The pointer to Ice%sCS%G must be associated in unpack_ocean_ice_boundary_calved_shelf_berg.")
 
-  FIA => Ice%fCS%FIA ; G => Ice%fCS%G
-  US => Ice%fCS%US
+  FIA => Ice%sCS%FIA ; G => Ice%sCS%G
+  US => Ice%sCS%US
 
   isc = G%isc ; iec = G%iec ; jsc = G%jsc ; jec = G%jec
 
@@ -460,8 +460,8 @@ subroutine unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, OIB)
     endif
   endif ; enddo ; enddo
 
-  if (Ice%fCS%debug) then
-    call FIA_chksum("End of unpack_ocean_ice_boundary_calved_shelf_berg", FIA, G, Ice%fCS%US)
+  if (Ice%sCS%debug) then
+    call FIA_chksum("End of unpack_ocean_ice_boundary_calved_shelf_berg", FIA, G, Ice%sCS%US)
   endif
 
 end subroutine unpack_ocean_ice_boundary_calved_shelf_bergs


### PR DESCRIPTION
In subroutine unpack_ocean_ice_boundary_calved_shelf_bergs, corrected FIA%calving and FIA%calving_hflx so that they are on slow-ice PEs, as called from the coupler (this type of calving comes from the ice shelf on the MOM6 grid).

Also made changes to allow calving in a cell to accumulate from both ice-sheet flux and land model frozen runoff, as there are cases where this should be possible.