### PR TITLE
Fix spec_ice to work with do_leads = true

### DIFF
--- a/src/ice_spec.F90
+++ b/src/ice_spec.F90
@@ -139,7 +139,9 @@ subroutine get_sea_surface(Time, HI, SST, ice_conc, ice_thick, ice_domain, ice_d
       iceh = 0.0
     end where
     if (.not.do_leads) then
-      where (icec >= minimum_ice_concentration) icec = 1.0
+       where (icec >= minimum_ice_concentration) icec = 1.0
+    else ! Ensure ice concentration does not exceed 1.0 when leads are enabled
+       where (icec >= 1.0) icec = 1.0
     endif
   endif
 


### PR DESCRIPTION
This PR only affects `specified_ice` mode, which is used for AMIP experiments with specified SST and sea ice boundary conditions. As currently formulated, specified ice experiments fail with `do_leads = true`. This is due to the fact that the sea ice concentration AMIP data provided by PCMDI includes values both <0% and >100% due to the temporal interpolation scheme that is used to produce the dataset. More details are provided [here](https://pcmdi.llnl.gov/report/pdf/60.pdf). Thus, sea ice concentration values must be "clipped" to ensure the values obey the range [0,100]. The negative values are already clipped in the code via the `minimum_ice_concentration`. This PR clips any values that are greater than 100% to a value of 100%. Answers are bitwise identical for any experiment not using `specified_ice`. Experiments with `specified_ice = true` will no longer crash when `do_leads = true`.

The idea for this PR was produced by Xia Li (@polarxia).