### PR TITLE
Bugfix in unit conversion for salt_left_behind

### DIFF
--- a/src/SIS_slow_thermo.F90
+++ b/src/SIS_slow_thermo.F90
@@ -1021,7 +1021,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
       endif
       if (CS%do_brine_plume .and. h2o_ocn_to_ice > 0.0) then
         salt_left_in_ocean(i,j) = salt_left_in_ocean(i,j) + (OSS%s_surf(i,j) * h2o_ocn_to_ice - &
-                                  salt_to_ice * 0.001)
+                                  salt_to_ice)
       endif
 
       ! Copy back into the tracer array
@@ -1384,7 +1384,7 @@ subroutine SIS2_thermodynamics(IST, dt_slow, CS, OSS, FIA, IOF, G, US, IG)
   if (CS%do_brine_plume) then
     do j=jsc,jec ; do i=isc,iec
       ! Note the conversion here from g m-2 to kg m-2 s-1.
-      IOF%salt_left_behind(i,j) = salt_left_in_ocean(i,j) * Idt_slow
+      IOF%salt_left_behind(i,j) = salt_left_in_ocean(i,j) * (0.001*Idt_slow)
     enddo ; enddo
   endif
 


### PR DESCRIPTION
- salt_left_behind is used by the brine plume parameterization and passed to an ocean model (MOM6).  It is expected to be in units of kg/m2/s by MOM6.  However, only one of the two terms was being converted to kg here, resulting in mixed units and this amount was roughly 1000x the expected value.  This commit moves the conversion so that the total calculation is converted to kg/m2/s after two terms are subtracted (total salt in water that goes to ice minus fraction of salt that actually goes to ice, leaving the rejected salt).  It will (significantly) change the behavior of the brine plume parameterization in MOM6, but it is approximately compensated by an unrelated bug inside MOM6.