### PR TITLE
Add cell methods to register_static_field call

### DIFF
--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -214,7 +214,7 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   id_geo_lat   = register_static_field('ice_model', 'GEOLAT', diag%axesT1, 'latitude', &
                  'degrees')
   id_cell_area = register_static_field('ice_model', 'CELL_AREA', diag%axesT1, &
-                 'cell area', 'sphere', conversion=US%L_to_m**2, &
+                 'cell area', 'sphere', &
                  x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
 
   FIA%id_sh       = register_SIS_diag_field('ice_model', 'SH', diag%axesT1, Time, &

--- a/src/SIS_ctrl_types.F90
+++ b/src/SIS_ctrl_types.F90
@@ -214,7 +214,8 @@ subroutine ice_diagnostics_init(IOF, OSS, FIA, G, US, IG, diag, Time, Cgrid)
   id_geo_lat   = register_static_field('ice_model', 'GEOLAT', diag%axesT1, 'latitude', &
                  'degrees')
   id_cell_area = register_static_field('ice_model', 'CELL_AREA', diag%axesT1, &
-                 'cell area', 'sphere')
+                 'cell area', 'sphere', conversion=US%L_to_m**2, &
+                 x_cell_method='sum', y_cell_method='sum', area_cell_method='sum')
 
   FIA%id_sh       = register_SIS_diag_field('ice_model', 'SH', diag%axesT1, Time, &
                'sensible heat flux', units='W m-2', conversion=US%QRZ_T_to_W_m2)


### PR DESCRIPTION
This PR addresses Issue #255 by adding cell methods to the `register_static_field` call for `CELL_AREA`. I believe this is the only SIS2 diagnostic that requires cell_methods to be added. I have confirmed that answers are bitwise identical, as expected.