### PR TITLE
Add ensemble functionality

### DIFF
--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -48,7 +48,7 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
   character(len=40)  :: mdl = "SIS_initialize_fixed" ! This module's name.
-  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
+  character(len=32) :: filename_appendix = "" !fms appendix to filename for ensemble runs
   logical :: debug
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -130,10 +130,7 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
   if (write_geom) then
     !query fms_io if there is a filename_appendix (for ensemble runs)
     call get_filename_appendix(filename_appendix)
-    if (len_trim(filename_appendix) > 0) then
-      call write_ocean_geometry_file(G, PF, output_dir, &
-                geom_file="sea_ice_geometry"//'.'//trim(filename_appendix), US=US)
-    else
+    if ((len_trim(filename_appendix) == 0) .or. (filename_appendix == "ens_01")) then
       call write_ocean_geometry_file(G, PF, output_dir, &
                 geom_file="sea_ice_geometry", US=US)
     endif

--- a/src/SIS_fixed_initialization.F90
+++ b/src/SIS_fixed_initialization.F90
@@ -14,7 +14,7 @@ use MOM_error_handler, only   : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only   : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only     : get_param, read_param, log_param, log_version, param_file_type
 use MOM_grid_initialize, only : initialize_masks, set_grid_metrics
-use MOM_io, only              : slasher
+use MOM_io, only              : slasher, get_filename_appendix
 ! use MOM_shared_initialization, only : MOM_shared_init_init
 use MOM_shared_initialization, only : MOM_initialize_rotation, MOM_calculate_grad_Coriolis
 use MOM_shared_initialization, only : initialize_topography_from_file, apply_topography_edits_from_file
@@ -48,6 +48,7 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
   character(len=200) :: inputdir   ! The directory where NetCDF input files are.
   character(len=200) :: config
   character(len=40)  :: mdl = "SIS_initialize_fixed" ! This module's name.
+  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
   logical :: debug
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -126,8 +127,18 @@ subroutine SIS_initialize_fixed(G, US, PF, write_geom, output_dir, OBC)
   call initialize_grid_rotation_angle(G, PF)
 
   ! Write out all of the grid data used by this run.
-  if (write_geom) call write_ocean_geometry_file(G, PF, output_dir, &
-                                                 geom_file="sea_ice_geometry", US=US)
+  if (write_geom) then
+    !query fms_io if there is a filename_appendix (for ensemble runs)
+    call get_filename_appendix(filename_appendix)
+    if (len_trim(filename_appendix) > 0) then
+      call write_ocean_geometry_file(G, PF, output_dir, &
+                geom_file="sea_ice_geometry"//'.'//trim(filename_appendix), US=US)
+    else
+      call write_ocean_geometry_file(G, PF, output_dir, &
+                geom_file="sea_ice_geometry", US=US)
+    endif
+    
+  endif
 
   call callTree_leave('SIS_initialize_fixed()')
 

--- a/src/SIS_get_input.F90
+++ b/src/SIS_get_input.F90
@@ -69,20 +69,17 @@ subroutine Get_SIS_Input(param_file, dirs, check_params, component, ensemble_num
   enddo
 10 call close_file(unit)
   if (present(dirs)) then
-
-      if (present(ensemble_num)) then
-
-        dirs%output_directory = trim(slasher(ensembler(output_directory,ensemble_num)))
-        dirs%restart_output_dir = trim(slasher(ensembler(restart_output_dir,ensemble_num)))
-        dirs%restart_input_dir = trim(slasher(ensembler(restart_input_dir,ensemble_num)))
-        dirs%input_filename = trim(ensembler(input_filename,ensemble_num))
-      else
-        dirs%output_directory = trim(slasher(ensembler(output_directory)))
-        dirs%restart_output_dir = trim(slasher(ensembler(restart_output_dir)))
-        dirs%restart_input_dir = trim(slasher(ensembler(restart_input_dir)))
-        dirs%input_filename = trim(ensembler(input_filename))
-      endif
-
+    if (present(ensemble_num)) then
+      dirs%output_directory = trim(slasher(ensembler(output_directory,ensemble_num)))
+      dirs%restart_output_dir = trim(slasher(ensembler(restart_output_dir,ensemble_num)))
+      dirs%restart_input_dir = trim(slasher(ensembler(restart_input_dir,ensemble_num)))
+      dirs%input_filename = trim(ensembler(input_filename,ensemble_num))
+    else
+      dirs%output_directory = trim(slasher(ensembler(output_directory)))
+      dirs%restart_output_dir = trim(slasher(ensembler(restart_output_dir)))
+      dirs%restart_input_dir = trim(slasher(ensembler(restart_input_dir)))
+      dirs%input_filename = trim(ensembler(input_filename))
+    endif
   endif
 
   comp = "SIS" ; if (present(component)) comp = trim(adjustl(component))
@@ -90,21 +87,13 @@ subroutine Get_SIS_Input(param_file, dirs, check_params, component, ensemble_num
   if (present(param_file)) then
     output_dir = trim(slasher(ensembler(output_directory)))
     valid_param_files = 0
-    do io = 1, npf
-  
-    if (len_trim(trim(parameter_filename(io))) > 0) then
-  
-     if (present(ensemble_num)) then
-            call open_param_file(trim(ensembler(parameter_filename(io),ensemble_num)), param_file, &
-                                 check_params, component=comp, &
-                                 doc_file_dir=output_dir)
-     else
-            call open_param_file(trim(ensembler(parameter_filename(io))), param_file, &
-                                 check_params, component=comp, &
-                                 doc_file_dir=output_dir)
-     endif
-            valid_param_files = valid_param_files + 1
-    endif
+    do io = 1, npf  
+      if (len_trim(trim(parameter_filename(io))) > 0) then
+        call open_param_file(trim(ensembler(parameter_filename(io),ensemble_num)), param_file, &
+                             check_params, component=comp, &
+                             doc_file_dir=output_dir)
+        valid_param_files = valid_param_files + 1
+      endif
     enddo
     if (valid_param_files == 0) call SIS_error(FATAL, "There must be at "//&
          "least 1 valid entry in input_filename in SIS_input_nml in input.nml.")

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -111,7 +111,7 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
   ! Local variables
   character(len=40)  :: mdl = "SIS_sum_output" ! This module's name.
   character(len=200) :: statsfile  ! The name of the statistics file.
-  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
+  character(len=32) :: filename_appendix = "" !fms appendix to filename for ensemble runs
   
   ! This include declares and sets the variable "version".
 # include "version_variable.h"

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -20,6 +20,7 @@ use MOM_error_handler, only : SIS_error=>MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 ! use MOM_io,          only : create_file, fieldtype, flush_file, reopen_file, vardesc, write_field
 use MOM_io,            only : open_ASCII_file, APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
+use MOM_io,            only : get_filename_appendix
 use MOM_string_functions, only : slasher
 use MOM_time_manager,  only : time_type, get_time, operator(>), operator(-)
 use MOM_time_manager,  only : get_date, get_calendar_type, NO_CALENDAR
@@ -110,6 +111,8 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
   ! Local variables
   character(len=40)  :: mdl = "SIS_sum_output" ! This module's name.
   character(len=200) :: statsfile  ! The name of the statistics file.
+  character(len=32) :: filename_appendix = '' !fms appendix to filename for ensemble runs
+  
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
 
@@ -146,8 +149,15 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
                  "The file to use to write the globally integrated "//&
                  "statistics.", default="seaice.stats")
 
-  CS%statsfile = trim(slasher(directory))//trim(statsfile)
+  !query fms_io if there is a filename_appendix (for ensemble runs)
+  call get_filename_appendix(filename_appendix)
+  if (len_trim(filename_appendix) > 0) then
+     CS%statsfile = trim(slasher(directory))//trim(statsfile)//'.'//trim(filename_appendix)
+  else
+     CS%statsfile = trim(slasher(directory))//trim(statsfile)
+  endif
   call log_param(param_file, mdl, "output_path/STATISTICS_FILE", CS%statsfile)
+
 #ifdef STATSLABEL
   CS%statsfile = trim(CS%statsfile)//"."//trim(adjustl(STATSLABEL))
 #endif

--- a/src/SIS_sum_output.F90
+++ b/src/SIS_sum_output.F90
@@ -152,9 +152,9 @@ subroutine SIS_sum_output_init(G, param_file, directory, Input_start_time, US, C
   !query fms_io if there is a filename_appendix (for ensemble runs)
   call get_filename_appendix(filename_appendix)
   if (len_trim(filename_appendix) > 0) then
-     CS%statsfile = trim(slasher(directory))//trim(statsfile)//'.'//trim(filename_appendix)
+    CS%statsfile = trim(slasher(directory))//trim(statsfile)//'.'//trim(filename_appendix)
   else
-     CS%statsfile = trim(slasher(directory))//trim(statsfile)
+    CS%statsfile = trim(slasher(directory))//trim(statsfile)
   endif
   call log_param(param_file, mdl, "output_path/STATISTICS_FILE", CS%statsfile)
 


### PR DESCRIPTION
This PR adds some functionalities needed for running ensemble experiments with SIS2. 

The changes to `SIS_get_input.F90` mean that the user can run a perturbed sea ice physics ensemble by passing unique `SIS_override` files to `SIS_input_nml` via:

`parameter_filename = 'INPUT/SIS_input','INPUT/SIS_layout','INPUT/SIS_override_%E'`

The changes to `SIS_sum_output.F90` mean that a `seaice.stats` file will be created for each ensemble member, allowing the user to track conservation statistics for each member.

The changes to `SIS_fixed_initialization.F90` mean that a `sea_ice_geometry` file will be created for each ensemble member. This was needed because the simulation crashes during initialization when running a large (30-member) perturbed sea ice physics ensemble from a cold start (`input_filename = 'n'`). It seemed like all the ensemble members were trying to read/write the same `sea_ice_geometry` file. This fix of having one geometry file per member is not the most elegant solution, but at least the model runs.